### PR TITLE
Add bottom navigation bar and path-based SPA routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@ tvguide/
 | `GET /api/guide?date=YYYY-MM-DD` | Airings overlapping the given date (local TZ). Defaults to today. |
 | `GET /api/status` | Last refresh time, next refresh time, source URL |
 | `GET /images/channel/{channel-id}` | Cached channel logo. Re-downloads from upstream if the local file is missing. Returns 404 if the channel has no icon. |
-| `GET /` | Serves the embedded frontend |
+| `GET /` | Serves the embedded frontend (SPA shell) |
+| `GET /{any}` | SPA fallback — serves `index.html` for any path not matching API, images, or static files. Enables client-side routing via History API. |
 
 ## Configuration (environment variables)
 
@@ -117,7 +118,24 @@ Stored client-side in `localStorage` under the key `tvguide-prefs`:
 { "hidden": { "channel-id": true }, "favourites": { "channel-id": true } }
 ```
 
-Favourites appear at the top of the guide. The remaining visible channels are sorted by `lcn` (logical channel number) when present; channels without an `lcn` fall back to source order. Hidden channels are excluded from the guide view entirely. Both are managed via the "Channels" slide-out panel.
+Favourites appear at the top of the guide. The remaining visible channels are sorted by `lcn` (logical channel number) when present; channels without an `lcn` fall back to source order. Hidden channels are excluded from the guide view entirely. Both are managed via the Settings tab (bottom navigation).
+
+## Frontend navigation
+
+The app uses a bottom navigation bar (iOS-style) with four tabs:
+
+| Tab | Route | Description |
+|---|---|---|
+| Guide | `/` or `/guide` | The main TV guide grid (default) |
+| Search | `/search` | Placeholder — search coming soon |
+| Favourites | `/favourites` | Placeholder — favourites coming soon |
+| Settings | `/settings` | Channel visibility and favourite toggles |
+
+Navigation uses the **History API** (`pushState`/`popstate`) for client-side routing without full page reloads. The top bar (date display + prev/next day buttons) is only visible on the Guide tab. The Guide tab preserves its `?date=YYYY-MM-DD` query parameter behaviour.
+
+The backend serves `index.html` for any unmatched path (SPA fallback via `spaHandler` in `main.go`), so direct navigation to `/search` or browser refresh on `/favourites` works correctly.
+
+The now-line timer only runs when the Guide tab is active.
 
 ## Data flow
 
@@ -163,8 +181,8 @@ After completing any change, verify that CLAUDE.md (and any other relevant docs)
 
 These were discussed and intentionally excluded from the MVP:
 
-- **Multi-day navigation** — API already supports `?date=YYYY-MM-DD`; only the frontend nav buttons need enabling.
+- **Search** — The `/search` tab is a placeholder. Future: search for programmes by title.
+- **Favourite shows** — The `/favourites` tab is a placeholder. Future: track specific show titles and surface when they are scheduled.
 - **Programmes table** — Split airings into a `programmes` table (one row per show) and an `airings` table (one row per broadcast). Deferred because XMLTV lacks a stable universal programme ID; the `prog_id` column (dd_progid) is the future deduplication key when available.
 - **HDHomeRun integration** — Use the device's `http://[ip]/lineup.json` for channel data instead of XMLTV.
-- **Favourite shows** — Track specific show titles and surface when they are scheduled.
 - **Notifications** — Alert when a tracked show is about to start.

--- a/integration_test.go
+++ b/integration_test.go
@@ -85,7 +85,7 @@ func newIntegrationServer(t *testing.T, xmltvURL string) *httptest.Server {
 	if err != nil {
 		t.Fatalf("fs.Sub: %v", err)
 	}
-	mux.Handle("/", http.FileServer(http.FS(webSub)))
+	mux.Handle("/", spaHandler(http.FS(webSub)))
 
 	srv := httptest.NewServer(mux)
 	t.Cleanup(func() {
@@ -492,5 +492,162 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	noIconResp.Body.Close()
 	if noIconResp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404 for ch2 (no icon), got %d", noIconResp.StatusCode)
+	}
+}
+
+// TestIntegration_SPAFallback_SearchReturnsHTML verifies that GET /search
+// returns index.html content (SPA fallback) instead of 404.
+func TestIntegration_SPAFallback_SearchReturnsHTML(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/search")
+	if err != nil {
+		t.Fatalf("GET /search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type: expected text/html, got %q", ct)
+	}
+	var buf strings.Builder
+	io.Copy(&buf, resp.Body) //nolint:errcheck
+	if !strings.Contains(buf.String(), "TV Guide") {
+		t.Error("expected body to contain 'TV Guide'")
+	}
+}
+
+// TestIntegration_SPAFallback_FavouritesReturnsHTML verifies that GET /favourites
+// returns index.html content (SPA fallback) instead of 404.
+func TestIntegration_SPAFallback_FavouritesReturnsHTML(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/favourites")
+	if err != nil {
+		t.Fatalf("GET /favourites: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type: expected text/html, got %q", ct)
+	}
+	var buf strings.Builder
+	io.Copy(&buf, resp.Body) //nolint:errcheck
+	if !strings.Contains(buf.String(), "TV Guide") {
+		t.Error("expected body to contain 'TV Guide'")
+	}
+}
+
+// TestIntegration_SPAFallback_SettingsReturnsHTML verifies that GET /settings
+// returns index.html content (SPA fallback).
+func TestIntegration_SPAFallback_SettingsReturnsHTML(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/settings")
+	if err != nil {
+		t.Fatalf("GET /settings: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type: expected text/html, got %q", ct)
+	}
+}
+
+// TestIntegration_SPAFallback_APINotCaught verifies that /api/channels
+// still returns JSON and is not caught by the SPA fallback.
+func TestIntegration_SPAFallback_APINotCaught(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/api/channels")
+	if err != nil {
+		t.Fatalf("GET /api/channels: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type: expected application/json, got %q", ct)
+	}
+}
+
+// TestIntegration_SPAFallback_StaticFileNotCaught verifies that /style.css
+// still returns the CSS file and is not caught by the SPA fallback.
+func TestIntegration_SPAFallback_StaticFileNotCaught(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/style.css")
+	if err != nil {
+		t.Fatalf("GET /style.css: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "css") {
+		t.Errorf("Content-Type: expected css, got %q", ct)
+	}
+}
+
+// TestIntegration_SPAFallback_GuidePathReturnsHTML verifies that GET /guide
+// returns index.html content (SPA fallback).
+func TestIntegration_SPAFallback_GuidePathReturnsHTML(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/guide?date=2026-04-01")
+	if err != nil {
+		t.Fatalf("GET /guide: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type: expected text/html, got %q", ct)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("embedding web files: %v", err)
 	}
-	mux.Handle("/", http.FileServer(http.FS(webContent)))
+	mux.Handle("/", spaHandler(http.FS(webContent)))
 
 	srv := &http.Server{
 		Addr:    ":" + port,
@@ -145,6 +145,30 @@ func runInitialRefresh(db *database.DB, client *http.Client, xmltvURL string, po
 		db.SetNextRefresh(time.Now().Add(pollInterval))
 		log.Printf("skipping initial fetch, data already present (next refresh in %s)", pollInterval)
 	}
+}
+
+// spaHandler returns an http.Handler that serves static files from fsys,
+// falling back to index.html for any path that doesn't match a real file.
+// This enables client-side (History API) routing in the SPA.
+func spaHandler(fsys http.FileSystem) http.Handler {
+	fileServer := http.FileServer(fsys)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Try to open the requested file. If it exists, serve it normally.
+		path := r.URL.Path
+		if path == "/" {
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+		f, err := fsys.Open(path)
+		if err == nil {
+			f.Close()
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+		// File not found — serve index.html for SPA client-side routing.
+		r.URL.Path = "/"
+		fileServer.ServeHTTP(w, r)
+	})
 }
 
 func refresh(db *database.DB, client *http.Client, url string, interval time.Duration) error {

--- a/web/app.js
+++ b/web/app.js
@@ -21,6 +21,8 @@ const state = {
     programmes:  [],
     currentDate: getTodayString(),  // 'YYYY-MM-DD' in browser local time
     prefs:       loadPrefs(),
+    activePage:  'guide',           // current page: guide | search | favourites | settings
+    nowLineTimer: null,             // interval ID for the now-line updater
 };
 
 // ── Preferences (localStorage) ───────────────────────────────────────────────
@@ -55,6 +57,53 @@ function toggleFavourite(channelId) {
     renderSettingsPanel();
 }
 
+// ── Routing ──────────────────────────────────────────────────────────────────
+
+const PAGES = ['guide', 'search', 'favourites', 'settings'];
+
+function getPageFromPath() {
+    const path = window.location.pathname.replace(/^\/+/, '').split('?')[0];
+    if (PAGES.includes(path)) return path;
+    return 'guide';
+}
+
+function navigateToPage(page, { pushState = true } = {}) {
+    if (!PAGES.includes(page)) page = 'guide';
+    state.activePage = page;
+
+    // Update URL
+    if (pushState) {
+        const url = page === 'guide' ? '/' + (window.location.search || '') : '/' + page;
+        history.pushState({}, '', url);
+    }
+
+    // Show/hide pages
+    for (const p of PAGES) {
+        const el = document.getElementById('page-' + p);
+        if (el) el.style.display = p === page ? '' : 'none';
+    }
+
+    // Update bottom nav active state
+    document.querySelectorAll('.bottom-nav-btn').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.page === page);
+    });
+
+    // Top bar is only visible on the Guide tab
+    document.getElementById('topBar').style.display = page === 'guide' ? '' : 'none';
+
+    // Start/stop the now-line timer based on whether Guide is active
+    if (page === 'guide') {
+        startNowLineTimer();
+    } else {
+        stopNowLineTimer();
+    }
+
+    // Render settings when switching to that page
+    if (page === 'settings') {
+        renderSettingsPanel();
+    }
+}
+
 // ── URL state management ──────────────────────────────────────────────────────
 
 function getDateFromURL() {
@@ -66,6 +115,10 @@ function getDateFromURL() {
 
 function setDateInURL(dateStr) {
     const url = new URL(window.location.href);
+    // Ensure we stay on the guide path
+    if (url.pathname !== '/' && url.pathname !== '/guide') {
+        url.pathname = '/';
+    }
     if (dateStr === getTodayString()) {
         url.searchParams.delete('date');
     } else {
@@ -354,6 +407,18 @@ function updateNowLine(midnight) {
     nowLine.style.height  = document.getElementById('programmesInner').style.height;
 }
 
+function startNowLineTimer() {
+    if (state.nowLineTimer) return;
+    state.nowLineTimer = setInterval(() => updateNowLine(dateMidnight(state.currentDate)), 60_000);
+}
+
+function stopNowLineTimer() {
+    if (state.nowLineTimer) {
+        clearInterval(state.nowLineTimer);
+        state.nowLineTimer = null;
+    }
+}
+
 // ── Time axis ─────────────────────────────────────────────────────────────────
 
 function renderTimeAxis() {
@@ -397,17 +462,7 @@ function scrollToNow() {
     progOuter.style.scrollBehavior = '';
 }
 
-// ── Settings panel ────────────────────────────────────────────────────────────
-
-function openSettings() {
-    document.getElementById('settingsPanel').classList.add('open');
-    document.getElementById('settingsOverlay').classList.add('open');
-}
-
-function closeSettings() {
-    document.getElementById('settingsPanel').classList.remove('open');
-    document.getElementById('settingsOverlay').classList.remove('open');
-}
+// ── Settings page ────────────────────────────────────────────────────────────
 
 function renderSettingsPanel() {
     const list = document.getElementById('settingsList');
@@ -503,6 +558,9 @@ function closeModal() {
 // ── Initialisation ────────────────────────────────────────────────────────────
 
 async function init() {
+    // Resolve the active page from the URL path
+    const initialPage = getPageFromPath();
+
     // Resolve the active date from the URL (falls back to today)
     state.currentDate = getDateFromURL();
 
@@ -526,16 +584,27 @@ async function init() {
     });
     document.getElementById('prevDay').addEventListener('click', () => navigateToDate(addDays(state.currentDate, -1)));
     document.getElementById('nextDay').addEventListener('click', () => navigateToDate(addDays(state.currentDate, 1)));
-    document.getElementById('settingsBtn').addEventListener('click', openSettings);
-    document.getElementById('settingsClose').addEventListener('click', closeSettings);
-    document.getElementById('settingsOverlay').addEventListener('click', closeSettings);
     document.getElementById('modalClose').addEventListener('click', closeModal);
     document.getElementById('modalBackdrop').addEventListener('click', (e) => {
         if (e.target === e.currentTarget) closeModal();
     });
 
-    // Sync navigation when the user presses the browser back/forward buttons
-    window.addEventListener('popstate', () => navigateToDate(getDateFromURL(), { pushState: false }));
+    // Bottom nav tab switching
+    document.querySelectorAll('.bottom-nav-btn').forEach(btn => {
+        btn.addEventListener('click', () => navigateToPage(btn.dataset.page));
+    });
+
+    // Handle browser back/forward
+    window.addEventListener('popstate', () => {
+        const page = getPageFromPath();
+        navigateToPage(page, { pushState: false });
+        if (page === 'guide') {
+            navigateToDate(getDateFromURL(), { pushState: false });
+        }
+    });
+
+    // Show the initial page (without pushing state — we're already on this URL)
+    navigateToPage(initialPage, { pushState: false });
 
     // Load data
     try {
@@ -555,11 +624,8 @@ async function init() {
 
         // Small delay lets the browser complete layout before scrolling
         setTimeout(() => {
-            if (state.currentDate === getTodayString()) scrollToNow();
+            if (state.currentDate === getTodayString() && state.activePage === 'guide') scrollToNow();
         }, 50);
-
-        // Keep the now-line position current
-        setInterval(() => updateNowLine(dateMidnight(state.currentDate)), 60_000);
 
     } catch (err) {
         console.error('Failed to load guide data:', err);

--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-    <header class="top-bar">
+    <header class="top-bar" id="topBar">
         <span class="app-title">
             <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="TV Guide">
                 <rect x="2" y="7" width="20" height="15" rx="2" ry="2"/>
@@ -25,55 +25,94 @@
         </div>
         <div class="top-bar-actions">
             <button class="action-btn" id="nowBtn">Now</button>
-            <button class="action-btn" id="settingsBtn">Channels</button>
         </div>
     </header>
 
-    <!--
-        Guide grid: 2x2 CSS grid
-          [corner]        [time-axis]
-          [channel-col]   [programmes]
-    -->
-    <div class="guide-container">
+    <!-- Page: Guide -->
+    <div class="page" id="page-guide">
+        <div class="guide-container">
 
-        <div class="guide-corner"></div>
+            <div class="guide-corner"></div>
 
-        <!-- Time axis: overflow hidden, scrollLeft synced with programmes -->
-        <div class="time-axis-outer" id="timeAxisOuter">
-            <div class="time-axis" id="timeAxis"></div>
-        </div>
-
-        <!-- Channel column: overflow hidden, scrollTop synced with programmes -->
-        <div class="channel-col-outer" id="channelColOuter">
-            <div class="channel-col" id="channelCol"></div>
-        </div>
-
-        <!-- Main scroll container — drives scroll sync for the other two -->
-        <div class="programmes-outer" id="programmesOuter">
-            <div class="programmes-inner" id="programmesInner">
-                <div class="now-line" id="nowLine"></div>
+            <!-- Time axis: overflow hidden, scrollLeft synced with programmes -->
+            <div class="time-axis-outer" id="timeAxisOuter">
+                <div class="time-axis" id="timeAxis"></div>
             </div>
+
+            <!-- Channel column: overflow hidden, scrollTop synced with programmes -->
+            <div class="channel-col-outer" id="channelColOuter">
+                <div class="channel-col" id="channelCol"></div>
+            </div>
+
+            <!-- Main scroll container — drives scroll sync for the other two -->
+            <div class="programmes-outer" id="programmesOuter">
+                <div class="programmes-inner" id="programmesInner">
+                    <div class="now-line" id="nowLine"></div>
+                </div>
+            </div>
+
+            <!-- Loading overlay — shown during day-to-day navigation -->
+            <div class="guide-loading-overlay" id="guideLoadingOverlay">
+                <div class="loading-spinner"></div>
+            </div>
+
+            <!-- No-data message — shown when the selected day has no guide data -->
+            <div class="guide-empty" id="guideEmpty">No guide data available for this date.</div>
+
         </div>
-
-        <!-- Loading overlay — shown during day-to-day navigation -->
-        <div class="guide-loading-overlay" id="guideLoadingOverlay">
-            <div class="loading-spinner"></div>
-        </div>
-
-        <!-- No-data message — shown when the selected day has no guide data -->
-        <div class="guide-empty" id="guideEmpty">No guide data available for this date.</div>
-
     </div>
 
-    <!-- Settings slide-out panel -->
-    <div class="settings-overlay" id="settingsOverlay"></div>
-    <aside class="settings-panel" id="settingsPanel">
-        <div class="settings-header">
-            <h2>Channels</h2>
-            <button class="close-btn" id="settingsClose">&#10005;</button>
+    <!-- Page: Search (placeholder) -->
+    <div class="page" id="page-search" style="display:none">
+        <div class="page-content">
+            <h1>Search</h1>
+            <p class="page-placeholder">Search coming soon.</p>
         </div>
-        <div class="settings-list" id="settingsList"></div>
-    </aside>
+    </div>
+
+    <!-- Page: Favourites (placeholder) -->
+    <div class="page" id="page-favourites" style="display:none">
+        <div class="page-content">
+            <h1>Favourites</h1>
+            <p class="page-placeholder">Favourites coming soon.</p>
+        </div>
+    </div>
+
+    <!-- Page: Settings -->
+    <div class="page" id="page-settings" style="display:none">
+        <div class="page-content">
+            <h1>Channels</h1>
+            <div class="settings-list" id="settingsList"></div>
+        </div>
+    </div>
+
+    <!-- Bottom navigation bar -->
+    <nav class="bottom-nav" id="bottomNav">
+        <button class="bottom-nav-btn active" data-page="guide" aria-label="Guide">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>
+            </svg>
+            <span>Guide</span>
+        </button>
+        <button class="bottom-nav-btn" data-page="search" aria-label="Search">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+            <span>Search</span>
+        </button>
+        <button class="bottom-nav-btn" data-page="favourites" aria-label="Favourites">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+            </svg>
+            <span>Favourites</span>
+        </button>
+        <button class="bottom-nav-btn" data-page="settings" aria-label="Settings">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+            </svg>
+            <span>Settings</span>
+        </button>
+    </nav>
 
     <!-- Programme details modal -->
     <div class="modal-backdrop" id="modalBackdrop">

--- a/web/style.css
+++ b/web/style.css
@@ -19,6 +19,7 @@
 
     /* Layout dimensions — changing these values adjusts the whole guide */
     --top-bar-height:      48px;
+    --bottom-nav-height:   56px;
     --channel-col-width:   120px;
     --time-row-height:     36px;
     --row-height:          54px; /* keep in sync with ROW_HEIGHT in app.js */
@@ -106,6 +107,34 @@ body {
 
 .action-btn:hover {
     background: var(--bg-card);
+}
+
+/* ── Pages ────────────────────────────────────────────────────── */
+
+.page {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.page-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 16px;
+    padding-bottom: calc(20px + var(--bottom-nav-height));
+}
+
+.page-content h1 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 16px;
+}
+
+.page-placeholder {
+    color: var(--text-secondary);
+    font-size: 14px;
 }
 
 /* ── Guide grid ───────────────────────────────────────────────── */
@@ -324,69 +353,58 @@ body {
     border-radius: 50%;
 }
 
-/* ── Settings panel ───────────────────────────────────────────── */
+/* ── Bottom navigation bar ─────────────────────────────────────── */
 
-.settings-overlay {
+.bottom-nav {
     position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 30;
-    display: none;
-}
-
-.settings-overlay.open {
-    display: block;
-}
-
-.settings-panel {
-    position: fixed;
-    top: 0;
-    right: 0;
     bottom: 0;
-    width: 300px;
+    left: 0;
+    right: 0;
+    height: var(--bottom-nav-height);
     background: var(--bg-secondary);
-    border-left: 1px solid var(--border);
-    z-index: 31;
-    display: flex;
-    flex-direction: column;
-    transform: translateX(100%);
-    transition: transform 0.25s ease;
-}
-
-.settings-panel.open {
-    transform: translateX(0);
-}
-
-.settings-header {
+    border-top: 1px solid var(--border);
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 14px 16px;
-    border-bottom: 1px solid var(--border);
-    flex-shrink: 0;
+    justify-content: space-around;
+    z-index: 25;
+    padding-bottom: env(safe-area-inset-bottom, 0);
 }
 
-.settings-header h2 {
-    font-size: 15px;
-    font-weight: 600;
-}
-
-.close-btn {
+.bottom-nav-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
     background: none;
     border: none;
-    color: var(--text-secondary);
+    color: var(--text-muted);
     cursor: pointer;
-    font-size: 16px;
-    padding: 4px 8px;
-    border-radius: 4px;
-    line-height: 1;
-    transition: color 0.15s, background 0.15s;
+    padding: 6px 12px;
+    border-radius: 8px;
+    transition: color 0.15s;
+    -webkit-tap-highlight-color: transparent;
 }
 
-.close-btn:hover {
-    color: var(--text-primary);
-    background: var(--bg-card);
+.bottom-nav-btn span {
+    font-size: 10px;
+    line-height: 1;
 }
+
+.bottom-nav-btn svg {
+    width: 22px;
+    height: 22px;
+}
+
+.bottom-nav-btn:hover {
+    color: var(--text-secondary);
+}
+
+.bottom-nav-btn.active {
+    color: var(--text-primary);
+}
+
+/* ── Settings page (channel list) ─────────────────────────────── */
 
 .settings-list {
     overflow-y: auto;
@@ -396,7 +414,7 @@ body {
 .settings-item {
     display: flex;
     align-items: center;
-    padding: 7px 16px;
+    padding: 7px 0;
     gap: 10px;
     border-bottom: 1px solid var(--border);
 }
@@ -473,6 +491,23 @@ body {
     position: absolute;
     top: 12px;
     right: 12px;
+}
+
+.close-btn {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 16px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    line-height: 1;
+    transition: color 0.15s, background 0.15s;
+}
+
+.close-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-card);
 }
 
 .modal-meta {

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,6 +1,9 @@
 const CACHE = 'tvguide-__CACHE_VERSION__';
 const STATIC = ['/', '/index.html', '/style.css', '/app.js', '/manifest.json'];
 
+// SPA routes that should be served from the cached index.html
+const SPA_ROUTES = ['/guide', '/search', '/favourites', '/settings'];
+
 self.addEventListener('install', event => {
     event.waitUntil(
         caches.open(CACHE).then(cache => cache.addAll(STATIC))
@@ -24,6 +27,11 @@ self.addEventListener('fetch', event => {
         // Network-first for API: always try to get fresh data.
         event.respondWith(
             fetch(event.request).catch(() => caches.match(event.request))
+        );
+    } else if (SPA_ROUTES.includes(url.pathname)) {
+        // SPA routes: serve cached index.html (the SPA shell)
+        event.respondWith(
+            caches.match('/index.html').then(cached => cached || fetch('/'))
         );
     } else {
         // Cache-first for static assets.


### PR DESCRIPTION
## Summary
- Add a persistent bottom navigation bar with Guide, Search, Favourites, and Settings tabs
- Implement path-based client-side routing using the History API (`/guide`, `/search`, `/favourites`, `/settings`)
- Add SPA fallback handler in the Go backend so direct navigation and page refresh work for all routes
- Convert the settings slide-out panel into a full Settings page; remove the old panel and its top-bar trigger
- Add placeholder pages for Search and Favourites
- Update service worker to serve cached `index.html` for SPA routes

Closes #28

## Test plan
- [x] 6 new integration tests for SPA fallback behaviour (routes return HTML, API/static files unaffected)
- [x] All existing tests pass
- [ ] Manually verify bottom nav switches between pages
- [ ] Manually verify browser back/forward navigation works
- [ ] Manually verify direct navigation to `/search`, `/favourites`, `/settings` works
- [ ] Manually verify Guide tab: date nav, scroll sync, now-line, `?date=` query param
- [ ] Manually verify Settings tab: channel visibility and favourite toggles work
- [ ] Manually verify layout on mobile (bottom nav doesn't overlap content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)