### PR TITLE
Add 'today' filter to search API (#56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ tvguide/
 | `GET /api/channels` | All channels in source order |
 | `GET /api/guide?date=YYYY-MM-DD` | Airings overlapping the given date (local TZ). Defaults to today. |
 | `GET /api/status` | Last refresh time, next refresh time, source URL |
-| `GET /api/search?q=...&mode=...` | Search airings. `q` (required): search text. `mode`: `simple` (title only, default) or `advanced` (title+subtitle+description). Advanced-only params: `categories` (comma-separated), `include_past` (bool, default false). Shared: `include_repeats` (bool, default true). Returns results grouped by title. |
+| `GET /api/search?q=...&mode=...` | Search airings. `q` (required): search text. `mode`: `simple` (title only, default) or `advanced` (title+subtitle+description). Advanced-only params: `categories` (comma-separated), `include_past` (bool, default false). Shared: `include_repeats` (bool, default true), `today` (bool, default false — when true, only returns airings starting before midnight tonight in the server's local timezone). Returns results grouped by title. |
 | `GET /api/categories` | Sorted JSON array of all distinct category strings |
 | `GET /images/channel/{channel-id}` | Cached channel logo. Re-downloads from upstream if the local file is missing. Returns 404 if the channel has no icon. |
 | `GET /` | Serves the embedded frontend (SPA shell) |

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -21,8 +21,8 @@ type store interface {
 	GetAirings(date time.Time) ([]database.Airing, error)
 	GetStatus() database.Status
 	EnsureChannelIcon(ctx context.Context, channelID string) (string, error)
-	SearchSimple(query string, includeRepeats bool) ([]database.SearchResult, error)
-	SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool) ([]database.SearchResult, error)
+	SearchSimple(query string, includeRepeats bool, today bool) ([]database.SearchResult, error)
+	SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]database.SearchResult, error)
 	GetCategories() ([]string, error)
 }
 
@@ -136,6 +136,7 @@ func (h *Handler) getSearch(w http.ResponseWriter, r *http.Request) {
 
 	mode := r.URL.Query().Get("mode")
 	includeRepeats := r.URL.Query().Get("include_repeats") != "false"
+	today := r.URL.Query().Get("today") == "true"
 
 	var results []database.SearchResult
 	var err error
@@ -146,9 +147,9 @@ func (h *Handler) getSearch(w http.ResponseWriter, r *http.Request) {
 			categories = strings.Split(cats, ",")
 		}
 		includePast := r.URL.Query().Get("include_past") == "true"
-		results, err = h.db.SearchAdvanced(q, categories, includePast, includeRepeats)
+		results, err = h.db.SearchAdvanced(q, categories, includePast, includeRepeats, today)
 	} else {
-		results, err = h.db.SearchSimple(q, includeRepeats)
+		results, err = h.db.SearchSimple(q, includeRepeats, today)
 	}
 
 	if err != nil {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -907,6 +907,161 @@ func TestSearch_AiringsOrderedByStartTime(t *testing.T) {
 	t.Error("expected 'Cricket Live' group in results")
 }
 
+func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
+	dir := t.TempDir()
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	now := time.Now()
+	tomorrow := time.Date(now.Year(), now.Month(), now.Day()+1, 10, 0, 0, 0, time.Local)
+	tv := &xmltv.TV{
+		Channels: []xmltv.Channel{
+			{ID: "ch1", DisplayNames: []xmltv.Name{{Value: "ABC"}}},
+		},
+		Programmes: []xmltv.Programme{
+			{
+				Start:   xmltv.XmltvTime{Time: now.Add(1 * time.Hour)},
+				Stop:    xmltv.XmltvTime{Time: now.Add(2 * time.Hour)},
+				Channel: "ch1",
+				Titles:  []xmltv.Name{{Value: "Today Show"}},
+			},
+			{
+				Start:   xmltv.XmltvTime{Time: tomorrow},
+				Stop:    xmltv.XmltvTime{Time: tomorrow.Add(1 * time.Hour)},
+				Channel: "ch1",
+				Titles:  []xmltv.Name{{Value: "Tomorrow Show"}},
+			},
+		},
+	}
+
+	if err := db.Refresh(context.Background(), tv, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	handler := api.New(db)
+	handler.RegisterRoutes(mux)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		srv.Close()
+		db.Close()
+	})
+
+	// With today=true, only today's airing should be returned
+	resp, err := http.Get(srv.URL + "/api/search?q=Show&today=true")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result []struct {
+		Title   string `json:"title"`
+		Airings []struct {
+			StartTime time.Time `json:"startTime"`
+		} `json:"airings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	titles := map[string]bool{}
+	for _, g := range result {
+		titles[g.Title] = true
+	}
+	if !titles["Today Show"] {
+		t.Error("expected 'Today Show' in results with today=true")
+	}
+	if titles["Tomorrow Show"] {
+		t.Error("'Tomorrow Show' should be excluded with today=true")
+	}
+
+	// Without today filter, both should be returned
+	resp2, err := http.Get(srv.URL + "/api/search?q=Show")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	var result2 []struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(resp2.Body).Decode(&result2); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	titles2 := map[string]bool{}
+	for _, g := range result2 {
+		titles2[g.Title] = true
+	}
+	if !titles2["Tomorrow Show"] {
+		t.Error("expected 'Tomorrow Show' in results without today filter")
+	}
+}
+
+func TestSearch_TodayFilter_AdvancedMode(t *testing.T) {
+	dir := t.TempDir()
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	now := time.Now()
+	tomorrow := time.Date(now.Year(), now.Month(), now.Day()+1, 10, 0, 0, 0, time.Local)
+	tv := &xmltv.TV{
+		Channels: []xmltv.Channel{
+			{ID: "ch1", DisplayNames: []xmltv.Name{{Value: "ABC"}}},
+		},
+		Programmes: []xmltv.Programme{
+			{
+				Start:      xmltv.XmltvTime{Time: now.Add(1 * time.Hour)},
+				Stop:       xmltv.XmltvTime{Time: now.Add(2 * time.Hour)},
+				Channel:    "ch1",
+				Titles:     []xmltv.Name{{Value: "Today Match"}},
+				Categories: []xmltv.Name{{Value: "Sport"}},
+			},
+			{
+				Start:      xmltv.XmltvTime{Time: tomorrow},
+				Stop:       xmltv.XmltvTime{Time: tomorrow.Add(1 * time.Hour)},
+				Channel:    "ch1",
+				Titles:     []xmltv.Name{{Value: "Tomorrow Match"}},
+				Categories: []xmltv.Name{{Value: "Sport"}},
+			},
+		},
+	}
+
+	if err := db.Refresh(context.Background(), tv, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	handler := api.New(db)
+	handler.RegisterRoutes(mux)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		srv.Close()
+		db.Close()
+	})
+
+	resp, err := http.Get(srv.URL + "/api/search?q=Match&mode=advanced&today=true")
+	if err != nil {
+		t.Fatalf("GET /api/search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "Today Match") {
+		t.Error("expected 'Today Match' in advanced search with today=true")
+	}
+	if strings.Contains(bodyStr, "Tomorrow Match") {
+		t.Error("'Tomorrow Match' should be excluded in advanced search with today=true")
+	}
+}
+
 func TestCategories_ContentType(t *testing.T) {
 	srv := newSearchSeededServer(t)
 	resp, err := http.Get(srv.URL + "/api/categories")

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -773,7 +773,7 @@ func (d *DB) ExecRaw(query string) (sql.Result, error) {
 // SearchSimple performs an FTS5 search on the title column only.
 // Returns future airings ordered by relevance then start time.
 // If includeRepeats is false, repeats are excluded.
-func (d *DB) SearchSimple(query string, includeRepeats bool) ([]SearchResult, error) {
+func (d *DB) SearchSimple(query string, includeRepeats bool, today bool) ([]SearchResult, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	q := `
 		SELECT
@@ -796,6 +796,11 @@ func (d *DB) SearchSimple(query string, includeRepeats bool) ([]SearchResult, er
 	if !includeRepeats {
 		q += ` AND a.is_repeat = 0`
 	}
+	if today {
+		endOfDay := endOfToday()
+		q += ` AND a.start_time < ?`
+		args = append(args, endOfDay)
+	}
 	q += ` ORDER BY f.rank, a.start_time`
 
 	return d.scanSearchResults(q, args...)
@@ -805,7 +810,7 @@ func (d *DB) SearchSimple(query string, includeRepeats bool) ([]SearchResult, er
 // If categories is non-empty, only airings with at least one matching category are returned.
 // If includePast is false, only future airings are returned.
 // If includeRepeats is false, repeats are excluded.
-func (d *DB) SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool) ([]SearchResult, error) {
+func (d *DB) SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]SearchResult, error) {
 	q := `
 		SELECT
 			a.channel_id, a.start_time, a.stop_time,
@@ -839,9 +844,20 @@ func (d *DB) SearchAdvanced(query string, categories []string, includePast bool,
 		}
 		q += ` AND EXISTS (SELECT 1 FROM json_each(a.categories) WHERE value IN (` + strings.Join(placeholders, ",") + `))`
 	}
+	if today {
+		endOfDay := endOfToday()
+		q += ` AND a.start_time < ?`
+		args = append(args, endOfDay)
+	}
 	q += ` ORDER BY f.rank, a.start_time`
 
 	return d.scanSearchResults(q, args...)
+}
+
+// endOfToday returns midnight tonight in the server's local timezone, formatted as RFC3339 in UTC.
+func endOfToday() string {
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, time.Local).UTC().Format(time.RFC3339)
 }
 
 // GetCategories returns all distinct categories sorted alphabetically.

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -736,7 +736,7 @@ func TestSearchSimple_MatchesTitle(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true)
+	results, err := db.SearchSimple("News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -762,7 +762,7 @@ func TestSearchSimple_ExcludesDescriptionOnlyMatches(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true)
+	results, err := db.SearchSimple("News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -778,7 +778,7 @@ func TestSearchSimple_ExcludesFinishedAirings(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true)
+	results, err := db.SearchSimple("News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -794,7 +794,7 @@ func TestSearchSimple_ExcludesRepeats(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", false)
+	results, err := db.SearchSimple("News", false, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -810,7 +810,7 @@ func TestSearchSimple_IncludesRepeats(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true)
+	results, err := db.SearchSimple("News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -831,7 +831,7 @@ func TestSearchAdvanced_MatchesTitleSubtitleDescription(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	// "news" should match in title (Morning News, Evening News) AND subtitle/description (Documentary Special)
-	results, err := db.SearchAdvanced("news", nil, false, true)
+	results, err := db.SearchAdvanced("news", nil, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -853,7 +853,7 @@ func TestSearchAdvanced_FiltersByCategory(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	// Search for "news" but filter to "Documentary" category only
-	results, err := db.SearchAdvanced("news", []string{"Documentary"}, false, true)
+	results, err := db.SearchAdvanced("news", []string{"Documentary"}, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -878,7 +878,7 @@ func TestSearchAdvanced_IncludesPastAirings(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchAdvanced("News", nil, true, true)
+	results, err := db.SearchAdvanced("News", nil, true, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -898,7 +898,7 @@ func TestSearchAdvanced_ExcludesFinishedAirings(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchAdvanced("News", nil, false, true)
+	results, err := db.SearchAdvanced("News", nil, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -914,7 +914,7 @@ func TestSearchAdvanced_ExcludesRepeats(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchAdvanced("News", nil, false, false)
+	results, err := db.SearchAdvanced("News", nil, false, false, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -931,7 +931,7 @@ func TestSearchAdvanced_CombinesCategoryAndText(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	// Search for "sport" filtered to "Entertainment" category
-	results, err := db.SearchAdvanced("sport", []string{"Entertainment"}, false, true)
+	results, err := db.SearchAdvanced("sport", []string{"Entertainment"}, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -950,7 +950,7 @@ func TestSearchSimple_IncludesCurrentlyAiring(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true)
+	results, err := db.SearchSimple("News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -970,7 +970,7 @@ func TestSearchAdvanced_IncludesCurrentlyAiring(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchAdvanced("News", nil, false, true)
+	results, err := db.SearchAdvanced("News", nil, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -982,6 +982,101 @@ func TestSearchAdvanced_IncludesCurrentlyAiring(t *testing.T) {
 	}
 	if !hasCurrentlyAiring {
 		t.Error("SearchAdvanced with includePast=false should include currently-airing shows")
+	}
+}
+
+// searchTVWithTomorrow returns test data like searchTV but adds an airing
+// starting tomorrow, used to test the "today" filter.
+func searchTVWithTomorrow() *xmltv.TV {
+	tv := searchTV()
+	tomorrow := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day()+1, 10, 0, 0, 0, time.Local)
+	tv.Programmes = append(tv.Programmes, xmltv.Programme{
+		Start:      xmltv.XmltvTime{Time: tomorrow},
+		Stop:       xmltv.XmltvTime{Time: tomorrow.Add(1 * time.Hour)},
+		Channel:    "ch1",
+		Titles:     []xmltv.Name{{Value: "Tomorrow News"}},
+		Descs:      []xmltv.Name{{Value: "News from the future."}},
+		Categories: []xmltv.Name{{Value: "News"}},
+	})
+	return tv
+}
+
+func TestSearchSimple_TodayFilter_ExcludesTomorrow(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTVWithTomorrow(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchSimple("News", true, true)
+	if err != nil {
+		t.Fatalf("SearchSimple: %v", err)
+	}
+	for _, r := range results {
+		if r.Title == "Tomorrow News" {
+			t.Error("SearchSimple with today=true should exclude airings starting tomorrow")
+		}
+	}
+	if len(results) == 0 {
+		t.Error("expected at least one result for today")
+	}
+}
+
+func TestSearchSimple_TodayFilter_IncludesToday(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTVWithTomorrow(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	// Without today filter, tomorrow's airing should be included
+	results, err := db.SearchSimple("News", true, false)
+	if err != nil {
+		t.Fatalf("SearchSimple: %v", err)
+	}
+	hasTomorrow := false
+	for _, r := range results {
+		if r.Title == "Tomorrow News" {
+			hasTomorrow = true
+		}
+	}
+	if !hasTomorrow {
+		t.Error("SearchSimple with today=false should include airings starting tomorrow")
+	}
+}
+
+func TestSearchAdvanced_TodayFilter_ExcludesTomorrow(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTVWithTomorrow(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchAdvanced("News", nil, false, true, true)
+	if err != nil {
+		t.Fatalf("SearchAdvanced: %v", err)
+	}
+	for _, r := range results {
+		if r.Title == "Tomorrow News" {
+			t.Error("SearchAdvanced with today=true should exclude airings starting tomorrow")
+		}
+	}
+	if len(results) == 0 {
+		t.Error("expected at least one result for today")
+	}
+}
+
+func TestSearchAdvanced_TodayFilter_IncludesToday(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTVWithTomorrow(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := db.SearchAdvanced("News", nil, false, true, false)
+	if err != nil {
+		t.Fatalf("SearchAdvanced: %v", err)
+	}
+	hasTomorrow := false
+	for _, r := range results {
+		if r.Title == "Tomorrow News" {
+			hasTomorrow = true
+		}
+	}
+	if !hasTomorrow {
+		t.Error("SearchAdvanced with today=false should include airings starting tomorrow")
 	}
 }
 
@@ -1026,7 +1121,7 @@ func TestRefresh_PopulatesFTSAndCategories(t *testing.T) {
 	}
 
 	// FTS should be populated — simple search should work
-	results, err := db.SearchSimple("Morning", true)
+	results, err := db.SearchSimple("Morning", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple after Refresh: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Adds `today=true` query parameter to `GET /api/search` that limits results to airings starting before midnight tonight (server local TZ)
- Works in both simple and advanced search modes, alongside all existing parameters
- Adds `endOfToday()` helper that computes midnight in `time.Local` (set by `TZ` env var)

Closes #56

## Test plan
- [x] Database tests verify `SearchSimple` and `SearchAdvanced` exclude tomorrow's airings when `today=true`
- [x] Database tests verify `today=false` preserves existing behaviour (includes future days)
- [x] API integration tests verify simple and advanced mode both filter correctly via query parameter
- [x] All existing tests pass with the new parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)