### PR TITLE
Fix last channel obscured by bottom nav (#67)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -382,7 +382,8 @@ function renderGuide() {
         (byChannel[p.channelId] ??= []).push(p);
     }
 
-    const totalHeight = channels.length * CONFIG.ROW_HEIGHT;
+    const bottomNavHeight = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--bottom-nav-height')) || 56;
+    const totalHeight = channels.length * CONFIG.ROW_HEIGHT + bottomNavHeight;
 
     // ── Channel column ──
     const channelCol = document.getElementById('channelCol');


### PR DESCRIPTION
## Summary
- The last channel in the guide was hidden behind the fixed bottom navigation bar when scrolled to the bottom
- Added the bottom nav height to the guide's `totalHeight` so the scroll area extends far enough to bring the last channel fully above the nav
- The value is read from the `--bottom-nav-height` CSS variable (with a fallback of 56) so it stays in sync automatically

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)