### PR TITLE
Add FTS5 full-text search and categories table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,11 +90,20 @@ airings (
   star_rating, content_rating, year, icon, country,
   is_repeat, is_premiere
 )
+
+airings_fts  -- FTS5 virtual table for full-text search
+  (channel_id, start_time, title, sub_title, description)
+  -- Rebuilt on each Refresh(): cleared and repopulated from airings table
+  -- Used by SearchSimple (title only) and SearchAdvanced (all text columns)
+
+categories (name TEXT PRIMARY KEY)
+  -- Distinct category values extracted from airings.categories JSON arrays
+  -- Rebuilt on each Refresh()
 ```
 
 ### Refresh strategy
 
-On each poll: upsert channels → `INSERT OR REPLACE` airings (composite PK handles duplicates) → prune airings older than `RETENTION_DAYS`. All in one transaction.
+On each poll: upsert channels → `INSERT OR REPLACE` airings (composite PK handles duplicates) → prune airings older than `RETENTION_DAYS` → rebuild FTS index → rebuild categories table. All in one transaction.
 
 Historical airings not present in the latest XMLTV file are preserved until they age out.
 

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -120,6 +120,10 @@ var migrations = []struct {
 }{
 	{1, `ALTER TABLE channels ADD COLUMN lcn INTEGER`},
 	{2, `ALTER TABLE channels ADD COLUMN icon_url TEXT`},
+	{3, `CREATE VIRTUAL TABLE IF NOT EXISTS airings_fts USING fts5(
+		channel_id, start_time, title, sub_title, description
+	)`},
+	{4, `CREATE TABLE IF NOT EXISTS categories (name TEXT PRIMARY KEY)`},
 }
 
 func applyMigrations(db *sql.DB) error {
@@ -166,8 +170,22 @@ func migrationAlreadyApplied(db *sql.DB, version int) (bool, error) {
 		return columnExists(db, "channels", "lcn")
 	case 2:
 		return columnExists(db, "channels", "icon_url")
+	case 3:
+		return tableExists(db, "airings_fts")
+	case 4:
+		return tableExists(db, "categories")
 	}
 	return false, nil
+}
+
+// tableExists reports whether a table (or virtual table) exists in the database.
+func tableExists(db *sql.DB, table string) (bool, error) {
+	var count int
+	err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE name = ?`, table).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 // columnExists reports whether the named column is present in the given table.
@@ -376,6 +394,30 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	cutoff := time.Now().AddDate(0, 0, -d.retentionDays).UTC().Format(time.RFC3339)
 	if _, err := tx.Exec(`DELETE FROM airings WHERE stop_time < ?`, cutoff); err != nil {
 		return fmt.Errorf("pruning airings: %w", err)
+	}
+
+	// Rebuild FTS index: clear and repopulate from airings table.
+	if _, err := tx.Exec(`DELETE FROM airings_fts`); err != nil {
+		return fmt.Errorf("clearing FTS index: %w", err)
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO airings_fts (channel_id, start_time, title, sub_title, description)
+		SELECT channel_id, start_time, title, COALESCE(sub_title, ''), COALESCE(description, '')
+		FROM airings
+	`); err != nil {
+		return fmt.Errorf("populating FTS index: %w", err)
+	}
+
+	// Rebuild categories table from distinct values in airings.categories JSON arrays.
+	if _, err := tx.Exec(`DELETE FROM categories`); err != nil {
+		return fmt.Errorf("clearing categories: %w", err)
+	}
+	if _, err := tx.Exec(`
+		INSERT OR IGNORE INTO categories (name)
+		SELECT DISTINCT value FROM airings, json_each(airings.categories)
+		WHERE value IS NOT NULL AND value != ''
+	`); err != nil {
+		return fmt.Errorf("populating categories: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -713,4 +755,134 @@ func boolToInt(b bool) int {
 		return 1
 	}
 	return 0
+}
+
+// ExecRaw executes a raw SQL statement against the database.
+// Exposed for testing (e.g. verifying FTS5 availability).
+func (d *DB) ExecRaw(query string) (sql.Result, error) {
+	return d.db.Exec(query)
+}
+
+// SearchSimple performs an FTS5 search on the title column only.
+// Returns future airings ordered by relevance then start time.
+// If includeRepeats is false, repeats are excluded.
+func (d *DB) SearchSimple(query string, includeRepeats bool) ([]Airing, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	q := `
+		SELECT
+			a.channel_id, a.start_time, a.stop_time,
+			a.title, COALESCE(a.sub_title, ''), COALESCE(a.description, ''),
+			COALESCE(a.categories, '[]'),
+			COALESCE(a.episode_num, ''), COALESCE(a.episode_num_display, ''),
+			COALESCE(a.prog_id, ''), COALESCE(a.star_rating, ''),
+			COALESCE(a.content_rating, ''), COALESCE(a.year, ''),
+			COALESCE(a.icon, ''), COALESCE(a.country, ''),
+			a.is_repeat, a.is_premiere
+		FROM airings_fts f
+		JOIN airings a ON a.channel_id = f.channel_id AND a.start_time = f.start_time
+		WHERE f.title MATCH ?
+		  AND a.start_time > ?`
+	args := []any{query, now}
+
+	if !includeRepeats {
+		q += ` AND a.is_repeat = 0`
+	}
+	q += ` ORDER BY f.rank, a.start_time`
+
+	return d.scanAirings(q, args...)
+}
+
+// SearchAdvanced performs an FTS5 search on title, sub_title, and description.
+// If categories is non-empty, only airings with at least one matching category are returned.
+// If includePast is false, only future airings are returned.
+// If includeRepeats is false, repeats are excluded.
+func (d *DB) SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool) ([]Airing, error) {
+	q := `
+		SELECT
+			a.channel_id, a.start_time, a.stop_time,
+			a.title, COALESCE(a.sub_title, ''), COALESCE(a.description, ''),
+			COALESCE(a.categories, '[]'),
+			COALESCE(a.episode_num, ''), COALESCE(a.episode_num_display, ''),
+			COALESCE(a.prog_id, ''), COALESCE(a.star_rating, ''),
+			COALESCE(a.content_rating, ''), COALESCE(a.year, ''),
+			COALESCE(a.icon, ''), COALESCE(a.country, ''),
+			a.is_repeat, a.is_premiere
+		FROM airings_fts f
+		JOIN airings a ON a.channel_id = f.channel_id AND a.start_time = f.start_time
+		WHERE airings_fts MATCH ?`
+	args := []any{query}
+
+	if !includePast {
+		now := time.Now().UTC().Format(time.RFC3339)
+		q += ` AND a.start_time > ?`
+		args = append(args, now)
+	}
+	if !includeRepeats {
+		q += ` AND a.is_repeat = 0`
+	}
+	if len(categories) > 0 {
+		placeholders := make([]string, len(categories))
+		for i, c := range categories {
+			placeholders[i] = "?"
+			args = append(args, c)
+		}
+		q += ` AND EXISTS (SELECT 1 FROM json_each(a.categories) WHERE value IN (` + strings.Join(placeholders, ",") + `))`
+	}
+	q += ` ORDER BY f.rank, a.start_time`
+
+	return d.scanAirings(q, args...)
+}
+
+// GetCategories returns all distinct categories sorted alphabetically.
+func (d *DB) GetCategories() ([]string, error) {
+	rows, err := d.db.Query(`SELECT name FROM categories ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("querying categories: %w", err)
+	}
+	defer rows.Close()
+
+	cats := []string{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scanning category: %w", err)
+		}
+		cats = append(cats, name)
+	}
+	return cats, rows.Err()
+}
+
+// scanAirings executes a query and scans results into Airing slices.
+func (d *DB) scanAirings(query string, args ...any) ([]Airing, error) {
+	rows, err := d.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying airings: %w", err)
+	}
+	defer rows.Close()
+
+	var airings []Airing
+	for rows.Next() {
+		var a Airing
+		var startStr, stopStr, catsJSON string
+		var isRepeat, isPremiere int
+
+		if err := rows.Scan(
+			&a.ChannelID, &startStr, &stopStr,
+			&a.Title, &a.SubTitle, &a.Description, &catsJSON,
+			&a.EpisodeNum, &a.EpisodeNumDisplay, &a.ProgID,
+			&a.StarRating, &a.ContentRating, &a.Year, &a.Icon, &a.Country,
+			&isRepeat, &isPremiere,
+		); err != nil {
+			return nil, fmt.Errorf("scanning airing: %w", err)
+		}
+
+		a.Start, _ = time.Parse(time.RFC3339, startStr)
+		a.Stop, _ = time.Parse(time.RFC3339, stopStr)
+		json.Unmarshal([]byte(catsJSON), &a.Categories)
+		a.IsRepeat = isRepeat == 1
+		a.IsPremiere = isPremiere == 1
+
+		airings = append(airings, a)
+	}
+	return airings, rows.Err()
 }

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -646,6 +646,354 @@ func TestGetAirings_PremiereFlagAndCategories(t *testing.T) {
 	}
 }
 
+// --- FTS5 and Search tests ---
+
+// TestFTS5_Available verifies that modernc.org/sqlite supports FTS5.
+func TestFTS5_Available(t *testing.T) {
+	db := openTestDB(t)
+	// Attempt to create a simple FTS5 table. If this fails, FTS5 is not compiled in.
+	_, err := db.ExecRaw(`CREATE VIRTUAL TABLE IF NOT EXISTS fts5_test USING fts5(content)`)
+	if err != nil {
+		t.Fatalf("FTS5 not available in modernc.org/sqlite: %v", err)
+	}
+	_, err = db.ExecRaw(`DROP TABLE fts5_test`)
+	if err != nil {
+		t.Fatalf("dropping FTS5 test table: %v", err)
+	}
+}
+
+// searchTV returns test data with airings in the future and past, with varied
+// titles, subtitles, descriptions, categories, and repeat flags for search tests.
+func searchTV() *xmltv.TV {
+	return &xmltv.TV{
+		Channels: []xmltv.Channel{
+			{ID: "ch1", DisplayNames: []xmltv.Name{{Value: "ABC"}}},
+			{ID: "ch2", DisplayNames: []xmltv.Name{{Value: "SBS"}}},
+		},
+		Programmes: []xmltv.Programme{
+			{
+				// Future, non-repeat, title match for "News"
+				Start:      xmltv.XmltvTime{Time: time.Now().Add(1 * time.Hour)},
+				Stop:       xmltv.XmltvTime{Time: time.Now().Add(2 * time.Hour)},
+				Channel:    "ch1",
+				Titles:     []xmltv.Name{{Value: "Morning News"}},
+				Descs:      []xmltv.Name{{Value: "Start your day with the latest headlines."}},
+				Categories: []xmltv.Name{{Value: "News"}},
+			},
+			{
+				// Future, repeat, title match for "News"
+				Start:           xmltv.XmltvTime{Time: time.Now().Add(3 * time.Hour)},
+				Stop:            xmltv.XmltvTime{Time: time.Now().Add(4 * time.Hour)},
+				Channel:         "ch1",
+				Titles:          []xmltv.Name{{Value: "Evening News"}},
+				Descs:           []xmltv.Name{{Value: "Recap of today's events."}},
+				Categories:      []xmltv.Name{{Value: "News"}},
+				PreviouslyShown: &xmltv.PreviouslyShown{},
+			},
+			{
+				// Future, non-repeat, title does NOT match "News" but description does
+				Start:      xmltv.XmltvTime{Time: time.Now().Add(5 * time.Hour)},
+				Stop:       xmltv.XmltvTime{Time: time.Now().Add(6 * time.Hour)},
+				Channel:    "ch2",
+				Titles:     []xmltv.Name{{Value: "Documentary Special"}},
+				SubTitles:  []xmltv.Name{{Value: "Behind the news desk"}},
+				Descs:      []xmltv.Name{{Value: "A look at how news is made."}},
+				Categories: []xmltv.Name{{Value: "Documentary"}},
+			},
+			{
+				// Past, non-repeat, title match for "News"
+				Start:      xmltv.XmltvTime{Time: time.Now().Add(-3 * time.Hour)},
+				Stop:       xmltv.XmltvTime{Time: time.Now().Add(-2 * time.Hour)},
+				Channel:    "ch1",
+				Titles:     []xmltv.Name{{Value: "Late Night News"}},
+				Descs:      []xmltv.Name{{Value: "Yesterday's late night news."}},
+				Categories: []xmltv.Name{{Value: "News"}},
+			},
+			{
+				// Future, non-repeat, category "Sport"
+				Start:      xmltv.XmltvTime{Time: time.Now().Add(7 * time.Hour)},
+				Stop:       xmltv.XmltvTime{Time: time.Now().Add(8 * time.Hour)},
+				Channel:    "ch2",
+				Titles:     []xmltv.Name{{Value: "Sports Tonight"}},
+				Descs:      []xmltv.Name{{Value: "All the sport highlights."}},
+				Categories: []xmltv.Name{{Value: "Sport"}, {Value: "Entertainment"}},
+			},
+		},
+	}
+}
+
+func TestSearchSimple_MatchesTitle(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchSimple("News", true)
+	if err != nil {
+		t.Fatalf("SearchSimple: %v", err)
+	}
+	// Should match "Morning News", "Evening News" (future, title match only)
+	// Should NOT match "Documentary Special" (title doesn't contain "News")
+	// Should NOT match "Late Night News" (past)
+	for _, r := range results {
+		if r.Title == "Documentary Special" {
+			t.Error("SearchSimple should not match on subtitle/description, only title")
+		}
+		if r.Title == "Late Night News" {
+			t.Error("SearchSimple should exclude past airings")
+		}
+	}
+	if len(results) < 2 {
+		t.Errorf("expected at least 2 results matching 'News' in title, got %d", len(results))
+	}
+}
+
+func TestSearchSimple_ExcludesDescriptionOnlyMatches(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchSimple("News", true)
+	if err != nil {
+		t.Fatalf("SearchSimple: %v", err)
+	}
+	for _, r := range results {
+		if r.Title == "Documentary Special" {
+			t.Error("SearchSimple should not return results that only match in description/subtitle")
+		}
+	}
+}
+
+func TestSearchSimple_ExcludesPastAirings(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchSimple("News", true)
+	if err != nil {
+		t.Fatalf("SearchSimple: %v", err)
+	}
+	for _, r := range results {
+		if r.Start.Before(time.Now()) {
+			t.Errorf("SearchSimple returned past airing: %q at %v", r.Title, r.Start)
+		}
+	}
+}
+
+func TestSearchSimple_ExcludesRepeats(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchSimple("News", false)
+	if err != nil {
+		t.Fatalf("SearchSimple: %v", err)
+	}
+	for _, r := range results {
+		if r.IsRepeat {
+			t.Errorf("SearchSimple with includeRepeats=false returned repeat: %q", r.Title)
+		}
+	}
+}
+
+func TestSearchSimple_IncludesRepeats(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchSimple("News", true)
+	if err != nil {
+		t.Fatalf("SearchSimple: %v", err)
+	}
+	hasRepeat := false
+	for _, r := range results {
+		if r.IsRepeat {
+			hasRepeat = true
+		}
+	}
+	if !hasRepeat {
+		t.Error("SearchSimple with includeRepeats=true should include repeats")
+	}
+}
+
+func TestSearchAdvanced_MatchesTitleSubtitleDescription(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	// "news" should match in title (Morning News, Evening News) AND subtitle/description (Documentary Special)
+	results, err := db.SearchAdvanced("news", nil, false, true)
+	if err != nil {
+		t.Fatalf("SearchAdvanced: %v", err)
+	}
+	titles := map[string]bool{}
+	for _, r := range results {
+		titles[r.Title] = true
+	}
+	if !titles["Morning News"] {
+		t.Error("expected Morning News in results")
+	}
+	if !titles["Documentary Special"] {
+		t.Error("expected Documentary Special in results (matches in subtitle/description)")
+	}
+}
+
+func TestSearchAdvanced_FiltersByCategory(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	// Search for "news" but filter to "Documentary" category only
+	results, err := db.SearchAdvanced("news", []string{"Documentary"}, false, true)
+	if err != nil {
+		t.Fatalf("SearchAdvanced: %v", err)
+	}
+	for _, r := range results {
+		if r.Title == "Morning News" {
+			t.Error("Morning News should be filtered out — it's not in Documentary category")
+		}
+	}
+	hasDocumentary := false
+	for _, r := range results {
+		if r.Title == "Documentary Special" {
+			hasDocumentary = true
+		}
+	}
+	if !hasDocumentary {
+		t.Error("expected Documentary Special in results")
+	}
+}
+
+func TestSearchAdvanced_IncludesPastAirings(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchAdvanced("News", nil, true, true)
+	if err != nil {
+		t.Fatalf("SearchAdvanced: %v", err)
+	}
+	hasPast := false
+	for _, r := range results {
+		if r.Start.Before(time.Now()) {
+			hasPast = true
+		}
+	}
+	if !hasPast {
+		t.Error("SearchAdvanced with includePast=true should include past airings")
+	}
+}
+
+func TestSearchAdvanced_ExcludesPastAirings(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchAdvanced("News", nil, false, true)
+	if err != nil {
+		t.Fatalf("SearchAdvanced: %v", err)
+	}
+	for _, r := range results {
+		if r.Start.Before(time.Now()) {
+			t.Errorf("SearchAdvanced with includePast=false returned past airing: %q at %v", r.Title, r.Start)
+		}
+	}
+}
+
+func TestSearchAdvanced_ExcludesRepeats(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchAdvanced("News", nil, false, false)
+	if err != nil {
+		t.Fatalf("SearchAdvanced: %v", err)
+	}
+	for _, r := range results {
+		if r.IsRepeat {
+			t.Errorf("SearchAdvanced with includeRepeats=false returned repeat: %q", r.Title)
+		}
+	}
+}
+
+func TestSearchAdvanced_CombinesCategoryAndText(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	// Search for "sport" filtered to "Entertainment" category
+	results, err := db.SearchAdvanced("sport", []string{"Entertainment"}, false, true)
+	if err != nil {
+		t.Fatalf("SearchAdvanced: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected at least 1 result for 'sport' in Entertainment category")
+	}
+	for _, r := range results {
+		if r.Title != "Sports Tonight" {
+			t.Errorf("unexpected result: %q", r.Title)
+		}
+	}
+}
+
+func TestGetCategories_ReturnsSorted(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	cats, err := db.GetCategories()
+	if err != nil {
+		t.Fatalf("GetCategories: %v", err)
+	}
+	expected := []string{"Documentary", "Entertainment", "News", "Sport"}
+	if len(cats) != len(expected) {
+		t.Fatalf("expected %d categories, got %d: %v", len(expected), len(cats), cats)
+	}
+	for i, c := range cats {
+		if c != expected[i] {
+			t.Errorf("category[%d]: expected %q, got %q", i, expected[i], c)
+		}
+	}
+}
+
+func TestGetCategories_EmptyWhenNoData(t *testing.T) {
+	db := openTestDB(t)
+	cats, err := db.GetCategories()
+	if err != nil {
+		t.Fatalf("GetCategories: %v", err)
+	}
+	if cats == nil {
+		t.Fatal("expected non-nil slice, got nil")
+	}
+	if len(cats) != 0 {
+		t.Fatalf("expected 0 categories, got %d", len(cats))
+	}
+}
+
+func TestRefresh_PopulatesFTSAndCategories(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	// FTS should be populated — simple search should work
+	results, err := db.SearchSimple("Morning", true)
+	if err != nil {
+		t.Fatalf("SearchSimple after Refresh: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected FTS results after Refresh")
+	}
+
+	// Categories should be populated
+	cats, err := db.GetCategories()
+	if err != nil {
+		t.Fatalf("GetCategories after Refresh: %v", err)
+	}
+	if len(cats) == 0 {
+		t.Error("expected categories after Refresh")
+	}
+}
+
 func TestRefresh_Upsert_NoDuplicates(t *testing.T) {
 	db := openTestDB(t)
 	tv := sampleTV()


### PR DESCRIPTION
## Summary
- Add FTS5 virtual table (`airings_fts`) indexing title, sub_title, and description for full-text search
- Add normalised `categories` table populated from airings JSON arrays
- Add `SearchSimple()`, `SearchAdvanced()`, and `GetCategories()` query functions
- Both tables are rebuilt on each `Refresh()` within the existing transaction

Closes #29

## Test plan
- [x] FTS5 availability verified with modernc.org/sqlite
- [x] SearchSimple: title-only matching, excludes past airings, repeat filtering
- [x] SearchAdvanced: full-text matching, category filtering, past/repeat filtering
- [x] GetCategories: sorted distinct values, empty when no data
- [x] Refresh integration: FTS and categories populated after refresh
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)