### PR TITLE
Fix PWA not loading updated assets after deployment

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,6 +155,14 @@ func spaHandler(fsys http.FileSystem) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Try to open the requested file. If it exists, serve it normally.
 		path := r.URL.Path
+
+		// Prevent the browser from caching the service worker script itself.
+		// The browser checks for byte-level changes on each SW update check;
+		// stale HTTP caching of sw.js defeats the entire versioning scheme.
+		if path == "/sw.js" {
+			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		}
+
 		if path == "/" {
 			fileServer.ServeHTTP(w, r)
 			return

--- a/web/app.js
+++ b/web/app.js
@@ -1203,7 +1203,21 @@ async function init() {
 // ── Service worker registration ───────────────────────────────────────────────
 
 if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/sw.js').catch(err => {
+    // Reload the page when a new service worker takes control, so users
+    // always see the latest assets without needing to force-quit the PWA.
+    let refreshing = false;
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (!refreshing) {
+            refreshing = true;
+            window.location.reload();
+        }
+    });
+
+    navigator.serviceWorker.register('/sw.js').then(reg => {
+        // Periodically check for SW updates (every 60s) so long-lived
+        // PWA sessions pick up new deployments promptly.
+        setInterval(() => reg.update(), 60 * 1000);
+    }).catch(err => {
         console.warn('Service worker registration failed:', err);
     });
 }


### PR DESCRIPTION
## Summary

Closes #38

The iOS bottom nav CSS fix from #45 was correctly implemented, but users were still seeing the old layout because the **service worker was serving stale cached assets**. The PWA required force-quitting and reloading to pick up new deployments.

- **Auto-reload on SW update**: Added `controllerchange` listener in `app.js` that reloads the page when a new service worker takes control
- **Periodic update checks**: The app now checks for new SW versions every 60 seconds, so long-lived PWA sessions detect deployments promptly
- **No-cache headers for `sw.js`**: Added `Cache-Control: no-cache, no-store, must-revalidate` on the `/sw.js` response so the browser always fetches the latest version

## Test plan

- [ ] Deploy new version and verify the PWA auto-reloads within ~60s without force-quitting
- [ ] Confirm the iOS bottom nav fix is now visible after the auto-reload
- [ ] Verify `sw.js` response has `Cache-Control: no-cache` header
- [ ] Check that normal static asset caching still works (cache-first for CSS/JS/HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)