### PR TITLE
Store and use LCN for channel ordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,14 +72,15 @@ SQLite file at `DB_PATH` (default `/data/tvguide.db`). Mount `/data` as a named 
 ### Schema
 
 ```sql
-channels (id PK, display_name, icon, sort_order)
+channels (id PK, display_name, icon, sort_order, lcn)
+-- lcn: logical channel number from <lcn> element (nullable); used for display ordering
 
 airings (
   channel_id + start_time  -- composite PK
   stop_time, title, sub_title, description,
   categories               -- JSON array e.g. '["News","Sport"]'
   episode_num              -- xmltv_ns format: "1.2.0/1"
-  episode_num_display      -- onscreen format: "S02 E04"
+  episode_num_display      -- onscreen/SxxExx format: "S02E04"
   prog_id                  -- dd_progid (TMS/Gracenote stable ID, if present)
   star_rating, content_rating, year, icon, country,
   is_repeat, is_premiere
@@ -112,7 +113,7 @@ Stored client-side in `localStorage` under the key `tvguide-prefs`:
 { "hidden": { "channel-id": true }, "favourites": { "channel-id": true } }
 ```
 
-Favourites appear at the top of the guide, above the regular channel order. Hidden channels are excluded from the guide view entirely. Both are managed via the "Channels" slide-out panel.
+Favourites appear at the top of the guide. The remaining visible channels are sorted by `lcn` (logical channel number) when present; channels without an `lcn` fall back to source order. Hidden channels are excluded from the guide view entirely. Both are managed via the "Channels" slide-out panel.
 
 ## Data flow
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -33,6 +33,7 @@ func newSeededServer(t *testing.T) *httptest.Server {
 			{
 				ID:           "ch1",
 				DisplayNames: []xmltv.Name{{Value: "ABC"}},
+				LCN:          "2",
 			},
 			{
 				ID:           "ch2",
@@ -110,6 +111,45 @@ func TestGetChannels_Order(t *testing.T) {
 	}
 	if result[0].ID != "ch1" {
 		t.Errorf("expected first channel ID %q, got %q", "ch1", result[0].ID)
+	}
+}
+
+func TestGetChannels_LCN(t *testing.T) {
+	srv := newSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/channels")
+	if err != nil {
+		t.Fatalf("GET /api/channels: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result []struct {
+		ID  string `json:"id"`
+		LCN *int   `json:"lcn"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result) < 2 {
+		t.Fatalf("expected at least 2 channels, got %d", len(result))
+	}
+	// ch1 was seeded with LCN=2
+	var ch1, ch2 *struct {
+		ID  string `json:"id"`
+		LCN *int   `json:"lcn"`
+	}
+	for i := range result {
+		if result[i].ID == "ch1" {
+			ch1 = &result[i]
+		}
+		if result[i].ID == "ch2" {
+			ch2 = &result[i]
+		}
+	}
+	if ch1 == nil || ch1.LCN == nil || *ch1.LCN != 2 {
+		t.Errorf("ch1 LCN: expected 2, got %v", ch1)
+	}
+	if ch2 == nil || ch2.LCN != nil {
+		t.Errorf("ch2 LCN: expected nil, got %v", ch2.LCN)
 	}
 }
 

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,7 +19,8 @@ CREATE TABLE IF NOT EXISTS channels (
 	id           TEXT    PRIMARY KEY,
 	display_name TEXT    NOT NULL,
 	icon         TEXT,
-	sort_order   INTEGER NOT NULL
+	sort_order   INTEGER NOT NULL,
+	lcn          INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS airings (
@@ -51,6 +53,7 @@ type Channel struct {
 	ID          string `json:"id"`
 	DisplayName string `json:"displayName"`
 	Icon        string `json:"icon,omitempty"`
+	LCN         *int   `json:"lcn,omitempty"`
 }
 
 // Airing holds all data for a single broadcast slot.
@@ -119,6 +122,10 @@ func Open(path string, retentionDays int, sourceURL string) (*DB, error) {
 		return nil, fmt.Errorf("applying schema: %w", err)
 	}
 
+	// Migration: add lcn column to existing databases that predate this column.
+	// SQLite returns an error if the column already exists; we intentionally ignore it.
+	_, _ = db.Exec(`ALTER TABLE channels ADD COLUMN lcn INTEGER`)
+
 	return &DB{
 		db:            db,
 		retentionDays: retentionDays,
@@ -138,8 +145,8 @@ func (d *DB) Refresh(tv *xmltv.TV, nextRefresh time.Time) error {
 	defer tx.Rollback()
 
 	chStmt, err := tx.Prepare(`
-		INSERT OR REPLACE INTO channels (id, display_name, icon, sort_order)
-		VALUES (?, ?, ?, ?)
+		INSERT OR REPLACE INTO channels (id, display_name, icon, sort_order, lcn)
+		VALUES (?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("preparing channel upsert: %w", err)
@@ -155,7 +162,13 @@ func (d *DB) Refresh(tv *xmltv.TV, nextRefresh time.Time) error {
 		if len(ch.Icons) > 0 {
 			icon = ch.Icons[0].Src
 		}
-		if _, err := chStmt.Exec(ch.ID, name, icon, i); err != nil {
+		var lcn any
+		if ch.LCN != "" {
+			if n, err := strconv.Atoi(ch.LCN); err == nil {
+				lcn = n
+			}
+		}
+		if _, err := chStmt.Exec(ch.ID, name, icon, i, lcn); err != nil {
 			return fmt.Errorf("upserting channel %s: %w", ch.ID, err)
 		}
 	}
@@ -226,7 +239,7 @@ func (d *DB) Refresh(tv *xmltv.TV, nextRefresh time.Time) error {
 // GetChannels returns all channels ordered by their source sort order.
 func (d *DB) GetChannels() ([]Channel, error) {
 	rows, err := d.db.Query(`
-		SELECT id, display_name, COALESCE(icon, '')
+		SELECT id, display_name, COALESCE(icon, ''), lcn
 		FROM channels
 		ORDER BY sort_order
 	`)
@@ -238,8 +251,13 @@ func (d *DB) GetChannels() ([]Channel, error) {
 	channels := []Channel{}
 	for rows.Next() {
 		var ch Channel
-		if err := rows.Scan(&ch.ID, &ch.DisplayName, &ch.Icon); err != nil {
+		var lcn sql.NullInt64
+		if err := rows.Scan(&ch.ID, &ch.DisplayName, &ch.Icon, &lcn); err != nil {
 			return nil, fmt.Errorf("scanning channel: %w", err)
+		}
+		if lcn.Valid {
+			n := int(lcn.Int64)
+			ch.LCN = &n
 		}
 		channels = append(channels, ch)
 	}
@@ -366,7 +384,7 @@ func airingFromXMLTV(p xmltv.Programme) Airing {
 		switch strings.ToLower(en.System) {
 		case "xmltv_ns":
 			a.EpisodeNum = strings.TrimSpace(en.Value)
-		case "onscreen":
+		case "onscreen", "sxxexx":
 			a.EpisodeNumDisplay = strings.TrimSpace(en.Value)
 		case "dd_progid":
 			a.ProgID = strings.TrimSpace(en.Value)

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -33,6 +33,7 @@ func sampleTV() *xmltv.TV {
 				ID:           "ch1",
 				DisplayNames: []xmltv.Name{{Value: "ABC"}},
 				Icons:        []xmltv.Icon{{Src: "https://example.com/abc.png"}},
+				LCN:          "2",
 			},
 			{
 				ID:           "ch2",
@@ -157,6 +158,68 @@ func TestRefresh_ChannelFields(t *testing.T) {
 	ch2 := channels[1]
 	if ch2.Icon != "" {
 		t.Errorf("ch2 Icon: expected empty, got %q", ch2.Icon)
+	}
+}
+
+func TestRefresh_ChannelLCN(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(sampleTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	channels, err := db.GetChannels()
+	if err != nil {
+		t.Fatalf("GetChannels: %v", err)
+	}
+	if len(channels) < 2 {
+		t.Fatalf("expected at least 2 channels, got %d", len(channels))
+	}
+	ch1 := channels[0]
+	if ch1.LCN == nil || *ch1.LCN != 2 {
+		t.Errorf("ch1 LCN: expected 2, got %v", ch1.LCN)
+	}
+	ch2 := channels[1]
+	if ch2.LCN != nil {
+		t.Errorf("ch2 LCN: expected nil, got %v", ch2.LCN)
+	}
+}
+
+func TestGetAirings_SxxExxEpisodeMapping(t *testing.T) {
+	db := openTestDB(t)
+	tv := sampleTV()
+	// Add a programme with SxxExx episode numbering (as used by this XMLTV source)
+	tv.Programmes = append(tv.Programmes, xmltv.Programme{
+		Start:   xmltv.XmltvTime{Time: time.Date(2026, 3, 29, 9, 0, 0, 0, time.UTC)},
+		Stop:    xmltv.XmltvTime{Time: time.Date(2026, 3, 29, 10, 0, 0, 0, time.UTC)},
+		Channel: "ch1",
+		Titles:  []xmltv.Name{{Value: "Drama Show"}},
+		EpisodeNums: []xmltv.EpisodeNum{
+			{Value: "S02E04", System: "SxxExx"},
+			{Value: "1.3.", System: "xmltv_ns"},
+		},
+	})
+	if err := db.Refresh(tv, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	date := time.Date(2026, 3, 29, 0, 0, 0, 0, time.UTC)
+	airings, err := db.GetAirings(date)
+	if err != nil {
+		t.Fatalf("GetAirings: %v", err)
+	}
+	var drama *database.Airing
+	for i := range airings {
+		if airings[i].Title == "Drama Show" {
+			drama = &airings[i]
+			break
+		}
+	}
+	if drama == nil {
+		t.Fatal("could not find Drama Show airing")
+	}
+	if drama.EpisodeNumDisplay != "S02E04" {
+		t.Errorf("EpisodeNumDisplay: expected %q, got %q", "S02E04", drama.EpisodeNumDisplay)
+	}
+	if drama.EpisodeNum != "1.3." {
+		t.Errorf("EpisodeNum: expected %q, got %q", "1.3.", drama.EpisodeNum)
 	}
 }
 

--- a/internal/xmltv/parser.go
+++ b/internal/xmltv/parser.go
@@ -18,6 +18,7 @@ type TV struct {
 type Channel struct {
 	ID           string `xml:"id,attr"`
 	DisplayNames []Name `xml:"display-name"`
+	LCN          string `xml:"lcn"`
 	Icons        []Icon `xml:"icon"`
 }
 

--- a/internal/xmltv/parser_test.go
+++ b/internal/xmltv/parser_test.go
@@ -80,6 +80,7 @@ const minimalXML = `<?xml version="1.0" encoding="UTF-8"?>
 <tv>
   <channel id="ch1">
     <display-name>ABC</display-name>
+    <lcn>2</lcn>
   </channel>
   <channel id="ch2">
     <display-name>SBS</display-name>
@@ -88,6 +89,31 @@ const minimalXML = `<?xml version="1.0" encoding="UTF-8"?>
     <title>Morning News</title>
   </programme>
 </tv>`
+
+func TestParse_ChannelLCN(t *testing.T) {
+	tv, err := xmltv.Parse(strings.NewReader(minimalXML))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(tv.Channels) != 2 {
+		t.Fatalf("expected 2 channels, got %d", len(tv.Channels))
+	}
+	var ch1, ch2 *xmltv.Channel
+	for i := range tv.Channels {
+		if tv.Channels[i].ID == "ch1" {
+			ch1 = &tv.Channels[i]
+		}
+		if tv.Channels[i].ID == "ch2" {
+			ch2 = &tv.Channels[i]
+		}
+	}
+	if ch1 == nil || ch1.LCN != "2" {
+		t.Errorf("ch1 LCN: expected %q, got %q", "2", ch1.LCN)
+	}
+	if ch2 == nil || ch2.LCN != "" {
+		t.Errorf("ch2 LCN: expected empty, got %q", ch2.LCN)
+	}
+}
 
 func TestParse_Channels(t *testing.T) {
 	tv, err := xmltv.Parse(strings.NewReader(minimalXML))

--- a/testdata/sample.xml
+++ b/testdata/sample.xml
@@ -3,6 +3,7 @@
 <tv>
   <channel id="ch1">
     <display-name>ABC</display-name>
+    <lcn>2</lcn>
     <icon src="https://example.com/abc.png"/>
   </channel>
   <channel id="ch2">

--- a/web/app.js
+++ b/web/app.js
@@ -105,11 +105,19 @@ async function fetchGuide(dateStr) {
 
 // ── Channel ordering ──────────────────────────────────────────────────────────
 
-// Returns visible channels with favourites first, then source order.
+// Returns visible channels with favourites first, then remaining channels
+// sorted by lcn (if present), falling back to source order for channels
+// without an lcn.
 function orderedVisibleChannels() {
     const visible = state.channels.filter(ch => !isHidden(ch.id));
     const favs    = visible.filter(ch =>  isFavourite(ch.id));
     const rest    = visible.filter(ch => !isFavourite(ch.id));
+    rest.sort((a, b) => {
+        if (a.lcn != null && b.lcn != null) return a.lcn - b.lcn;
+        if (a.lcn != null) return -1;
+        if (b.lcn != null) return  1;
+        return 0; // both absent — preserve source order
+    });
     return [...favs, ...rest];
 }
 
@@ -151,15 +159,26 @@ function renderGuide() {
         label.style.top    = top + 'px';
         label.style.height = CONFIG.ROW_HEIGHT + 'px';
 
+        // Top row: icon + LCN
+        const topRow = document.createElement('div');
+        topRow.className = 'channel-top-row';
         if (ch.icon) {
             const img = document.createElement('img');
             img.src       = ch.icon;
             img.alt       = '';
             img.className = 'channel-icon';
             img.onerror   = () => img.remove();
-            label.appendChild(img);
+            topRow.appendChild(img);
         }
+        if (ch.lcn != null) {
+            const lcnEl = document.createElement('span');
+            lcnEl.className   = 'channel-lcn';
+            lcnEl.textContent = ch.lcn;
+            topRow.appendChild(lcnEl);
+        }
+        label.appendChild(topRow);
 
+        // Bottom row: channel name
         const nameEl = document.createElement('span');
         nameEl.className   = 'channel-name';
         nameEl.textContent = ch.displayName;

--- a/web/style.css
+++ b/web/style.css
@@ -168,9 +168,10 @@ body {
     left: 0;
     right: 0;
     display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 0 10px;
+    flex-direction: column;
+    justify-content: center;
+    gap: 2px;
+    padding: 4px 10px;
     border-bottom: 1px solid var(--border);
     overflow: hidden;
     cursor: default;
@@ -180,19 +181,33 @@ body {
     border-left: 3px solid var(--accent-fav);
 }
 
+.channel-top-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .channel-icon {
-    width: 28px;
-    height: 28px;
+    width: 22px;
+    height: 22px;
     object-fit: contain;
     flex-shrink: 0;
     border-radius: 3px;
 }
 
+.channel-lcn {
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-weight: 500;
+    white-space: nowrap;
+}
+
 .channel-name {
-    font-size: 13px;
+    font-size: 12px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    color: var(--text-secondary);
 }
 
 /* Programmes area */

--- a/wiremock/__files/guide.xml
+++ b/wiremock/__files/guide.xml
@@ -3,10 +3,12 @@
 <tv>
   <channel id="ch1">
     <display-name>ABC</display-name>
+    <lcn>2</lcn>
     <icon src="https://example.com/abc.png"/>
   </channel>
   <channel id="ch2">
     <display-name>SBS</display-name>
+    <lcn>3</lcn>
   </channel>
 
   <!-- Yesterday: late night movie spanning midnight into today -->


### PR DESCRIPTION
## Summary

- Parses `<lcn>` (logical channel number) from XMLTV channel elements and stores it as a nullable `lcn INTEGER` column in the `channels` table, with an `ALTER TABLE` migration for existing databases
- Returns `lcn` in the `/api/channels` JSON response
- Frontend sorts non-favourite channels by `lcn` when present, falling back to source order for channels without one
- Channel label redesigned as two lines: icon + LCN on the top row, channel name below — fits within the existing 54px row height
- Secondary fix: `episode-num system="SxxExx"` is now mapped to `episode_num_display` (previously only `system="onscreen"` was handled, leaving this field empty for the Melbourne XMLTV source)

## Test plan

- [ ] `TestParse_ChannelLCN` — parser captures LCN; absent LCN is empty string
- [ ] `TestRefresh_ChannelLCN` — DB stores and returns `lcn` as `*int`, nil when absent
- [ ] `TestGetAirings_SxxExxEpisodeMapping` — `SxxExx` system maps to `episode_num_display`
- [ ] `TestGetChannels_LCN` — API returns `lcn` field in JSON response
- [ ] All existing tests continue to pass

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)