### PR TITLE
Refactor: move domain types to internal/model/ (#63)

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -15,17 +15,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/model"
 )
 
 // store is the narrow interface the Handler needs from the database layer.
 type store interface {
-	GetChannels() ([]database.Channel, error)
-	GetAirings(date time.Time) ([]database.Airing, error)
-	GetStatus() database.Status
+	GetChannels() ([]model.Channel, error)
+	GetAirings(date time.Time) ([]model.Airing, error)
+	GetStatus() model.Status
 	EnsureChannelIcon(ctx context.Context, channelID string) (string, error)
-	SearchSimple(query string, includeRepeats bool, today bool) ([]database.SearchResult, error)
-	SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]database.SearchResult, error)
+	SearchSimple(query string, includeRepeats bool, today bool) ([]model.SearchResult, error)
+	SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error)
 	GetCategories() ([]string, error)
 }
 
@@ -144,7 +144,7 @@ func (h *Handler) getSearch(w http.ResponseWriter, r *http.Request) {
 	includeRepeats := r.URL.Query().Get("include_repeats") != "false"
 	today := r.URL.Query().Get("today") == "true"
 
-	var results []database.SearchResult
+	var results []model.SearchResult
 	var err error
 
 	var categories []string
@@ -272,7 +272,7 @@ type xmlCDATA struct {
 	Value string `xml:",cdata"`
 }
 
-func (h *Handler) writeSearchRSS(w http.ResponseWriter, r *http.Request, query, mode string, categories []string, results []database.SearchResult) {
+func (h *Handler) writeSearchRSS(w http.ResponseWriter, r *http.Request, query, mode string, categories []string, results []model.SearchResult) {
 	// Sort results by start time ascending.
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].Start.Before(results[j].Start)
@@ -321,7 +321,7 @@ func (h *Handler) writeSearchRSS(w http.ResponseWriter, r *http.Request, query, 
 	}
 }
 
-func buildRSSItem(sr database.SearchResult) xmlRSSItem {
+func buildRSSItem(sr model.SearchResult) xmlRSSItem {
 	// Build title: "Title - SubTitle (EpisodeNumDisplay)"
 	title := sr.Title
 	if sr.SubTitle != "" {

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -17,6 +17,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
+	"github.com/acbgbca/xmltvguide/internal/model"
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
 )
 
@@ -53,50 +54,6 @@ CREATE TABLE IF NOT EXISTS airings (
 CREATE INDEX IF NOT EXISTS idx_airings_window ON airings(start_time, stop_time);
 CREATE INDEX IF NOT EXISTS idx_airings_stop   ON airings(stop_time);
 `
-
-// Channel holds display data for a TV channel.
-type Channel struct {
-	ID          string `json:"id"`
-	DisplayName string `json:"displayName"`
-	Icon        string `json:"icon,omitempty"`
-	LCN         *int   `json:"lcn,omitempty"`
-}
-
-// Airing holds all data for a single broadcast slot.
-// JSON field names for start/stop are kept as "start"/"stop" for frontend compatibility.
-type Airing struct {
-	ChannelID         string    `json:"channelId"`
-	Start             time.Time `json:"start"`
-	Stop              time.Time `json:"stop"`
-	Title             string    `json:"title"`
-	SubTitle          string    `json:"subTitle,omitempty"`
-	Description       string    `json:"description,omitempty"`
-	Categories        []string  `json:"categories,omitempty"`
-	EpisodeNum        string    `json:"episodeNum,omitempty"`
-	EpisodeNumDisplay string    `json:"episodeNumDisplay,omitempty"`
-	ProgID            string    `json:"progId,omitempty"`
-	StarRating        string    `json:"starRating,omitempty"`
-	ContentRating     string    `json:"contentRating,omitempty"`
-	Year              string    `json:"year,omitempty"`
-	Icon              string    `json:"icon,omitempty"`
-	Country           string    `json:"country,omitempty"`
-	IsRepeat          bool      `json:"isRepeat"`
-	IsPremiere        bool      `json:"isPremiere"`
-}
-
-// Status holds metadata about the last data refresh.
-type Status struct {
-	LastRefresh time.Time `json:"lastRefresh"`
-	NextRefresh time.Time `json:"nextRefresh"`
-	SourceURL   string    `json:"sourceUrl"`
-}
-
-// SearchResult extends Airing with additional fields needed by the search API.
-type SearchResult struct {
-	Airing
-	ChannelName string  `json:"channelName"`
-	Rank        float64 `json:"-"`
-}
 
 // DB wraps a SQLite database connection.
 type DB struct {
@@ -570,7 +527,7 @@ func extFromURL(u string) string {
 // GetChannels returns all channels ordered by their source sort order.
 // The Icon field contains the proxy URL (/images/channel/{id}) for channels
 // that have an icon; it is empty for channels without one.
-func (d *DB) GetChannels() ([]Channel, error) {
+func (d *DB) GetChannels() ([]model.Channel, error) {
 	rows, err := d.db.Query(`
 		SELECT id, display_name, COALESCE(icon_url, ''), lcn
 		FROM channels
@@ -581,9 +538,9 @@ func (d *DB) GetChannels() ([]Channel, error) {
 	}
 	defer rows.Close()
 
-	channels := []Channel{}
+	channels := []model.Channel{}
 	for rows.Next() {
-		var ch Channel
+		var ch model.Channel
 		var lcn sql.NullInt64
 		var iconURL string
 		if err := rows.Scan(&ch.ID, &ch.DisplayName, &iconURL, &lcn); err != nil {
@@ -603,7 +560,7 @@ func (d *DB) GetChannels() ([]Channel, error) {
 
 // GetAirings returns all airings that overlap with the given calendar date,
 // interpreted in the server's local timezone.
-func (d *DB) GetAirings(date time.Time) ([]Airing, error) {
+func (d *DB) GetAirings(date time.Time) ([]model.Airing, error) {
 	dayStart := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.Local).UTC()
 	dayEnd := dayStart.Add(24 * time.Hour)
 
@@ -635,9 +592,9 @@ func (d *DB) GetAirings(date time.Time) ([]Airing, error) {
 	}
 	defer rows.Close()
 
-	airings := []Airing{}
+	airings := []model.Airing{}
 	for rows.Next() {
-		var a Airing
+		var a model.Airing
 		var startStr, stopStr, catsJSON string
 		var isRepeat, isPremiere int
 
@@ -663,10 +620,10 @@ func (d *DB) GetAirings(date time.Time) ([]Airing, error) {
 }
 
 // GetStatus returns the current refresh metadata.
-func (d *DB) GetStatus() Status {
+func (d *DB) GetStatus() model.Status {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	return Status{
+	return model.Status{
 		LastRefresh: d.lastRefresh,
 		NextRefresh: d.nextRefresh,
 		SourceURL:   d.sourceURL,
@@ -694,8 +651,8 @@ func (d *DB) Close() error {
 }
 
 // airingFromXMLTV maps an xmltv.Programme to an Airing.
-func airingFromXMLTV(p xmltv.Programme) Airing {
-	a := Airing{
+func airingFromXMLTV(p xmltv.Programme) model.Airing {
+	a := model.Airing{
 		ChannelID:  p.Channel,
 		Start:      p.Start.Time,
 		Stop:       p.Stop.Time,
@@ -773,7 +730,7 @@ func (d *DB) ExecRaw(query string) (sql.Result, error) {
 // SearchSimple performs an FTS5 search on the title column only.
 // Returns future airings ordered by relevance then start time.
 // If includeRepeats is false, repeats are excluded.
-func (d *DB) SearchSimple(query string, includeRepeats bool, today bool) ([]SearchResult, error) {
+func (d *DB) SearchSimple(query string, includeRepeats bool, today bool) ([]model.SearchResult, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	q := `
 		SELECT
@@ -810,7 +767,7 @@ func (d *DB) SearchSimple(query string, includeRepeats bool, today bool) ([]Sear
 // If categories is non-empty, only airings with at least one matching category are returned.
 // If includePast is false, only future airings are returned.
 // If includeRepeats is false, repeats are excluded.
-func (d *DB) SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]SearchResult, error) {
+func (d *DB) SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error) {
 	q := `
 		SELECT
 			a.channel_id, a.start_time, a.stop_time,
@@ -881,16 +838,16 @@ func (d *DB) GetCategories() ([]string, error) {
 
 // scanSearchResults executes a query and scans results into SearchResult slices.
 // The query must select the standard airing columns plus display_name and rank.
-func (d *DB) scanSearchResults(query string, args ...any) ([]SearchResult, error) {
+func (d *DB) scanSearchResults(query string, args ...any) ([]model.SearchResult, error) {
 	rows, err := d.db.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying search results: %w", err)
 	}
 	defer rows.Close()
 
-	var results []SearchResult
+	var results []model.SearchResult
 	for rows.Next() {
-		var sr SearchResult
+		var sr model.SearchResult
 		var startStr, stopStr, catsJSON string
 		var isRepeat, isPremiere int
 
@@ -917,16 +874,16 @@ func (d *DB) scanSearchResults(query string, args ...any) ([]SearchResult, error
 }
 
 // scanAirings executes a query and scans results into Airing slices.
-func (d *DB) scanAirings(query string, args ...any) ([]Airing, error) {
+func (d *DB) scanAirings(query string, args ...any) ([]model.Airing, error) {
 	rows, err := d.db.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying airings: %w", err)
 	}
 	defer rows.Close()
 
-	airings := []Airing{}
+	airings := []model.Airing{}
 	for rows.Next() {
-		var a Airing
+		var a model.Airing
 		var startStr, stopStr, catsJSON string
 		var isRepeat, isPremiere int
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/model"
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
 )
 
@@ -517,7 +518,7 @@ func TestGetAirings_SxxExxEpisodeMapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
-	var drama *database.Airing
+	var drama *model.Airing
 	for i := range airings {
 		if airings[i].Title == "Drama Show" {
 			drama = &airings[i]
@@ -575,7 +576,7 @@ func TestGetAirings_FieldMapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
-	var sunrise *database.Airing
+	var sunrise *model.Airing
 	for i := range airings {
 		if airings[i].Title == "Sunrise" {
 			sunrise = &airings[i]
@@ -612,7 +613,7 @@ func TestGetAirings_PremiereFlagAndCategories(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
-	var worldNews *database.Airing
+	var worldNews *model.Airing
 	for i := range airings {
 		if airings[i].Title == "World News" {
 			worldNews = &airings[i]

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -1,0 +1,47 @@
+package model
+
+import "time"
+
+// Channel holds display data for a TV channel.
+type Channel struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+	Icon        string `json:"icon,omitempty"`
+	LCN         *int   `json:"lcn,omitempty"`
+}
+
+// Airing holds all data for a single broadcast slot.
+// JSON field names for start/stop are kept as "start"/"stop" for frontend compatibility.
+type Airing struct {
+	ChannelID         string    `json:"channelId"`
+	Start             time.Time `json:"start"`
+	Stop              time.Time `json:"stop"`
+	Title             string    `json:"title"`
+	SubTitle          string    `json:"subTitle,omitempty"`
+	Description       string    `json:"description,omitempty"`
+	Categories        []string  `json:"categories,omitempty"`
+	EpisodeNum        string    `json:"episodeNum,omitempty"`
+	EpisodeNumDisplay string    `json:"episodeNumDisplay,omitempty"`
+	ProgID            string    `json:"progId,omitempty"`
+	StarRating        string    `json:"starRating,omitempty"`
+	ContentRating     string    `json:"contentRating,omitempty"`
+	Year              string    `json:"year,omitempty"`
+	Icon              string    `json:"icon,omitempty"`
+	Country           string    `json:"country,omitempty"`
+	IsRepeat          bool      `json:"isRepeat"`
+	IsPremiere        bool      `json:"isPremiere"`
+}
+
+// Status holds metadata about the last data refresh.
+type Status struct {
+	LastRefresh time.Time `json:"lastRefresh"`
+	NextRefresh time.Time `json:"nextRefresh"`
+	SourceURL   string    `json:"sourceUrl"`
+}
+
+// SearchResult extends Airing with additional fields needed by the search API.
+type SearchResult struct {
+	Airing
+	ChannelName string  `json:"channelName"`
+	Rank        float64 `json:"-"`
+}

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -1,0 +1,105 @@
+package model_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/model"
+)
+
+// TestModelTypes verifies that the domain types have the expected fields and
+// JSON serialisation tags. This is a compile-time + structural test: if a field
+// is missing or renamed, this file will fail to compile.
+func TestChannelFields(t *testing.T) {
+	lcn := 7
+	ch := model.Channel{
+		ID:          "ch1",
+		DisplayName: "ABC",
+		Icon:        "/images/channel/ch1",
+		LCN:         &lcn,
+	}
+	data, err := json.Marshal(ch)
+	if err != nil {
+		t.Fatalf("marshal Channel: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"id", "displayName", "icon", "lcn"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("Channel JSON missing key %q", key)
+		}
+	}
+}
+
+func TestAiringFields(t *testing.T) {
+	a := model.Airing{
+		ChannelID: "ch1",
+		Start:     time.Now(),
+		Stop:      time.Now().Add(30 * time.Minute),
+		Title:     "Test Show",
+	}
+	data, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("marshal Airing: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"channelId", "start", "stop", "title", "isRepeat", "isPremiere"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("Airing JSON missing key %q", key)
+		}
+	}
+}
+
+func TestStatusFields(t *testing.T) {
+	s := model.Status{
+		LastRefresh: time.Now(),
+		NextRefresh: time.Now().Add(time.Hour),
+		SourceURL:   "http://example.com/xmltv",
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal Status: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"lastRefresh", "nextRefresh", "sourceUrl"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("Status JSON missing key %q", key)
+		}
+	}
+}
+
+func TestSearchResultEmbedding(t *testing.T) {
+	// SearchResult must embed Airing and add ChannelName.
+	sr := model.SearchResult{
+		Airing: model.Airing{
+			ChannelID: "ch1",
+			Title:     "Test",
+		},
+		ChannelName: "ABC",
+		Rank:        0.5,
+	}
+	data, err := json.Marshal(sr)
+	if err != nil {
+		t.Fatalf("marshal SearchResult: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["channelName"]; !ok {
+		t.Error("SearchResult JSON missing key \"channelName\"")
+	}
+	// Rank has json:"-" so it must NOT appear in JSON.
+	if _, ok := m["rank"]; ok {
+		t.Error("SearchResult JSON should not include \"rank\" (json:\"-\")")
+	}
+}


### PR DESCRIPTION
## Summary

- Creates `internal/model/types.go` with `Channel`, `Airing`, `Status`, and `SearchResult` structs (pure structs, no logic, only `time` import)
- Removes the four struct definitions from `internal/database/db.go` and updates all references to use `model.*` types
- Updates `internal/api/handlers.go` to import `model` instead of `database`, eliminating the coupling between the HTTP and storage layers at the type level
- Adds `internal/model/types_test.go` with structural tests verifying JSON field names and struct embedding

Closes #63

## Test plan

- [x] `go build ./...` passes with no errors
- [x] `go test ./...` passes — all existing tests plus new model package tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)