### PR TITLE
Fix bottom nav bar not expanding for iOS safe area inset

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -360,7 +360,7 @@ body {
     bottom: 0;
     left: 0;
     right: 0;
-    height: var(--bottom-nav-height);
+    height: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0));
     background: var(--bg-secondary);
     border-top: 1px solid var(--border);
     display: flex;


### PR DESCRIPTION
## Summary
- Fixes the bottom navigation bar background not expanding to cover the iOS safe area inset, causing buttons to appear above the bar
- Changed `height` from a fixed value to `calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0))` so the bar grows to include the safe area padding

Closes #48

## Test plan
- [ ] On iOS PWA: verify bottom nav buttons are fully within the bar background
- [ ] On non-iOS: verify no visual change (safe-area-inset-bottom resolves to 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)