### PR TITLE
Add favourite searches feature (#32)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,34 @@ Stored client-side in `localStorage` under the key `tvguide-prefs`:
 
 Favourites appear at the top of the guide. The remaining visible channels are sorted by `lcn` (logical channel number) when present; channels without an `lcn` fall back to source order. Hidden channels are excluded from the guide view entirely. Both are managed via the Settings tab (bottom navigation).
 
+## Favourite searches
+
+Saved search queries stored client-side in `localStorage` under the key `tvguide-favourites`:
+
+```json
+[
+  {
+    "id": "uuid",
+    "name": "The Block",
+    "query": "The Block",
+    "mode": "simple"
+  },
+  {
+    "id": "uuid",
+    "name": "Cricket",
+    "query": "Cricket",
+    "mode": "advanced",
+    "categories": ["Sport"],
+    "includePast": true,
+    "includeRepeats": false
+  }
+]
+```
+
+Favourites are **saved searches**, not individual show titles. Each favourite stores the full search configuration (query, mode, categories, etc.). On the Favourites page, all saved searches are executed in parallel via `/api/search` (always with `include_past=false`). Results are grouped by favourite → title → airings. Results are cached in memory for 5 minutes.
+
+The star button on Search result groups saves/removes the current search query as a favourite. A filled star (★) indicates the current query matches an existing favourite.
+
 ## Frontend navigation
 
 The app uses a bottom navigation bar (iOS-style) with four tabs:
@@ -139,7 +167,7 @@ The app uses a bottom navigation bar (iOS-style) with four tabs:
 |---|---|---|
 | Guide | `/` or `/guide` | The main TV guide grid (default) |
 | Search | `/search` | Search for programmes by title or with advanced filters |
-| Favourites | `/favourites` | Placeholder — favourites coming soon |
+| Favourites | `/favourites` | Saved search favourites — shows upcoming airings for all saved searches |
 | Settings | `/settings` | Channel visibility and favourite toggles |
 
 Navigation uses the **History API** (`pushState`/`popstate`) for client-side routing without full page reloads. The top bar (date display + prev/next day buttons) is only visible on the Guide tab. The Guide tab preserves its `?date=YYYY-MM-DD` query parameter behaviour.
@@ -192,7 +220,6 @@ After completing any change, verify that CLAUDE.md (and any other relevant docs)
 
 These were discussed and intentionally excluded from the MVP:
 
-- **Favourite shows** — The `/favourites` tab is a placeholder. Future: track specific show titles and surface when they are scheduled.
 - **Programmes table** — Split airings into a `programmes` table (one row per show) and an `airings` table (one row per broadcast). Deferred because XMLTV lacks a stable universal programme ID; the `prog_id` column (dd_progid) is the future deduplication key when available.
 - **HDHomeRun integration** — Use the device's `http://[ip]/lineup.json` for channel data instead of XMLTV.
 - **Notifications** — Alert when a tracked show is about to start.

--- a/integration_test.go
+++ b/integration_test.go
@@ -846,6 +846,100 @@ func TestIntegration_SPAFallback_StaticFileNotCaught(t *testing.T) {
 	}
 }
 
+// TestIntegration_FavouritesPage_HTMLElements verifies that the favourites page
+// contains the required UI elements for the saved-search favourites feature.
+func TestIntegration_FavouritesPage_HTMLElements(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/favourites")
+	if err != nil {
+		t.Fatalf("GET /favourites: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var buf strings.Builder
+	io.Copy(&buf, resp.Body) //nolint:errcheck
+	body := buf.String()
+
+	// Favourites page container
+	if !strings.Contains(body, `id="page-favourites"`) {
+		t.Error("expected favourites page with id='page-favourites'")
+	}
+
+	// Favourites list container (where results are rendered)
+	if !strings.Contains(body, `id="favouritesList"`) {
+		t.Error("expected favourites list container with id='favouritesList'")
+	}
+
+	// Loading spinner for favourites
+	if !strings.Contains(body, `id="favouritesLoading"`) {
+		t.Error("expected favourites loading indicator with id='favouritesLoading'")
+	}
+
+	// Empty state message
+	if !strings.Contains(body, `id="favouritesEmpty"`) {
+		t.Error("expected favourites empty state with id='favouritesEmpty'")
+	}
+
+	// Should NOT contain the old placeholder text
+	if strings.Contains(body, "Favourites coming soon") {
+		t.Error("expected old placeholder 'Favourites coming soon' to be removed")
+	}
+}
+
+// TestIntegration_FavouritesPage_JSFunctions verifies that app.js contains
+// the functions required for the favourites feature.
+func TestIntegration_FavouritesPage_JSFunctions(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	resp, err := http.Get(srv.URL + "/app.js")
+	if err != nil {
+		t.Fatalf("GET /app.js: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var buf strings.Builder
+	io.Copy(&buf, resp.Body) //nolint:errcheck
+	body := buf.String()
+
+	for _, fn := range []string{
+		"loadFavouriteSearches",
+		"saveFavouriteSearches",
+		"addFavouriteSearch",
+		"removeFavouriteSearch",
+		"renderFavouritesPage",
+		"executeFavouriteSearches",
+		"editFavouriteSearch",
+	} {
+		if !strings.Contains(body, fn) {
+			t.Errorf("expected app.js to define %s", fn)
+		}
+	}
+
+	// Verify state additions
+	if !strings.Contains(body, "state.favouriteSearches") {
+		t.Error("expected state.favouriteSearches in app.js")
+	}
+	if !strings.Contains(body, "state.favouriteResults") {
+		t.Error("expected state.favouriteResults in app.js")
+	}
+
+	// Verify localStorage key
+	if !strings.Contains(body, "tvguide-favourites") {
+		t.Error("expected 'tvguide-favourites' localStorage key in app.js")
+	}
+}
+
 // TestIntegration_SPAFallback_GuidePathReturnsHTML verifies that GET /guide
 // returns index.html content (SPA fallback).
 func TestIntegration_SPAFallback_GuidePathReturnsHTML(t *testing.T) {

--- a/web/app.js
+++ b/web/app.js
@@ -27,6 +27,9 @@ const state = {
     searchResults: [],              // current search results
     searchDebounce: null,           // debounce timer ID
     selectedCategories: new Set(),  // currently selected category filters
+    favouriteSearches: loadFavouriteSearches(),  // saved search favourites from localStorage
+    favouriteResults: {},           // map of favourite ID → search results
+    favouriteResultsTime: 0,       // timestamp when favourites were last fetched
 };
 
 // ── Preferences (localStorage) ───────────────────────────────────────────────
@@ -59,6 +62,111 @@ function toggleFavourite(channelId) {
     savePrefs();
     renderGuide();
     renderSettingsPanel();
+}
+
+// ── Favourite searches (localStorage) ────────────────────────────────────────
+
+function loadFavouriteSearches() {
+    try {
+        const raw = localStorage.getItem('tvguide-favourites');
+        return raw ? JSON.parse(raw) : [];
+    } catch {
+        return [];
+    }
+}
+
+function saveFavouriteSearches() {
+    localStorage.setItem('tvguide-favourites', JSON.stringify(state.favouriteSearches));
+}
+
+function addFavouriteSearch(searchConfig) {
+    const fav = {
+        id: crypto.randomUUID(),
+        name: searchConfig.query,
+        query: searchConfig.query,
+        mode: searchConfig.mode || 'simple',
+    };
+    if (fav.mode === 'advanced') {
+        if (searchConfig.categories && searchConfig.categories.length > 0) {
+            fav.categories = searchConfig.categories;
+        }
+        if (searchConfig.includePast) fav.includePast = true;
+        if (searchConfig.includeRepeats === false) fav.includeRepeats = false;
+    }
+    state.favouriteSearches.push(fav);
+    saveFavouriteSearches();
+    return fav;
+}
+
+function removeFavouriteSearch(id) {
+    state.favouriteSearches = state.favouriteSearches.filter(f => f.id !== id);
+    delete state.favouriteResults[id];
+    saveFavouriteSearches();
+}
+
+function findMatchingFavourite(query, mode, categories) {
+    return state.favouriteSearches.find(f => {
+        if (f.query !== query) return false;
+        if (f.mode !== mode) return false;
+        if (mode === 'advanced') {
+            const favCats = (f.categories || []).slice().sort().join(',');
+            const curCats = (categories || []).slice().sort().join(',');
+            if (favCats !== curCats) return false;
+        }
+        return true;
+    });
+}
+
+function getCurrentSearchConfig() {
+    const q = document.getElementById('searchInput').value.trim();
+    const useAdvanced = document.getElementById('searchDescriptions').checked;
+    const includePast = document.getElementById('includePast').checked;
+    const hideRepeats = document.getElementById('hideRepeats').checked;
+    const categories = [...state.selectedCategories];
+
+    const hasAdvanced = useAdvanced || categories.length > 0;
+    return {
+        query: q,
+        mode: hasAdvanced ? 'advanced' : 'simple',
+        categories: categories,
+        includePast: includePast,
+        includeRepeats: !hideRepeats,
+    };
+}
+
+function editFavouriteSearch(id) {
+    const fav = state.favouriteSearches.find(f => f.id === id);
+    if (!fav) return;
+
+    // Navigate to search page
+    navigateToPage('search');
+
+    // Pre-fill search input
+    document.getElementById('searchInput').value = fav.query;
+
+    // Pre-fill advanced options
+    const isAdvanced = fav.mode === 'advanced';
+    document.getElementById('searchDescriptions').checked = isAdvanced;
+    document.getElementById('includePast').checked = fav.includePast || false;
+    document.getElementById('hideRepeats').checked = fav.includeRepeats === false;
+
+    // Pre-fill categories
+    state.selectedCategories.clear();
+    if (fav.categories) {
+        for (const cat of fav.categories) {
+            state.selectedCategories.add(cat);
+        }
+    }
+
+    // Show advanced panel if needed
+    if (isAdvanced || (fav.categories && fav.categories.length > 0)) {
+        document.getElementById('advancedOptions').style.display = '';
+        document.getElementById('advancedToggle').classList.add('open');
+    }
+
+    // Render category chips and trigger search
+    fetchCategories().then(renderCategoryChips).catch(() => {});
+    triggerSearch();
 }
 
 // ── Routing ──────────────────────────────────────────────────────────────────
@@ -112,6 +220,11 @@ function navigateToPage(page, { pushState = true } = {}) {
         fetchCategories().then(renderCategoryChips).catch(err => {
             console.error('Failed to load categories:', err);
         });
+    }
+
+    // Load favourites when entering favourites page
+    if (page === 'favourites') {
+        renderFavouritesPage();
     }
 }
 
@@ -670,8 +783,27 @@ function renderSearchResults() {
 
         const starBtn = document.createElement('button');
         starBtn.className = 'search-fav-btn';
-        starBtn.textContent = '\u2606'; // ☆
-        starBtn.title = 'Save as favourite';
+        const config = getCurrentSearchConfig();
+        const existingFav = findMatchingFavourite(config.query, config.mode, config.categories);
+        starBtn.textContent = existingFav ? '\u2605' : '\u2606'; // ★ or ☆
+        starBtn.classList.toggle('active', !!existingFav);
+        starBtn.title = existingFav ? 'Remove from favourites' : 'Save as favourite';
+        starBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const cfg = getCurrentSearchConfig();
+            const match = findMatchingFavourite(cfg.query, cfg.mode, cfg.categories);
+            if (match) {
+                removeFavouriteSearch(match.id);
+                starBtn.textContent = '\u2606';
+                starBtn.classList.remove('active');
+                starBtn.title = 'Save as favourite';
+            } else {
+                addFavouriteSearch(cfg);
+                starBtn.textContent = '\u2605';
+                starBtn.classList.add('active');
+                starBtn.title = 'Remove from favourites';
+            }
+        });
         header.appendChild(starBtn);
 
         groupEl.appendChild(header);
@@ -796,6 +928,189 @@ function setupSearchPage() {
     document.getElementById('searchDescriptions').addEventListener('change', triggerSearch);
     document.getElementById('includePast').addEventListener('change', triggerSearch);
     document.getElementById('hideRepeats').addEventListener('change', triggerSearch);
+}
+
+// ── Favourites page ─────────────────────────────────────────────────────────
+
+function renderFavouritesPage() {
+    const list = document.getElementById('favouritesList');
+    const loading = document.getElementById('favouritesLoading');
+    const empty = document.getElementById('favouritesEmpty');
+
+    list.innerHTML = '';
+
+    if (state.favouriteSearches.length === 0) {
+        loading.style.display = 'none';
+        empty.style.display = '';
+        return;
+    }
+
+    empty.style.display = 'none';
+
+    // If results are fresh (< 5 min), reuse them
+    const cacheAge = Date.now() - state.favouriteResultsTime;
+    if (cacheAge < 5 * 60 * 1000 && Object.keys(state.favouriteResults).length > 0) {
+        loading.style.display = 'none';
+        renderFavouriteResults();
+        return;
+    }
+
+    loading.style.display = '';
+    executeFavouriteSearches();
+}
+
+async function executeFavouriteSearches() {
+    const loading = document.getElementById('favouritesLoading');
+    state.favouriteResults = {};
+
+    const promises = state.favouriteSearches.map(async (fav) => {
+        const params = new URLSearchParams({ q: fav.query });
+        // Always exclude past on favourites page
+        if (fav.mode === 'advanced') {
+            params.set('mode', 'advanced');
+            if (fav.categories && fav.categories.length > 0) {
+                params.set('categories', fav.categories.join(','));
+            }
+        }
+        if (fav.includeRepeats === false) {
+            params.set('include_repeats', 'false');
+        }
+
+        try {
+            const res = await fetch('/api/search?' + params);
+            if (!res.ok) throw new Error(`/api/search returned ${res.status}`);
+            const results = await res.json();
+            state.favouriteResults[fav.id] = results;
+            // Progressive rendering: update after each result
+            renderFavouriteResults();
+        } catch (err) {
+            console.error(`Favourite search "${fav.name}" failed:`, err);
+            state.favouriteResults[fav.id] = null; // mark as failed
+        }
+    });
+
+    await Promise.all(promises);
+    state.favouriteResultsTime = Date.now();
+    loading.style.display = 'none';
+    renderFavouriteResults();
+}
+
+function renderFavouriteResults() {
+    const list = document.getElementById('favouritesList');
+    list.innerHTML = '';
+
+    const channelMap = {};
+    for (const ch of state.channels) {
+        channelMap[ch.id] = ch;
+    }
+
+    for (const fav of state.favouriteSearches) {
+        const groupEl = document.createElement('div');
+        groupEl.className = 'fav-group';
+
+        // Header: star + name + edit + delete
+        const header = document.createElement('div');
+        header.className = 'fav-group-header';
+
+        const star = document.createElement('span');
+        star.className = 'fav-group-star';
+        star.textContent = '\u2605'; // ★
+        header.appendChild(star);
+
+        const nameEl = document.createElement('span');
+        nameEl.className = 'fav-group-name';
+        nameEl.textContent = '"' + fav.name + '"';
+        header.appendChild(nameEl);
+
+        const actions = document.createElement('div');
+        actions.className = 'fav-group-actions';
+
+        const editBtn = document.createElement('button');
+        editBtn.className = 'fav-action-btn';
+        editBtn.textContent = 'Edit';
+        editBtn.title = 'Edit this search';
+        editBtn.addEventListener('click', () => editFavouriteSearch(fav.id));
+        actions.appendChild(editBtn);
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'fav-action-btn fav-delete-btn';
+        deleteBtn.textContent = '\u2715'; // ✕
+        deleteBtn.title = 'Remove favourite';
+        deleteBtn.addEventListener('click', () => {
+            if (confirm('Remove "' + fav.name + '" from favourites?')) {
+                removeFavouriteSearch(fav.id);
+                renderFavouritesPage();
+            }
+        });
+        actions.appendChild(deleteBtn);
+
+        header.appendChild(actions);
+        groupEl.appendChild(header);
+
+        // Results
+        const results = state.favouriteResults[fav.id];
+        if (results === undefined) {
+            // Still loading
+            const loadingEl = document.createElement('div');
+            loadingEl.className = 'fav-loading';
+            loadingEl.innerHTML = '<div class="loading-spinner fav-spinner"></div>';
+            groupEl.appendChild(loadingEl);
+        } else if (results === null) {
+            // Failed
+            const errorEl = document.createElement('div');
+            errorEl.className = 'fav-no-results';
+            errorEl.textContent = 'Search failed. Try again later.';
+            groupEl.appendChild(errorEl);
+        } else {
+            // Filter hidden channels
+            const filtered = [];
+            for (const group of results) {
+                const visibleAirings = group.airings.filter(a => !isHidden(a.channelId));
+                if (visibleAirings.length > 0) {
+                    filtered.push({ title: group.title, airings: visibleAirings });
+                }
+            }
+
+            if (filtered.length === 0) {
+                const noResults = document.createElement('div');
+                noResults.className = 'fav-no-results';
+                noResults.textContent = 'No upcoming airings';
+                groupEl.appendChild(noResults);
+            } else {
+                for (const titleGroup of filtered) {
+                    const titleEl = document.createElement('div');
+                    titleEl.className = 'fav-title-group';
+
+                    const titleHeader = document.createElement('div');
+                    titleHeader.className = 'fav-title-name';
+                    titleHeader.textContent = titleGroup.title;
+                    titleEl.appendChild(titleHeader);
+
+                    for (const airing of titleGroup.airings) {
+                        const airingEl = document.createElement('div');
+                        airingEl.className = 'fav-airing';
+                        airingEl.addEventListener('click', () => openSearchAiringModal(airing, titleGroup.title));
+
+                        const channelEl = document.createElement('span');
+                        channelEl.className = 'fav-airing-channel';
+                        channelEl.textContent = airing.channelName || airing.channelId;
+                        airingEl.appendChild(channelEl);
+
+                        const timeEl = document.createElement('span');
+                        timeEl.className = 'fav-airing-time';
+                        timeEl.textContent = formatSearchDate(new Date(airing.startTime));
+                        airingEl.appendChild(timeEl);
+
+                        titleEl.appendChild(airingEl);
+                    }
+
+                    groupEl.appendChild(titleEl);
+                }
+            }
+        }
+
+        list.appendChild(groupEl);
+    }
 }
 
 // ── Initialisation ────────────────────────────────────────────────────────────

--- a/web/index.html
+++ b/web/index.html
@@ -87,11 +87,17 @@
         </div>
     </div>
 
-    <!-- Page: Favourites (placeholder) -->
+    <!-- Page: Favourites -->
     <div class="page" id="page-favourites" style="display:none">
-        <div class="page-content">
+        <div class="page-content favourites-page">
             <h1>Favourites</h1>
-            <p class="page-placeholder">Favourites coming soon.</p>
+            <div class="favourites-loading" id="favouritesLoading">
+                <div class="loading-spinner"></div>
+            </div>
+            <div class="favourites-empty" id="favouritesEmpty" style="display:none">
+                No favourite searches saved. Use the Search tab to find shows and save them.
+            </div>
+            <div class="favourites-list" id="favouritesList"></div>
         </div>
     </div>
 

--- a/web/style.css
+++ b/web/style.css
@@ -822,6 +822,147 @@ body {
     width: 100%;
 }
 
+/* ── Favourites page ─────────────────────────────────────────── */
+
+.favourites-page {
+    display: flex;
+    flex-direction: column;
+}
+
+.favourites-loading {
+    display: flex;
+    justify-content: center;
+    padding: 30px 0;
+}
+
+.favourites-empty {
+    font-size: 14px;
+    color: var(--text-secondary);
+    padding: 20px 0;
+    text-align: center;
+    line-height: 1.5;
+}
+
+.fav-group {
+    margin-bottom: 20px;
+}
+
+.fav-group-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 0 6px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 4px;
+}
+
+.fav-group-star {
+    color: var(--accent-fav);
+    font-size: 16px;
+    flex-shrink: 0;
+}
+
+.fav-group-name {
+    font-size: 15px;
+    font-weight: 600;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.fav-group-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.fav-action-btn {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 12px;
+    padding: 3px 10px;
+    border-radius: 5px;
+    transition: color 0.15s, background 0.15s;
+}
+
+.fav-action-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-card);
+}
+
+.fav-delete-btn {
+    font-size: 13px;
+    padding: 3px 8px;
+}
+
+.fav-delete-btn:hover {
+    color: var(--accent-now);
+    border-color: var(--accent-now);
+}
+
+.fav-no-results {
+    font-size: 13px;
+    color: var(--text-muted);
+    padding: 10px 6px;
+    font-style: italic;
+}
+
+.fav-loading {
+    display: flex;
+    justify-content: center;
+    padding: 12px 0;
+}
+
+.fav-spinner {
+    width: 20px;
+    height: 20px;
+    border-width: 2px;
+}
+
+.fav-title-group {
+    margin-left: 4px;
+    margin-bottom: 8px;
+}
+
+.fav-title-name {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-primary);
+    padding: 6px 6px 2px;
+}
+
+.fav-airing {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 6px 6px 6px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.12s;
+}
+
+.fav-airing:hover {
+    background: var(--bg-card);
+}
+
+.fav-airing-channel {
+    font-size: 13px;
+    color: var(--text-secondary);
+    min-width: 80px;
+}
+
+.fav-airing-time {
+    font-size: 13px;
+    color: var(--text-muted);
+}
+
+.search-fav-btn.active {
+    color: var(--accent-fav);
+}
+
 /* ── Loading screen ───────────────────────────────────────────── */
 
 .loading-screen {


### PR DESCRIPTION
## Summary
- Add saved search favourites stored in `localStorage` under `tvguide-favourites`
- Star button on Search result groups saves/removes the current search query as a favourite (filled ★ when saved, empty ☆ when not)
- Favourites page executes all saved searches in parallel via `/api/search`, displays results grouped by favourite → title → airings with edit and delete actions
- Results cached in memory for 5 minutes to avoid re-fetching on tab switches
- Hidden channels filtered out client-side, empty states handled

## Test plan
- [x] Integration tests verify favourites page HTML elements exist (`favouritesList`, `favouritesLoading`, `favouritesEmpty`)
- [x] Integration tests verify all required JS functions are defined (`loadFavouriteSearches`, `saveFavouriteSearches`, `addFavouriteSearch`, `removeFavouriteSearch`, `renderFavouritesPage`, `executeFavouriteSearches`, `editFavouriteSearch`)
- [x] All 22 existing tests continue to pass
- [ ] Manual: save a search as favourite, verify star toggles to filled
- [ ] Manual: navigate to Favourites tab, verify saved search results appear
- [ ] Manual: edit button navigates to Search with pre-filled params
- [ ] Manual: delete button removes favourite after confirmation

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)