### PR TITLE
Fix iOS Safari auto-zoom on search input focus

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -602,7 +602,7 @@ body {
     border: 1px solid var(--border);
     border-radius: 8px;
     color: var(--text-primary);
-    font-size: 15px;
+    font-size: 16px;
     outline: none;
     transition: border-color 0.15s;
 }


### PR DESCRIPTION
## Summary
- Fixes #39 — iOS Safari auto-zooms the page when focusing the search input, pushing the bottom nav off-screen
- Root cause: search input had `font-size: 15px`; iOS Safari auto-zooms on any input below 16px
- Bumped font-size from 15px to 16px to prevent the zoom behaviour

## Test plan
- [ ] Open on iOS Safari, tap the search input — page should no longer zoom
- [ ] Bottom navigation remains visible with keyboard open
- [ ] Search input text size looks visually unchanged (1px difference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)