### PR TITLE
Fix bottom nav obscured by iOS home indicator

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="theme-color" content="#161b22">
     <title>TV Guide</title>
     <link rel="manifest" href="/manifest.json">

--- a/web/style.css
+++ b/web/style.css
@@ -123,7 +123,7 @@ body {
     flex: 1;
     overflow-y: auto;
     padding: 20px 16px;
-    padding-bottom: calc(20px + var(--bottom-nav-height));
+    padding-bottom: calc(20px + var(--bottom-nav-height) + env(safe-area-inset-bottom, 0));
 }
 
 .page-content h1 {


### PR DESCRIPTION
## Summary
- Add `viewport-fit=cover` to the viewport meta tag so `env(safe-area-inset-bottom)` returns non-zero values on iOS
- Include `env(safe-area-inset-bottom)` in `.page-content` padding so scrollable content isn't hidden behind the taller nav bar
- The `.bottom-nav` already had `padding-bottom: env(safe-area-inset-bottom, 0)` — it just needed the viewport-fit trigger to activate

Fixes #38

## Test plan
- [ ] Install as PWA on an iOS device with a home indicator (iPhone X or later)
- [ ] Verify bottom nav buttons are fully visible and tappable above the gesture area
- [ ] Verify scrollable content on Search, Favourites, and Settings pages scrolls fully past the nav bar
- [ ] Verify no visual regression on Android or desktop browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)