### PR TITLE
Refactor: extract icon download logic to internal/images/ (#65)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/acbgbca/xmltvguide/internal/api"
 	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/images"
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
 )
 
@@ -63,7 +64,7 @@ func startMockXMLTVServer(t *testing.T, xmlContent string) *countingServer {
 func newIntegrationServer(t *testing.T, xmltvURL string) *httptest.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, xmltvURL, filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, xmltvURL, images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -287,7 +288,7 @@ func TestStartup_FreshInstall_AlwaysFetches(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -313,7 +314,7 @@ func TestStartup_ExistingData_SkipsFetch(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -347,7 +348,7 @@ func TestStartup_RefreshOnStart_FetchesEvenWithData(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -493,7 +494,7 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	dir := t.TempDir()
 	db, err := database.Open(
 		filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv",
-		filepath.Join(dir, "images"), mockSrv.Client(),
+		images.NewCache(mockSrv.Client(), filepath.Join(dir, "images")),
 	)
 	if err != nil {
 		t.Fatalf("Open: %v", err)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/acbgbca/xmltvguide/internal/api"
 	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/images"
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
 )
 
@@ -39,7 +40,7 @@ func startFakeIconServer(t *testing.T) *httptest.Server {
 func newSeededServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -94,7 +95,7 @@ func newSeededServer(t *testing.T) *httptest.Server {
 func newSeededServerWithIcons(t *testing.T, iconSrv *httptest.Server) (*httptest.Server, *database.DB) {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), iconSrv.Client())
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(iconSrv.Client(), filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -423,7 +424,7 @@ func TestGetChannelIcon_RedownloadsIfMissing(t *testing.T) {
 func newSearchSeededServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -779,7 +780,7 @@ func TestCategories_ReturnsSortedList(t *testing.T) {
 
 func TestCategories_EmptyWhenNoData(t *testing.T) {
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -814,7 +815,7 @@ func TestCategories_EmptyWhenNoData(t *testing.T) {
 // would produce a different order.
 func TestSearch_AiringsOrderedByStartTime(t *testing.T) {
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -910,7 +911,7 @@ func TestSearch_AiringsOrderedByStartTime(t *testing.T) {
 
 func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -1004,7 +1005,7 @@ func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 
 func TestSearch_TodayFilter_AdvancedMode(t *testing.T) {
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -1163,7 +1164,7 @@ type rssEnclosure struct {
 func newRSSSeededServer(t *testing.T, rssTTL int) *httptest.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", filepath.Join(dir, "images"), &http.Client{})
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -3,12 +3,12 @@ package database
 import (
 	"database/sql"
 	"fmt"
-	"net/http"
 	"sync"
 	"time"
 
 	_ "modernc.org/sqlite"
 
+	"github.com/acbgbca/xmltvguide/internal/images"
 	"github.com/acbgbca/xmltvguide/internal/model"
 )
 
@@ -51,8 +51,7 @@ type DB struct {
 	db            *sql.DB
 	retentionDays int
 	sourceURL     string
-	imageCacheDir string
-	httpClient    *http.Client
+	imageCache    *images.Cache
 
 	// lastRefresh and nextRefresh are kept in memory — they reflect the current
 	// process's poll cycle and reset on restart, which is intentional.
@@ -165,9 +164,8 @@ func columnExists(db *sql.DB, table, column string) (bool, error) {
 }
 
 // Open opens (or creates) a SQLite database at path and applies the schema.
-// imageCacheDir is the directory used to store downloaded channel icons.
-// httpClient is used for icon downloads; pass nil to disable icon caching.
-func Open(path string, retentionDays int, sourceURL, imageCacheDir string, httpClient *http.Client) (*DB, error) {
+// imageCache handles icon downloading and caching; pass nil to disable icon caching.
+func Open(path string, retentionDays int, sourceURL string, imageCache *images.Cache) (*DB, error) {
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
@@ -199,8 +197,7 @@ func Open(path string, retentionDays int, sourceURL, imageCacheDir string, httpC
 		db:            db,
 		retentionDays: retentionDays,
 		sourceURL:     sourceURL,
-		imageCacheDir: imageCacheDir,
-		httpClient:    httpClient,
+		imageCache:    imageCache,
 	}, nil
 }
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/images"
 	"github.com/acbgbca/xmltvguide/internal/model"
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
 )
@@ -34,7 +35,8 @@ func openTestDB(t *testing.T) *database.DB {
 	t.Helper()
 	dir := t.TempDir()
 	client := &http.Client{Transport: &failingTransport{}}
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", filepath.Join(dir, "images"), client)
+	cache := images.NewCache(client, filepath.Join(dir, "images"))
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", cache)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -47,7 +49,8 @@ func openTestDB(t *testing.T) *database.DB {
 func openTestDBWithIconServer(t *testing.T, iconServer *httptest.Server) *database.DB {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", filepath.Join(dir, "images"), iconServer.Client())
+	cache := images.NewCache(iconServer.Client(), filepath.Join(dir, "images"))
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", cache)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/internal/database/icons.go
+++ b/internal/database/icons.go
@@ -4,12 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io"
 	"log"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 // EnsureChannelIcon ensures the channel's icon is present on disk and returns
@@ -32,110 +27,23 @@ func (d *DB) EnsureChannelIcon(ctx context.Context, channelID string) (string, e
 		return "", nil
 	}
 
-	// Return the cached path if the file still exists.
-	if localPath != "" {
-		if _, err := os.Stat(localPath); err == nil {
-			return localPath, nil
-		}
-	}
-
-	// File is missing — re-download.
-	if d.httpClient == nil || d.imageCacheDir == "" {
+	if d.imageCache == nil {
 		return "", fmt.Errorf("image cache not configured for re-download")
 	}
-	newPath, err := d.downloadAndSaveIcon(ctx, channelID, iconURL)
+
+	newPath, err := d.imageCache.EnsureIcon(ctx, channelID, localPath, iconURL)
 	if err != nil {
 		return "", fmt.Errorf("re-downloading icon for %s: %w", channelID, err)
 	}
 
-	// Update the stored local path.
-	if _, err := d.db.ExecContext(ctx,
-		`UPDATE channels SET icon = ? WHERE id = ?`, newPath, channelID,
-	); err != nil {
-		log.Printf("warning: failed to update icon path for channel %s: %v", channelID, err)
+	// Update the stored local path if it changed.
+	if newPath != localPath {
+		if _, err := d.db.ExecContext(ctx,
+			`UPDATE channels SET icon = ? WHERE id = ?`, newPath, channelID,
+		); err != nil {
+			log.Printf("warning: failed to update icon path for channel %s: %v", channelID, err)
+		}
 	}
 
 	return newPath, nil
-}
-
-// downloadAndSaveIcon fetches the image at iconURL, determines its file
-// extension from the Content-Type header (falling back to the URL extension or
-// ".jpg"), writes it to {imageCacheDir}/channels/{channelID}{ext}, and returns
-// the local path.
-func (d *DB) downloadAndSaveIcon(ctx context.Context, channelID, iconURL string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, iconURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("building request: %w", err)
-	}
-	req.Header.Set("Accept", "image/*,*/*")
-	req.Header.Set("User-Agent", "xmltvguide/1.0")
-	resp, err := d.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("downloading: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, iconURL)
-	}
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("reading body: %w", err)
-	}
-
-	ext := extFromContentType(resp.Header.Get("Content-Type"))
-	if ext == "" {
-		ext = extFromURL(iconURL)
-	}
-	if ext == "" {
-		ext = ".jpg"
-	}
-
-	dir := filepath.Join(d.imageCacheDir, "channels")
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", fmt.Errorf("creating image directory: %w", err)
-	}
-
-	localPath := filepath.Join(dir, channelID+ext)
-	if err := os.WriteFile(localPath, data, 0644); err != nil {
-		return "", fmt.Errorf("writing icon file: %w", err)
-	}
-
-	return localPath, nil
-}
-
-// extFromContentType maps a MIME type to a file extension.
-func extFromContentType(ct string) string {
-	if i := strings.Index(ct, ";"); i >= 0 {
-		ct = strings.TrimSpace(ct[:i])
-	}
-	switch ct {
-	case "image/png":
-		return ".png"
-	case "image/jpeg", "image/jpg":
-		return ".jpg"
-	case "image/gif":
-		return ".gif"
-	case "image/svg+xml", "image/svg":
-		return ".svg"
-	case "image/webp":
-		return ".webp"
-	default:
-		return ""
-	}
-}
-
-// extFromURL extracts a recognised image file extension from a URL path,
-// ignoring query parameters.
-func extFromURL(u string) string {
-	if i := strings.Index(u, "?"); i >= 0 {
-		u = u[:i]
-	}
-	ext := filepath.Ext(u)
-	switch strings.ToLower(ext) {
-	case ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp":
-		return ext
-	default:
-		return ""
-	}
 }

--- a/internal/database/refresh.go
+++ b/internal/database/refresh.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 	"time"
 
@@ -44,29 +43,31 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 		incomingURL := ch.Icons[0].Src
 		existing := currentIcons[ch.ID]
 
-		// Skip download if URL is unchanged and the cached file still exists.
-		if existing.iconURL == incomingURL && existing.localPath != "" {
-			if _, err := os.Stat(existing.localPath); err == nil {
-				resolved[ch.ID] = resolvedIcon{existing.localPath, incomingURL}
-				continue
-			}
-		}
-
-		// Attempt download only when the cache is configured.
-		if d.imageCacheDir != "" && d.httpClient != nil {
-			localPath, err := d.downloadAndSaveIcon(ctx, ch.ID, incomingURL)
-			if err != nil {
-				log.Printf("warning: failed to cache icon for channel %s: %v", ch.ID, err)
-				// Store icon_url even if download failed so the handler can
-				// re-download on demand.
-				resolved[ch.ID] = resolvedIcon{"", incomingURL}
-				continue
-			}
-			resolved[ch.ID] = resolvedIcon{localPath, incomingURL}
+		if d.imageCache == nil {
+			// Cache not configured: store the URL for future use, no local file.
+			resolved[ch.ID] = resolvedIcon{"", incomingURL}
 			continue
 		}
-		// Cache not configured: store the URL for future use, no local file.
-		resolved[ch.ID] = resolvedIcon{"", incomingURL}
+
+		var (
+			localPath string
+			err       error
+		)
+		if existing.iconURL == incomingURL {
+			// URL unchanged: validate existing file and re-download only if missing.
+			localPath, err = d.imageCache.EnsureIcon(ctx, ch.ID, existing.localPath, incomingURL)
+		} else {
+			// URL changed: always download a fresh copy.
+			localPath, err = d.imageCache.Download(ctx, ch.ID, incomingURL)
+		}
+		if err != nil {
+			log.Printf("warning: failed to cache icon for channel %s: %v", ch.ID, err)
+			// Store icon_url even if download failed so the handler can
+			// re-download on demand.
+			resolved[ch.ID] = resolvedIcon{"", incomingURL}
+			continue
+		}
+		resolved[ch.ID] = resolvedIcon{localPath, incomingURL}
 	}
 
 	// Phase 3: Write everything to the database in a single transaction.

--- a/internal/images/cache.go
+++ b/internal/images/cache.go
@@ -1,0 +1,121 @@
+package images
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Cache manages the local icon file cache and handles downloading icons from
+// remote URLs. It is safe to call from multiple goroutines.
+type Cache struct {
+	httpClient *http.Client
+	dir        string
+}
+
+// NewCache creates a new Cache that stores files under dir and uses httpClient
+// for downloads. Pass nil for httpClient to disable downloading.
+func NewCache(httpClient *http.Client, dir string) *Cache {
+	return &Cache{httpClient: httpClient, dir: dir}
+}
+
+// EnsureIcon returns a valid local path for the channel's icon. If localPath
+// exists on disk it is returned as-is. Otherwise the icon is downloaded from
+// iconURL and the new local path is returned. Returns ("", nil) when iconURL
+// is empty.
+func (c *Cache) EnsureIcon(ctx context.Context, channelID, localPath, iconURL string) (string, error) {
+	if iconURL == "" {
+		return "", nil
+	}
+	if localPath != "" {
+		if _, err := os.Stat(localPath); err == nil {
+			return localPath, nil
+		}
+	}
+	return c.Download(ctx, channelID, iconURL)
+}
+
+// Download fetches the icon at iconURL and stores it under the cache directory,
+// returning the local file path.
+func (c *Cache) Download(ctx context.Context, channelID, iconURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, iconURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("Accept", "image/*,*/*")
+	req.Header.Set("User-Agent", "xmltvguide/1.0")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("downloading: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, iconURL)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading body: %w", err)
+	}
+
+	ext := extFromContentType(resp.Header.Get("Content-Type"))
+	if ext == "" {
+		ext = extFromURL(iconURL)
+	}
+	if ext == "" {
+		ext = ".jpg"
+	}
+
+	dir := filepath.Join(c.dir, "channels")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("creating image directory: %w", err)
+	}
+
+	localPath := filepath.Join(dir, channelID+ext)
+	if err := os.WriteFile(localPath, data, 0644); err != nil {
+		return "", fmt.Errorf("writing icon file: %w", err)
+	}
+
+	return localPath, nil
+}
+
+// extFromContentType maps a MIME type to a file extension.
+func extFromContentType(ct string) string {
+	if i := strings.Index(ct, ";"); i >= 0 {
+		ct = strings.TrimSpace(ct[:i])
+	}
+	switch ct {
+	case "image/png":
+		return ".png"
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/svg+xml", "image/svg":
+		return ".svg"
+	case "image/webp":
+		return ".webp"
+	default:
+		return ""
+	}
+}
+
+// extFromURL extracts a recognised image file extension from a URL path,
+// ignoring query parameters.
+func extFromURL(u string) string {
+	if i := strings.Index(u, "?"); i >= 0 {
+		u = u[:i]
+	}
+	ext := filepath.Ext(u)
+	switch strings.ToLower(ext) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp":
+		return ext
+	default:
+		return ""
+	}
+}

--- a/internal/images/cache_test.go
+++ b/internal/images/cache_test.go
@@ -1,0 +1,185 @@
+package images_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/acbgbca/xmltvguide/internal/images"
+)
+
+func newTestCache(t *testing.T, client *http.Client) *images.Cache {
+	t.Helper()
+	dir := t.TempDir()
+	return images.NewCache(client, dir)
+}
+
+func startIconServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("\x89PNG\r\n\x1a\n"))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func startStrictIconServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") == "" || r.Header.Get("User-Agent") == "" {
+			w.WriteHeader(http.StatusNotAcceptable)
+			return
+		}
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("\x89PNG\r\n\x1a\n"))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestCache_Download_Success(t *testing.T) {
+	srv := startIconServer(t)
+	cache := newTestCache(t, srv.Client())
+
+	path, err := cache.Download(context.Background(), "ch1", srv.URL+"/icon.png")
+	if err != nil {
+		t.Fatalf("Download: unexpected error: %v", err)
+	}
+	if path == "" {
+		t.Fatal("Download: expected non-empty path")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Download: file not found at %s: %v", path, err)
+	}
+	if filepath.Ext(path) != ".png" {
+		t.Errorf("Download: expected .png extension, got %s", filepath.Ext(path))
+	}
+}
+
+func TestCache_Download_SetsRequiredHeaders(t *testing.T) {
+	srv := startStrictIconServer(t)
+	cache := newTestCache(t, srv.Client())
+
+	path, err := cache.Download(context.Background(), "ch1", srv.URL+"/icon.png")
+	if err != nil {
+		t.Fatalf("Download: strict server rejected request (missing headers?): %v", err)
+	}
+	if path == "" {
+		t.Fatal("Download: expected non-empty path")
+	}
+}
+
+func TestCache_Download_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	cache := newTestCache(t, srv.Client())
+
+	_, err := cache.Download(context.Background(), "ch1", srv.URL+"/icon.png")
+	if err == nil {
+		t.Fatal("Download: expected error for non-200 response")
+	}
+}
+
+func TestCache_Download_URLExtension(t *testing.T) {
+	// Server returns no Content-Type header, rely on URL extension.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("data"))
+	}))
+	t.Cleanup(srv.Close)
+	cache := newTestCache(t, srv.Client())
+
+	path, err := cache.Download(context.Background(), "ch1", srv.URL+"/icon.jpg")
+	if err != nil {
+		t.Fatalf("Download: unexpected error: %v", err)
+	}
+	if filepath.Ext(path) != ".jpg" {
+		t.Errorf("Download: expected .jpg extension from URL, got %s", filepath.Ext(path))
+	}
+}
+
+func TestCache_Download_DefaultExtension(t *testing.T) {
+	// Server returns no Content-Type header and URL has no recognised extension.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("data"))
+	}))
+	t.Cleanup(srv.Close)
+	cache := newTestCache(t, srv.Client())
+
+	path, err := cache.Download(context.Background(), "ch1", srv.URL+"/icon")
+	if err != nil {
+		t.Fatalf("Download: unexpected error: %v", err)
+	}
+	if filepath.Ext(path) != ".jpg" {
+		t.Errorf("Download: expected default .jpg extension, got %s", filepath.Ext(path))
+	}
+}
+
+func TestCache_EnsureIcon_FileExists(t *testing.T) {
+	srv := startIconServer(t)
+	cache := newTestCache(t, srv.Client())
+
+	// Pre-create a local file.
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "ch1.png")
+	if err := os.WriteFile(existing, []byte("fake png"), 0644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	path, err := cache.EnsureIcon(context.Background(), "ch1", existing, srv.URL+"/icon.png")
+	if err != nil {
+		t.Fatalf("EnsureIcon: unexpected error: %v", err)
+	}
+	if path != existing {
+		t.Errorf("EnsureIcon: expected %s, got %s", existing, path)
+	}
+}
+
+func TestCache_EnsureIcon_FileMissing_Downloads(t *testing.T) {
+	srv := startIconServer(t)
+	cache := newTestCache(t, srv.Client())
+
+	// Local path provided but the file doesn't exist on disk.
+	missingPath := filepath.Join(t.TempDir(), "missing.png")
+
+	path, err := cache.EnsureIcon(context.Background(), "ch1", missingPath, srv.URL+"/icon.png")
+	if err != nil {
+		t.Fatalf("EnsureIcon: unexpected error: %v", err)
+	}
+	if path == "" {
+		t.Fatal("EnsureIcon: expected non-empty path after re-download")
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Fatalf("EnsureIcon: downloaded file not found at %s: %v", path, statErr)
+	}
+}
+
+func TestCache_EnsureIcon_EmptyLocalPath_Downloads(t *testing.T) {
+	srv := startIconServer(t)
+	cache := newTestCache(t, srv.Client())
+
+	path, err := cache.EnsureIcon(context.Background(), "ch1", "", srv.URL+"/icon.png")
+	if err != nil {
+		t.Fatalf("EnsureIcon: unexpected error: %v", err)
+	}
+	if path == "" {
+		t.Fatal("EnsureIcon: expected non-empty path after download")
+	}
+}
+
+func TestCache_EnsureIcon_EmptyURL(t *testing.T) {
+	cache := newTestCache(t, http.DefaultClient)
+
+	path, err := cache.EnsureIcon(context.Background(), "ch1", "", "")
+	if err != nil {
+		t.Fatalf("EnsureIcon: unexpected error: %v", err)
+	}
+	if path != "" {
+		t.Errorf("EnsureIcon: expected empty path for channel with no icon URL, got %s", path)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/acbgbca/xmltvguide/internal/api"
 	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/images"
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
 )
 
@@ -74,7 +75,9 @@ func main() {
 
 	httpClient := &http.Client{Timeout: 5 * time.Minute}
 
-	db, err := database.Open(dbPath, retentionDays, xmltvURL, imageCacheDir, httpClient)
+	imageCache := images.NewCache(httpClient, imageCacheDir)
+
+	db, err := database.Open(dbPath, retentionDays, xmltvURL, imageCache)
 	if err != nil {
 		log.Fatalf("opening database: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Creates `internal/images/` package with a `Cache` type that owns all icon download and caching logic
- `Cache.EnsureIcon()` validates the local file and re-downloads if missing; `Cache.Download()` always fetches fresh
- `database.Open()` now accepts `*images.Cache` instead of raw `imageCacheDir` + `httpClient` fields — the database package no longer imports `net/http` or `io`
- `main.go` instantiates `images.NewCache()` before opening the database

## Test plan

- [x] New `internal/images/cache_test.go` with 9 tests covering: download success, required headers (Accept + User-Agent), HTTP errors, content-type/URL/default extension detection, and all `EnsureIcon` code paths
- [x] All existing tests updated to use new `database.Open()` signature
- [x] `go test ./...` passes

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)