### PR TITLE
Add search and categories API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ tvguide/
 | `GET /api/channels` | All channels in source order |
 | `GET /api/guide?date=YYYY-MM-DD` | Airings overlapping the given date (local TZ). Defaults to today. |
 | `GET /api/status` | Last refresh time, next refresh time, source URL |
+| `GET /api/search?q=...&mode=...` | Search airings. `q` (required): search text. `mode`: `simple` (title only, default) or `advanced` (title+subtitle+description). Advanced-only params: `categories` (comma-separated), `include_past` (bool, default false). Shared: `include_repeats` (bool, default true). Returns results grouped by title. |
+| `GET /api/categories` | Sorted JSON array of all distinct category strings |
 | `GET /images/channel/{channel-id}` | Cached channel logo. Re-downloads from upstream if the local file is missing. Returns 404 if the channel has no icon. |
 | `GET /` | Serves the embedded frontend (SPA shell) |
 | `GET /{any}` | SPA fallback — serves `index.html` for any path not matching API, images, or static files. Enables client-side routing via History API. |

--- a/integration_test.go
+++ b/integration_test.go
@@ -495,6 +495,115 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	}
 }
 
+// TestIntegration_Search verifies the full search flow: load XMLTV data,
+// then call /api/search and verify the response shape.
+func TestIntegration_Search(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	// Search for "News" — sample.xml has "Morning News" and "World News"
+	resp, err := http.Get(srv.URL + "/api/search?q=News&mode=advanced&include_past=true")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type: expected application/json, got %q", ct)
+	}
+
+	var result []struct {
+		Title   string `json:"title"`
+		Airings []struct {
+			ChannelID   string `json:"channelId"`
+			ChannelName string `json:"channelName"`
+		} `json:"airings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(result) == 0 {
+		t.Fatal("expected at least one search result group")
+	}
+
+	// Verify channelName is populated
+	for _, g := range result {
+		for _, a := range g.Airings {
+			if a.ChannelName == "" {
+				t.Errorf("channelName should be populated for airing in group %q", g.Title)
+			}
+		}
+	}
+}
+
+// TestIntegration_Categories verifies the /api/categories endpoint returns
+// categories from the loaded XMLTV data.
+func TestIntegration_Categories(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/api/categories")
+	if err != nil {
+		t.Fatalf("GET /api/categories: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result []string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// sample.xml has categories: Movie, News, Entertainment, International
+	if len(result) == 0 {
+		t.Fatal("expected at least one category")
+	}
+
+	// Verify sorted
+	for i := 1; i < len(result); i++ {
+		if result[i] < result[i-1] {
+			t.Errorf("categories not sorted: %q before %q", result[i-1], result[i])
+		}
+	}
+}
+
+// TestIntegration_Search_MissingQuery verifies 400 for missing q parameter.
+func TestIntegration_Search_MissingQuery(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/api/search")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
 // TestIntegration_SPAFallback_SearchReturnsHTML verifies that GET /search
 // returns index.html content (SPA fallback) instead of 404.
 func TestIntegration_SPAFallback_SearchReturnsHTML(t *testing.T) {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3,10 +3,13 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/acbgbca/xmltvguide/internal/database"
@@ -18,6 +21,9 @@ type store interface {
 	GetAirings(date time.Time) ([]database.Airing, error)
 	GetStatus() database.Status
 	EnsureChannelIcon(ctx context.Context, channelID string) (string, error)
+	SearchSimple(query string, includeRepeats bool) ([]database.SearchResult, error)
+	SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool) ([]database.SearchResult, error)
+	GetCategories() ([]string, error)
 }
 
 // Handler holds the HTTP handler dependencies.
@@ -35,6 +41,8 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/channels", h.getChannels)
 	mux.HandleFunc("GET /api/guide", h.getGuide)
 	mux.HandleFunc("GET /api/status", h.getStatus)
+	mux.HandleFunc("GET /api/search", h.getSearch)
+	mux.HandleFunc("GET /api/categories", h.getCategories)
 	mux.HandleFunc("GET /images/channel/{id}", h.serveChannelIcon)
 }
 
@@ -97,6 +105,118 @@ func (h *Handler) serveChannelIcon(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", contentType)
 	w.Write(data) //nolint:errcheck
+}
+
+// searchResultAiring is the JSON shape for a single airing in a search result group.
+type searchResultAiring struct {
+	ChannelID         string    `json:"channelId"`
+	ChannelName       string    `json:"channelName"`
+	StartTime         time.Time `json:"startTime"`
+	StopTime          time.Time `json:"stopTime"`
+	SubTitle          string    `json:"subTitle,omitempty"`
+	Description       string    `json:"description,omitempty"`
+	EpisodeNumDisplay string    `json:"episodeNumDisplay,omitempty"`
+	Categories        []string  `json:"categories,omitempty"`
+	IsRepeat          bool      `json:"isRepeat"`
+	IsPremiere        bool      `json:"isPremiere"`
+}
+
+// searchResultGroup is the JSON shape for a group of airings sharing the same title.
+type searchResultGroup struct {
+	Title   string               `json:"title"`
+	Airings []searchResultAiring `json:"airings"`
+}
+
+func (h *Handler) getSearch(w http.ResponseWriter, r *http.Request) {
+	q := strings.TrimSpace(r.URL.Query().Get("q"))
+	if q == "" {
+		http.Error(w, "missing required parameter: q", http.StatusBadRequest)
+		return
+	}
+
+	mode := r.URL.Query().Get("mode")
+	includeRepeats := r.URL.Query().Get("include_repeats") != "false"
+
+	var results []database.SearchResult
+	var err error
+
+	if mode == "advanced" {
+		var categories []string
+		if cats := r.URL.Query().Get("categories"); cats != "" {
+			categories = strings.Split(cats, ",")
+		}
+		includePast := r.URL.Query().Get("include_past") == "true"
+		results, err = h.db.SearchAdvanced(q, categories, includePast, includeRepeats)
+	} else {
+		results, err = h.db.SearchSimple(q, includeRepeats)
+	}
+
+	if err != nil {
+		http.Error(w, "search error", http.StatusInternalServerError)
+		return
+	}
+
+	// Group by title, tracking best rank per group.
+	type groupData struct {
+		airings  []searchResultAiring
+		bestRank float64
+	}
+	groups := map[string]*groupData{}
+	order := []string{} // preserve insertion order for determinism
+
+	for _, sr := range results {
+		a := searchResultAiring{
+			ChannelID:         sr.ChannelID,
+			ChannelName:       sr.ChannelName,
+			StartTime:         sr.Start,
+			StopTime:          sr.Stop,
+			SubTitle:          sr.SubTitle,
+			Description:       sr.Description,
+			EpisodeNumDisplay: sr.EpisodeNumDisplay,
+			Categories:        sr.Categories,
+			IsRepeat:          sr.IsRepeat,
+			IsPremiere:        sr.IsPremiere,
+		}
+
+		g, ok := groups[sr.Title]
+		if !ok {
+			g = &groupData{bestRank: math.MaxFloat64}
+			groups[sr.Title] = g
+			order = append(order, sr.Title)
+		}
+		g.airings = append(g.airings, a)
+		if sr.Rank < g.bestRank {
+			g.bestRank = sr.Rank
+		}
+	}
+
+	// Sort groups by best rank, then alphabetically by title.
+	sort.SliceStable(order, func(i, j int) bool {
+		ri, rj := groups[order[i]].bestRank, groups[order[j]].bestRank
+		if ri != rj {
+			return ri < rj
+		}
+		return order[i] < order[j]
+	})
+
+	response := make([]searchResultGroup, 0, len(order))
+	for _, title := range order {
+		response = append(response, searchResultGroup{
+			Title:   title,
+			Airings: groups[title].airings,
+		})
+	}
+
+	writeJSON(w, response)
+}
+
+func (h *Handler) getCategories(w http.ResponseWriter, r *http.Request) {
+	cats, err := h.db.GetCategories()
+	if err != nil {
+		http.Error(w, "database error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, cats)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -391,6 +391,412 @@ func TestGetChannelIcon_RedownloadsIfMissing(t *testing.T) {
 
 // TestGetChannels_IconIsProxyURL verifies that /api/channels returns the proxy
 // URL for channels that have an icon.
+// newSearchSeededServer creates a test API server with search-relevant data:
+// future and past airings across two channels, with varied categories, repeats,
+// and text in titles/subtitles/descriptions.
+func newSearchSeededServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	now := time.Now()
+	tv := &xmltv.TV{
+		Channels: []xmltv.Channel{
+			{ID: "ch1", DisplayNames: []xmltv.Name{{Value: "ABC"}}},
+			{ID: "ch2", DisplayNames: []xmltv.Name{{Value: "SBS"}}},
+		},
+		Programmes: []xmltv.Programme{
+			{
+				// Future, non-repeat, title "Morning News", category News
+				Start:      xmltv.XmltvTime{Time: now.Add(1 * time.Hour)},
+				Stop:       xmltv.XmltvTime{Time: now.Add(2 * time.Hour)},
+				Channel:    "ch1",
+				Titles:     []xmltv.Name{{Value: "Morning News"}},
+				Descs:      []xmltv.Name{{Value: "Start your day with headlines."}},
+				Categories: []xmltv.Name{{Value: "News"}},
+			},
+			{
+				// Future, repeat, title "Morning News" (same title, different channel)
+				Start:           xmltv.XmltvTime{Time: now.Add(3 * time.Hour)},
+				Stop:            xmltv.XmltvTime{Time: now.Add(4 * time.Hour)},
+				Channel:         "ch2",
+				Titles:          []xmltv.Name{{Value: "Morning News"}},
+				Descs:           []xmltv.Name{{Value: "Replay of this morning's news."}},
+				Categories:      []xmltv.Name{{Value: "News"}},
+				PreviouslyShown: &xmltv.PreviouslyShown{},
+			},
+			{
+				// Future, non-repeat, description mentions "news" but title doesn't
+				Start:      xmltv.XmltvTime{Time: now.Add(5 * time.Hour)},
+				Stop:       xmltv.XmltvTime{Time: now.Add(6 * time.Hour)},
+				Channel:    "ch2",
+				Titles:     []xmltv.Name{{Value: "Documentary Special"}},
+				SubTitles:  []xmltv.Name{{Value: "Behind the news desk"}},
+				Descs:      []xmltv.Name{{Value: "A look at how news is made."}},
+				Categories: []xmltv.Name{{Value: "Documentary"}},
+			},
+			{
+				// Past, non-repeat, title "Late Night News"
+				Start:      xmltv.XmltvTime{Time: now.Add(-3 * time.Hour)},
+				Stop:       xmltv.XmltvTime{Time: now.Add(-2 * time.Hour)},
+				Channel:    "ch1",
+				Titles:     []xmltv.Name{{Value: "Late Night News"}},
+				Descs:      []xmltv.Name{{Value: "Yesterday's late night news."}},
+				Categories: []xmltv.Name{{Value: "News"}},
+			},
+			{
+				// Future, non-repeat, category Sport+Entertainment
+				Start:      xmltv.XmltvTime{Time: now.Add(7 * time.Hour)},
+				Stop:       xmltv.XmltvTime{Time: now.Add(8 * time.Hour)},
+				Channel:    "ch2",
+				Titles:     []xmltv.Name{{Value: "Sports Tonight"}},
+				Descs:      []xmltv.Name{{Value: "All the sport highlights."}},
+				Categories: []xmltv.Name{{Value: "Sport"}, {Value: "Entertainment"}},
+			},
+		},
+	}
+
+	if err := db.Refresh(context.Background(), tv, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	handler := api.New(db)
+	handler.RegisterRoutes(mux)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		srv.Close()
+		db.Close()
+	})
+	return srv
+}
+
+// --- Search endpoint tests ---
+
+func TestSearch_MissingQuery_Returns400(t *testing.T) {
+	srv := newSearchSeededServer(t)
+
+	// No q parameter
+	resp, err := http.Get(srv.URL + "/api/search")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing q, got %d", resp.StatusCode)
+	}
+
+	// Empty q parameter
+	resp2, err := http.Get(srv.URL + "/api/search?q=")
+	if err != nil {
+		t.Fatalf("GET /api/search?q=: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty q, got %d", resp2.StatusCode)
+	}
+}
+
+func TestSearch_SimpleMode_ReturnsTitleMatches(t *testing.T) {
+	srv := newSearchSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/search?q=News")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result []struct {
+		Title   string `json:"title"`
+		Airings []struct {
+			ChannelID   string `json:"channelId"`
+			ChannelName string `json:"channelName"`
+		} `json:"airings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Simple mode: should match title only, future only
+	titles := map[string]bool{}
+	for _, g := range result {
+		titles[g.Title] = true
+	}
+	if titles["Documentary Special"] {
+		t.Error("simple search should not match description-only results")
+	}
+	if titles["Late Night News"] {
+		t.Error("simple search should not return past airings")
+	}
+	if !titles["Morning News"] {
+		t.Error("expected 'Morning News' in results")
+	}
+}
+
+func TestSearch_SimpleMode_GroupsByTitle(t *testing.T) {
+	srv := newSearchSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/search?q=News")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result []struct {
+		Title   string `json:"title"`
+		Airings []struct {
+			ChannelID string    `json:"channelId"`
+			StartTime time.Time `json:"startTime"`
+		} `json:"airings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// "Morning News" appears on ch1 and ch2 — should be grouped
+	for _, g := range result {
+		if g.Title == "Morning News" {
+			if len(g.Airings) < 2 {
+				t.Errorf("expected at least 2 airings for 'Morning News' group, got %d", len(g.Airings))
+			}
+			// Verify sorted by start time ascending
+			for i := 1; i < len(g.Airings); i++ {
+				if g.Airings[i].StartTime.Before(g.Airings[i-1].StartTime) {
+					t.Error("airings within group should be sorted by start time ascending")
+				}
+			}
+			return
+		}
+	}
+	t.Error("expected 'Morning News' group in results")
+}
+
+func TestSearch_SimpleMode_ChannelNamePopulated(t *testing.T) {
+	srv := newSearchSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/search?q=News")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result []struct {
+		Title   string `json:"title"`
+		Airings []struct {
+			ChannelName string `json:"channelName"`
+		} `json:"airings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	for _, g := range result {
+		for _, a := range g.Airings {
+			if a.ChannelName == "" {
+				t.Errorf("channelName should be populated for airing in group %q", g.Title)
+			}
+		}
+	}
+}
+
+func TestSearch_SimpleMode_ExcludesRepeats(t *testing.T) {
+	srv := newSearchSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/search?q=News&include_repeats=false")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result []struct {
+		Title   string `json:"title"`
+		Airings []struct {
+			IsRepeat bool `json:"isRepeat"`
+		} `json:"airings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, g := range result {
+		for _, a := range g.Airings {
+			if a.IsRepeat {
+				t.Errorf("include_repeats=false should exclude repeats in group %q", g.Title)
+			}
+		}
+	}
+}
+
+func TestSearch_AdvancedMode_MatchesDescription(t *testing.T) {
+	srv := newSearchSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/search?q=news&mode=advanced")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result []struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	titles := map[string]bool{}
+	for _, g := range result {
+		titles[g.Title] = true
+	}
+	if !titles["Documentary Special"] {
+		t.Error("advanced search should match 'Documentary Special' via subtitle/description")
+	}
+}
+
+func TestSearch_AdvancedMode_CategoryFilter(t *testing.T) {
+	srv := newSearchSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/search?q=news&mode=advanced&categories=Documentary")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result []struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	for _, g := range result {
+		if g.Title == "Morning News" {
+			t.Error("category filter should exclude 'Morning News' (not in Documentary category)")
+		}
+	}
+	titles := map[string]bool{}
+	for _, g := range result {
+		titles[g.Title] = true
+	}
+	if !titles["Documentary Special"] {
+		t.Error("expected 'Documentary Special' in filtered results")
+	}
+}
+
+func TestSearch_AdvancedMode_IncludePast(t *testing.T) {
+	srv := newSearchSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/search?q=News&mode=advanced&include_past=true")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result []struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	titles := map[string]bool{}
+	for _, g := range result {
+		titles[g.Title] = true
+	}
+	if !titles["Late Night News"] {
+		t.Error("include_past=true should include past airings like 'Late Night News'")
+	}
+}
+
+func TestSearch_ContentType(t *testing.T) {
+	srv := newSearchSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/search?q=News")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type: expected application/json, got %q", ct)
+	}
+}
+
+// --- Categories endpoint tests ---
+
+func TestCategories_ReturnsSortedList(t *testing.T) {
+	srv := newSearchSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/categories")
+	if err != nil {
+		t.Fatalf("GET /api/categories: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result []string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	expected := []string{"Documentary", "Entertainment", "News", "Sport"}
+	if len(result) != len(expected) {
+		t.Fatalf("expected %d categories, got %d: %v", len(expected), len(result), result)
+	}
+	for i, c := range result {
+		if c != expected[i] {
+			t.Errorf("category[%d]: expected %q, got %q", i, expected[i], c)
+		}
+	}
+}
+
+func TestCategories_EmptyWhenNoData(t *testing.T) {
+	dir := t.TempDir()
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	handler := api.New(db)
+	handler.RegisterRoutes(mux)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		srv.Close()
+		db.Close()
+	})
+
+	resp, err := http.Get(srv.URL + "/api/categories")
+	if err != nil {
+		t.Fatalf("GET /api/categories: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result []string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected 0 categories, got %d", len(result))
+	}
+}
+
+func TestCategories_ContentType(t *testing.T) {
+	srv := newSearchSeededServer(t)
+	resp, err := http.Get(srv.URL + "/api/categories")
+	if err != nil {
+		t.Fatalf("GET /api/categories: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type: expected application/json, got %q", ct)
+	}
+}
+
 func TestGetChannels_IconIsProxyURL(t *testing.T) {
 	iconSrv := startFakeIconServer(t)
 	srv, _ := newSeededServerWithIcons(t, iconSrv)

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -91,6 +91,13 @@ type Status struct {
 	SourceURL   string    `json:"sourceUrl"`
 }
 
+// SearchResult extends Airing with additional fields needed by the search API.
+type SearchResult struct {
+	Airing
+	ChannelName string  `json:"channelName"`
+	Rank        float64 `json:"-"`
+}
+
 // DB wraps a SQLite database connection.
 type DB struct {
 	db            *sql.DB
@@ -766,7 +773,7 @@ func (d *DB) ExecRaw(query string) (sql.Result, error) {
 // SearchSimple performs an FTS5 search on the title column only.
 // Returns future airings ordered by relevance then start time.
 // If includeRepeats is false, repeats are excluded.
-func (d *DB) SearchSimple(query string, includeRepeats bool) ([]Airing, error) {
+func (d *DB) SearchSimple(query string, includeRepeats bool) ([]SearchResult, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	q := `
 		SELECT
@@ -777,9 +784,11 @@ func (d *DB) SearchSimple(query string, includeRepeats bool) ([]Airing, error) {
 			COALESCE(a.prog_id, ''), COALESCE(a.star_rating, ''),
 			COALESCE(a.content_rating, ''), COALESCE(a.year, ''),
 			COALESCE(a.icon, ''), COALESCE(a.country, ''),
-			a.is_repeat, a.is_premiere
+			a.is_repeat, a.is_premiere,
+			c.display_name, f.rank
 		FROM airings_fts f
 		JOIN airings a ON a.channel_id = f.channel_id AND a.start_time = f.start_time
+		JOIN channels c ON c.id = a.channel_id
 		WHERE f.title MATCH ?
 		  AND a.start_time > ?`
 	args := []any{query, now}
@@ -789,14 +798,14 @@ func (d *DB) SearchSimple(query string, includeRepeats bool) ([]Airing, error) {
 	}
 	q += ` ORDER BY f.rank, a.start_time`
 
-	return d.scanAirings(q, args...)
+	return d.scanSearchResults(q, args...)
 }
 
 // SearchAdvanced performs an FTS5 search on title, sub_title, and description.
 // If categories is non-empty, only airings with at least one matching category are returned.
 // If includePast is false, only future airings are returned.
 // If includeRepeats is false, repeats are excluded.
-func (d *DB) SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool) ([]Airing, error) {
+func (d *DB) SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool) ([]SearchResult, error) {
 	q := `
 		SELECT
 			a.channel_id, a.start_time, a.stop_time,
@@ -806,9 +815,11 @@ func (d *DB) SearchAdvanced(query string, categories []string, includePast bool,
 			COALESCE(a.prog_id, ''), COALESCE(a.star_rating, ''),
 			COALESCE(a.content_rating, ''), COALESCE(a.year, ''),
 			COALESCE(a.icon, ''), COALESCE(a.country, ''),
-			a.is_repeat, a.is_premiere
+			a.is_repeat, a.is_premiere,
+			c.display_name, f.rank
 		FROM airings_fts f
 		JOIN airings a ON a.channel_id = f.channel_id AND a.start_time = f.start_time
+		JOIN channels c ON c.id = a.channel_id
 		WHERE airings_fts MATCH ?`
 	args := []any{query}
 
@@ -830,7 +841,7 @@ func (d *DB) SearchAdvanced(query string, categories []string, includePast bool,
 	}
 	q += ` ORDER BY f.rank, a.start_time`
 
-	return d.scanAirings(q, args...)
+	return d.scanSearchResults(q, args...)
 }
 
 // GetCategories returns all distinct categories sorted alphabetically.
@@ -850,6 +861,43 @@ func (d *DB) GetCategories() ([]string, error) {
 		cats = append(cats, name)
 	}
 	return cats, rows.Err()
+}
+
+// scanSearchResults executes a query and scans results into SearchResult slices.
+// The query must select the standard airing columns plus display_name and rank.
+func (d *DB) scanSearchResults(query string, args ...any) ([]SearchResult, error) {
+	rows, err := d.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying search results: %w", err)
+	}
+	defer rows.Close()
+
+	var results []SearchResult
+	for rows.Next() {
+		var sr SearchResult
+		var startStr, stopStr, catsJSON string
+		var isRepeat, isPremiere int
+
+		if err := rows.Scan(
+			&sr.ChannelID, &startStr, &stopStr,
+			&sr.Title, &sr.SubTitle, &sr.Description, &catsJSON,
+			&sr.EpisodeNum, &sr.EpisodeNumDisplay, &sr.ProgID,
+			&sr.StarRating, &sr.ContentRating, &sr.Year, &sr.Icon, &sr.Country,
+			&isRepeat, &isPremiere,
+			&sr.ChannelName, &sr.Rank,
+		); err != nil {
+			return nil, fmt.Errorf("scanning search result: %w", err)
+		}
+
+		sr.Start, _ = time.Parse(time.RFC3339, startStr)
+		sr.Stop, _ = time.Parse(time.RFC3339, stopStr)
+		json.Unmarshal([]byte(catsJSON), &sr.Categories)
+		sr.IsRepeat = isRepeat == 1
+		sr.IsPremiere = isPremiere == 1
+
+		results = append(results, sr)
+	}
+	return results, rows.Err()
 }
 
 // scanAirings executes a query and scans results into Airing slices.


### PR DESCRIPTION
## Summary
- Adds `GET /api/search` endpoint with simple (title-only) and advanced (full-text + categories + past/repeats filters) modes, returning results grouped by title with channel names
- Adds `GET /api/categories` endpoint returning a sorted list of all distinct categories
- Updates DB `SearchSimple`/`SearchAdvanced` to JOIN channels table and return `SearchResult` (with `ChannelName` and `Rank`) for handler-level grouping and relevance sorting

Closes #30

## Test plan
- [x] Handler tests: missing query returns 400, simple mode matches titles only, groups by title, populates channelName, excludes repeats, advanced mode matches description, category filter, include_past
- [x] Integration tests: end-to-end search, categories, missing query
- [x] Existing DB and API tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)