### PR TITLE
Add search UI page with advanced filters (#31)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ The app uses a bottom navigation bar (iOS-style) with four tabs:
 | Tab | Route | Description |
 |---|---|---|
 | Guide | `/` or `/guide` | The main TV guide grid (default) |
-| Search | `/search` | Placeholder — search coming soon |
+| Search | `/search` | Search for programmes by title or with advanced filters |
 | Favourites | `/favourites` | Placeholder — favourites coming soon |
 | Settings | `/settings` | Channel visibility and favourite toggles |
 
@@ -192,7 +192,6 @@ After completing any change, verify that CLAUDE.md (and any other relevant docs)
 
 These were discussed and intentionally excluded from the MVP:
 
-- **Search** — The `/search` tab is a placeholder. Future: search for programmes by title.
 - **Favourite shows** — The `/favourites` tab is a placeholder. Future: track specific show titles and surface when they are scheduled.
 - **Programmes table** — Split airings into a `programmes` table (one row per show) and an `airings` table (one row per broadcast). Deferred because XMLTV lacks a stable universal programme ID; the `prog_id` column (dd_progid) is the future deduplication key when available.
 - **HDHomeRun integration** — Use the device's `http://[ip]/lineup.json` for channel data instead of XMLTV.

--- a/integration_test.go
+++ b/integration_test.go
@@ -689,6 +689,116 @@ func TestIntegration_SPAFallback_SettingsReturnsHTML(t *testing.T) {
 	}
 }
 
+// TestIntegration_SearchPage_HTMLElements verifies that the search page
+// contains the required UI elements (input, advanced options, results container).
+func TestIntegration_SearchPage_HTMLElements(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/search")
+	if err != nil {
+		t.Fatalf("GET /search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var buf strings.Builder
+	io.Copy(&buf, resp.Body) //nolint:errcheck
+	body := buf.String()
+
+	// Search input
+	if !strings.Contains(body, `id="searchInput"`) {
+		t.Error("expected search input with id='searchInput'")
+	}
+	if !strings.Contains(body, `Search programmes`) {
+		t.Error("expected placeholder text 'Search programmes...'")
+	}
+
+	// Clear button
+	if !strings.Contains(body, `id="searchClear"`) {
+		t.Error("expected clear button with id='searchClear'")
+	}
+
+	// Advanced options toggle
+	if !strings.Contains(body, `id="advancedToggle"`) {
+		t.Error("expected advanced toggle with id='advancedToggle'")
+	}
+
+	// Advanced options panel
+	if !strings.Contains(body, `id="advancedOptions"`) {
+		t.Error("expected advanced options panel with id='advancedOptions'")
+	}
+
+	// Checkboxes
+	if !strings.Contains(body, `id="searchDescriptions"`) {
+		t.Error("expected 'Search descriptions' checkbox")
+	}
+	if !strings.Contains(body, `id="includePast"`) {
+		t.Error("expected 'Include past airings' checkbox")
+	}
+	if !strings.Contains(body, `id="hideRepeats"`) {
+		t.Error("expected 'Hide repeats' checkbox")
+	}
+
+	// Category chips container
+	if !strings.Contains(body, `id="categoryChips"`) {
+		t.Error("expected category chips container")
+	}
+
+	// Results container
+	if !strings.Contains(body, `id="searchResults"`) {
+		t.Error("expected search results container")
+	}
+
+	// Search hint
+	if !strings.Contains(body, `id="searchHint"`) {
+		t.Error("expected search hint element")
+	}
+}
+
+// TestIntegration_SearchPage_JSFunctions verifies that app.js contains
+// the functions required for the search UI.
+func TestIntegration_SearchPage_JSFunctions(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/app.js")
+	if err != nil {
+		t.Fatalf("GET /app.js: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var buf strings.Builder
+	io.Copy(&buf, resp.Body) //nolint:errcheck
+	body := buf.String()
+
+	for _, fn := range []string{
+		"performSearch",
+		"fetchCategories",
+		"renderSearchResults",
+		"formatSearchDate",
+	} {
+		if !strings.Contains(body, fn) {
+			t.Errorf("expected app.js to define %s", fn)
+		}
+	}
+
+	// Verify state additions
+	if !strings.Contains(body, "state.categories") {
+		t.Error("expected state.categories in app.js")
+	}
+	if !strings.Contains(body, "state.searchResults") {
+		t.Error("expected state.searchResults in app.js")
+	}
+}
+
 // TestIntegration_SPAFallback_APINotCaught verifies that /api/channels
 // still returns JSON and is not caught by the SPA fallback.
 func TestIntegration_SPAFallback_APINotCaught(t *testing.T) {

--- a/web/app.js
+++ b/web/app.js
@@ -23,6 +23,10 @@ const state = {
     prefs:       loadPrefs(),
     activePage:  'guide',           // current page: guide | search | favourites | settings
     nowLineTimer: null,             // interval ID for the now-line updater
+    categories:    [],              // cached from /api/categories
+    searchResults: [],              // current search results
+    searchDebounce: null,           // debounce timer ID
+    selectedCategories: new Set(),  // currently selected category filters
 };
 
 // ── Preferences (localStorage) ───────────────────────────────────────────────
@@ -101,6 +105,13 @@ function navigateToPage(page, { pushState = true } = {}) {
     // Render settings when switching to that page
     if (page === 'settings') {
         renderSettingsPanel();
+    }
+
+    // Load categories when entering search page
+    if (page === 'search') {
+        fetchCategories().then(renderCategoryChips).catch(err => {
+            console.error('Failed to load categories:', err);
+        });
     }
 }
 
@@ -555,6 +566,238 @@ function closeModal() {
     document.getElementById('modalBackdrop').classList.remove('open');
 }
 
+// ── Search ───────────────────────────────────────────────────────────────────
+
+async function fetchCategories() {
+    if (state.categories.length > 0) return state.categories;
+    const res = await fetch('/api/categories');
+    if (!res.ok) throw new Error(`/api/categories returned ${res.status}`);
+    state.categories = await res.json();
+    return state.categories;
+}
+
+async function performSearch() {
+    const input = document.getElementById('searchInput');
+    const q = input.value.trim();
+
+    if (q.length < 2) {
+        state.searchResults = [];
+        document.getElementById('searchResults').innerHTML = '';
+        document.getElementById('searchHint').style.display = q.length > 0 ? '' : '';
+        document.getElementById('searchHint').textContent = 'Enter at least 2 characters to search';
+        return;
+    }
+
+    document.getElementById('searchHint').style.display = 'none';
+    document.getElementById('searchSpinner').classList.add('visible');
+
+    const params = new URLSearchParams({ q });
+    const useAdvanced = document.getElementById('searchDescriptions').checked;
+    const includePast = document.getElementById('includePast').checked;
+    const hideRepeats = document.getElementById('hideRepeats').checked;
+
+    if (useAdvanced) {
+        params.set('mode', 'advanced');
+    }
+    if (includePast) {
+        params.set('include_past', 'true');
+    }
+    if (hideRepeats) {
+        params.set('include_repeats', 'false');
+    }
+    if (state.selectedCategories.size > 0) {
+        // Category filtering requires advanced mode
+        params.set('mode', 'advanced');
+        params.set('categories', [...state.selectedCategories].join(','));
+        if (!includePast) params.delete('include_past');
+    }
+
+    try {
+        const res = await fetch('/api/search?' + params);
+        if (!res.ok) throw new Error(`/api/search returned ${res.status}`);
+        state.searchResults = await res.json();
+        renderSearchResults();
+    } catch (err) {
+        console.error('Search failed:', err);
+        document.getElementById('searchResults').innerHTML =
+            '<div class="search-empty">Search failed. Please try again.</div>';
+    } finally {
+        document.getElementById('searchSpinner').classList.remove('visible');
+    }
+}
+
+function triggerSearch() {
+    clearTimeout(state.searchDebounce);
+    state.searchDebounce = setTimeout(performSearch, 300);
+}
+
+function renderSearchResults() {
+    const container = document.getElementById('searchResults');
+    container.innerHTML = '';
+
+    // Build a channel name lookup from state.channels
+    const channelMap = {};
+    for (const ch of state.channels) {
+        channelMap[ch.id] = ch;
+    }
+
+    // Filter out hidden channels
+    const filtered = [];
+    for (const group of state.searchResults) {
+        const visibleAirings = group.airings.filter(a => !isHidden(a.channelId));
+        if (visibleAirings.length > 0) {
+            filtered.push({ title: group.title, airings: visibleAirings });
+        }
+    }
+
+    if (filtered.length === 0) {
+        container.innerHTML = '<div class="search-empty">No programmes found</div>';
+        return;
+    }
+
+    for (const group of filtered) {
+        const groupEl = document.createElement('div');
+        groupEl.className = 'search-group';
+
+        // Title heading with favourite star
+        const header = document.createElement('div');
+        header.className = 'search-group-header';
+
+        const titleEl = document.createElement('h3');
+        titleEl.className = 'search-group-title';
+        titleEl.textContent = group.title;
+        header.appendChild(titleEl);
+
+        const starBtn = document.createElement('button');
+        starBtn.className = 'search-fav-btn';
+        starBtn.textContent = '\u2606'; // ☆
+        starBtn.title = 'Save as favourite';
+        header.appendChild(starBtn);
+
+        groupEl.appendChild(header);
+
+        // Airings list
+        for (const airing of group.airings) {
+            const airingEl = document.createElement('div');
+            airingEl.className = 'search-airing';
+            airingEl.addEventListener('click', () => openSearchAiringModal(airing, group.title));
+
+            const channelEl = document.createElement('span');
+            channelEl.className = 'search-airing-channel';
+            channelEl.textContent = airing.channelName || airing.channelId;
+            airingEl.appendChild(channelEl);
+
+            const timeEl = document.createElement('span');
+            timeEl.className = 'search-airing-time';
+            timeEl.textContent = formatSearchDate(new Date(airing.startTime));
+            airingEl.appendChild(timeEl);
+
+            if (airing.episodeNumDisplay || airing.subTitle) {
+                const epEl = document.createElement('span');
+                epEl.className = 'search-airing-episode';
+                const parts = [];
+                if (airing.episodeNumDisplay) parts.push(airing.episodeNumDisplay);
+                if (airing.subTitle) parts.push(airing.subTitle);
+                epEl.textContent = parts.join(' - ');
+                airingEl.appendChild(epEl);
+            }
+
+            groupEl.appendChild(airingEl);
+        }
+
+        container.appendChild(groupEl);
+    }
+}
+
+function openSearchAiringModal(airing, title) {
+    // Adapt the search airing shape to the programme shape used by openProgrammeModal
+    const prog = {
+        title:             title,
+        start:             airing.startTime,
+        stop:              airing.stopTime,
+        subTitle:          airing.subTitle,
+        description:       airing.description,
+        categories:        airing.categories,
+        episodeNumDisplay: airing.episodeNumDisplay,
+        isRepeat:          airing.isRepeat,
+        isPremiere:        airing.isPremiere,
+    };
+    openProgrammeModal(prog);
+}
+
+function formatSearchDate(date) {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const weekAhead = new Date(today);
+    weekAhead.setDate(weekAhead.getDate() + 7);
+
+    const dateOnly = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    const time = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true });
+
+    if (dateOnly.getTime() === today.getTime()) {
+        return 'Today ' + time;
+    }
+    if (dateOnly.getTime() === tomorrow.getTime()) {
+        return 'Tomorrow ' + time;
+    }
+    if (dateOnly < weekAhead) {
+        return date.toLocaleDateString([], { weekday: 'short' }) + ' ' + time;
+    }
+    return date.toLocaleDateString([], { weekday: 'short', day: 'numeric', month: 'short' }) + ' ' + time;
+}
+
+function renderCategoryChips() {
+    const container = document.getElementById('categoryChips');
+    container.innerHTML = '';
+    for (const cat of state.categories) {
+        const chip = document.createElement('button');
+        chip.className = 'category-chip' + (state.selectedCategories.has(cat) ? ' selected' : '');
+        chip.textContent = cat;
+        chip.addEventListener('click', () => {
+            if (state.selectedCategories.has(cat)) {
+                state.selectedCategories.delete(cat);
+            } else {
+                state.selectedCategories.add(cat);
+            }
+            chip.classList.toggle('selected');
+            triggerSearch();
+        });
+        container.appendChild(chip);
+    }
+}
+
+function setupSearchPage() {
+    const input = document.getElementById('searchInput');
+    const clearBtn = document.getElementById('searchClear');
+    const advToggle = document.getElementById('advancedToggle');
+    const advPanel = document.getElementById('advancedOptions');
+
+    input.addEventListener('input', triggerSearch);
+
+    clearBtn.addEventListener('click', () => {
+        input.value = '';
+        state.searchResults = [];
+        state.selectedCategories.clear();
+        document.getElementById('searchResults').innerHTML = '';
+        document.getElementById('searchHint').style.display = '';
+        document.getElementById('searchHint').textContent = 'Enter at least 2 characters to search';
+        renderCategoryChips();
+    });
+
+    advToggle.addEventListener('click', () => {
+        const isOpen = advPanel.style.display !== 'none';
+        advPanel.style.display = isOpen ? 'none' : '';
+        advToggle.classList.toggle('open', !isOpen);
+    });
+
+    // Checkboxes re-trigger search
+    document.getElementById('searchDescriptions').addEventListener('change', triggerSearch);
+    document.getElementById('includePast').addEventListener('change', triggerSearch);
+    document.getElementById('hideRepeats').addEventListener('change', triggerSearch);
+}
+
 // ── Initialisation ────────────────────────────────────────────────────────────
 
 async function init() {
@@ -567,6 +810,7 @@ async function init() {
     // Render static parts that don't depend on data
     renderTimeAxis();
     setupScrollSync();
+    setupSearchPage();
 
     document.getElementById('dateDisplay').textContent = formatDateLong(state.currentDate);
 

--- a/web/index.html
+++ b/web/index.html
@@ -62,11 +62,28 @@
         </div>
     </div>
 
-    <!-- Page: Search (placeholder) -->
+    <!-- Page: Search -->
     <div class="page" id="page-search" style="display:none">
-        <div class="page-content">
-            <h1>Search</h1>
-            <p class="page-placeholder">Search coming soon.</p>
+        <div class="page-content search-page">
+            <div class="search-input-wrap">
+                <input type="text" id="searchInput" placeholder="Search programmes..." autocomplete="off" autocorrect="off" spellcheck="false">
+                <button class="search-clear-btn" id="searchClear" title="Clear search">&#10005;</button>
+                <div class="search-spinner" id="searchSpinner"></div>
+            </div>
+
+            <button class="advanced-toggle" id="advancedToggle">Advanced options</button>
+            <div class="advanced-options" id="advancedOptions" style="display:none">
+                <label class="search-checkbox"><input type="checkbox" id="searchDescriptions"> Search descriptions</label>
+                <label class="search-checkbox"><input type="checkbox" id="includePast"> Include past airings</label>
+                <label class="search-checkbox"><input type="checkbox" id="hideRepeats"> Hide repeats</label>
+                <div class="category-chips-wrap">
+                    <div class="category-chips-label">Categories</div>
+                    <div class="category-chips" id="categoryChips"></div>
+                </div>
+            </div>
+
+            <div class="search-hint" id="searchHint">Enter at least 2 characters to search</div>
+            <div class="search-results" id="searchResults"></div>
         </div>
     </div>
 

--- a/web/style.css
+++ b/web/style.css
@@ -583,6 +583,245 @@ body {
     color: var(--text-secondary);
 }
 
+/* ── Search page ─────────────────────────────────────────────── */
+
+.search-page {
+    display: flex;
+    flex-direction: column;
+}
+
+.search-input-wrap {
+    position: relative;
+    margin-bottom: 8px;
+}
+
+.search-input-wrap input {
+    width: 100%;
+    padding: 10px 36px 10px 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-size: 15px;
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+.search-input-wrap input:focus {
+    border-color: var(--text-secondary);
+}
+
+.search-input-wrap input::placeholder {
+    color: var(--text-muted);
+}
+
+.search-clear-btn {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 14px;
+    padding: 4px;
+    line-height: 1;
+    border-radius: 4px;
+}
+
+.search-clear-btn:hover {
+    color: var(--text-primary);
+}
+
+.search-spinner {
+    display: none;
+    position: absolute;
+    right: 32px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--border);
+    border-top-color: var(--text-secondary);
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+}
+
+.search-spinner.visible {
+    display: block;
+}
+
+.advanced-toggle {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 13px;
+    padding: 6px 0;
+    text-align: left;
+    transition: color 0.15s;
+}
+
+.advanced-toggle::before {
+    content: '\25B6';
+    display: inline-block;
+    margin-right: 6px;
+    font-size: 10px;
+    transition: transform 0.15s;
+}
+
+.advanced-toggle.open::before {
+    transform: rotate(90deg);
+}
+
+.advanced-toggle:hover {
+    color: var(--text-primary);
+}
+
+.advanced-options {
+    padding: 10px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.search-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.search-checkbox input[type="checkbox"] {
+    accent-color: var(--bg-prog-hover);
+}
+
+.category-chips-wrap {
+    margin-top: 4px;
+}
+
+.category-chips-label {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+}
+
+.category-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.category-chip {
+    font-size: 12px;
+    padding: 4px 10px;
+    border-radius: 14px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.category-chip:hover {
+    border-color: var(--text-secondary);
+}
+
+.category-chip.selected {
+    background: var(--bg-programme);
+    border-color: var(--bg-prog-hover);
+    color: var(--text-primary);
+}
+
+.search-hint {
+    font-size: 13px;
+    color: var(--text-muted);
+    padding: 20px 0;
+    text-align: center;
+}
+
+.search-empty {
+    font-size: 14px;
+    color: var(--text-secondary);
+    padding: 20px 0;
+    text-align: center;
+}
+
+.search-results {
+    flex: 1;
+}
+
+.search-group {
+    margin-bottom: 16px;
+}
+
+.search-group-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 0 4px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 4px;
+}
+
+.search-group-title {
+    font-size: 15px;
+    font-weight: 600;
+    flex: 1;
+}
+
+.search-fav-btn {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 18px;
+    padding: 2px 4px;
+    line-height: 1;
+    transition: color 0.15s;
+}
+
+.search-fav-btn:hover {
+    color: var(--accent-fav);
+}
+
+.search-airing {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 10px;
+    padding: 8px 6px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.12s;
+}
+
+.search-airing:hover {
+    background: var(--bg-card);
+}
+
+.search-airing-channel {
+    font-size: 13px;
+    color: var(--text-primary);
+    font-weight: 500;
+    min-width: 100px;
+}
+
+.search-airing-time {
+    font-size: 13px;
+    color: var(--text-secondary);
+    min-width: 120px;
+}
+
+.search-airing-episode {
+    font-size: 12px;
+    color: var(--text-muted);
+    width: 100%;
+}
+
 /* ── Loading screen ───────────────────────────────────────────── */
 
 .loading-screen {


### PR DESCRIPTION
## Summary
- Replaces the search placeholder with a full search page: debounced text input, simple/advanced mode toggle, category chip filters, and results grouped by title
- Results display channel name, relative date/time, and episode info; tapping opens the programme detail modal
- Hidden channels are filtered client-side; star button rendered but non-functional (wired up in #32)

Closes #31

## Test plan
- [ ] Verify search input triggers after 300ms debounce with 2+ characters
- [ ] Verify simple mode searches title only, advanced mode includes descriptions
- [ ] Verify advanced options (include past, hide repeats, category chips) work
- [ ] Verify results are grouped by title and hidden channels are excluded
- [ ] Verify tapping an airing opens the programme detail modal
- [ ] Verify relative date formatting (Today, Tomorrow, day name, full date)
- [ ] Verify all existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)