### PR TITLE
Refactor: extract application state and API layer into ES modules (#75)

### DIFF
--- a/web/js/api.js
+++ b/web/js/api.js
@@ -1,0 +1,23 @@
+// ── API fetch wrappers ────────────────────────────────────────────────────────
+
+import { state } from './state.js';
+
+export async function fetchChannels() {
+    const res = await fetch('/api/channels');
+    if (!res.ok) throw new Error(`/api/channels returned ${res.status}`);
+    return res.json();
+}
+
+export async function fetchGuide(dateStr) {
+    const res = await fetch(`/api/guide?date=${dateStr}`);
+    if (!res.ok) throw new Error(`/api/guide returned ${res.status}`);
+    return res.json();
+}
+
+export async function fetchCategories() {
+    if (state.categories.length > 0) return state.categories;
+    const res = await fetch('/api/categories');
+    if (!res.ok) throw new Error(`/api/categories returned ${res.status}`);
+    state.categories = await res.json();
+    return state.categories;
+}

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,23 +1,7 @@
 import { CONFIG } from './config.js';
 import { getTodayString, dateMidnight, formatTime, formatDateLong, minutesToHHMM, addDays, formatSearchDate } from './utils/date.js';
-
-// ── Application state ─────────────────────────────────────────────────────────
-
-const state = {
-    channels:    [],
-    programmes:  [],
-    currentDate: getTodayString(),  // 'YYYY-MM-DD' in browser local time
-    prefs:       loadPrefs(),
-    activePage:  'guide',           // current page: guide | search | favourites | settings
-    nowLineTimer: null,             // interval ID for the now-line updater
-    categories:    [],              // cached from /api/categories
-    searchResults: [],              // current search results
-    searchDebounce: null,           // debounce timer ID
-    selectedCategories: new Set(),  // currently selected category filters
-    favouriteSearches: loadFavouriteSearches(),  // saved search favourites from localStorage
-    favouriteResults: {},           // map of favourite ID → search results
-    favouriteResultsTime: 0,       // timestamp when favourites were last fetched
-};
+import { state } from './state.js';
+import { fetchChannels, fetchGuide, fetchCategories } from './api.js';
 
 // ── Preferences (localStorage) ───────────────────────────────────────────────
 
@@ -279,20 +263,6 @@ function hasAiringsStartingOn(airings, dateStr) {
     });
 }
 
-
-// ── API ───────────────────────────────────────────────────────────────────────
-
-async function fetchChannels() {
-    const res = await fetch('/api/channels');
-    if (!res.ok) throw new Error(`/api/channels returned ${res.status}`);
-    return res.json();
-}
-
-async function fetchGuide(dateStr) {
-    const res = await fetch(`/api/guide?date=${dateStr}`);
-    if (!res.ok) throw new Error(`/api/guide returned ${res.status}`);
-    return res.json();
-}
 
 // ── Channel ordering ──────────────────────────────────────────────────────────
 
@@ -601,14 +571,6 @@ function closeModal() {
 }
 
 // ── Search ───────────────────────────────────────────────────────────────────
-
-async function fetchCategories() {
-    if (state.categories.length > 0) return state.categories;
-    const res = await fetch('/api/categories');
-    if (!res.ok) throw new Error(`/api/categories returned ${res.status}`);
-    state.categories = await res.json();
-    return state.categories;
-}
 
 async function performSearch() {
     const input = document.getElementById('searchInput');
@@ -1014,6 +976,10 @@ function renderFavouriteResults() {
 // ── Initialisation ────────────────────────────────────────────────────────────
 
 async function init() {
+    // Populate localStorage-dependent state fields
+    state.prefs = loadPrefs();
+    state.favouriteSearches = loadFavouriteSearches();
+
     // Resolve the active page from the URL path
     const initialPage = getPageFromPath();
 

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -1,0 +1,20 @@
+// ── Application state ─────────────────────────────────────────────────────────
+//
+// State initializes with empty defaults. init() in main.js populates the
+// localStorage-dependent fields (prefs, favouriteSearches) and currentDate.
+
+export const state = {
+    channels:            [],
+    programmes:          [],
+    currentDate:         '',      // set by init() via getDateFromURL()
+    prefs:               { hidden: {}, favourites: {} },  // set by init() via loadPrefs()
+    activePage:          'guide', // current page: guide | search | favourites | settings
+    nowLineTimer:        null,    // interval ID for the now-line updater
+    categories:          [],      // cached from /api/categories
+    searchResults:       [],      // current search results
+    searchDebounce:      null,    // debounce timer ID
+    selectedCategories:  new Set(), // currently selected category filters
+    favouriteSearches:   [],      // set by init() via loadFavouriteSearches()
+    favouriteResults:    {},      // map of favourite ID → search results
+    favouriteResultsTime: 0,      // timestamp when favourites were last fetched
+};

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 const CACHE = 'tvguide-__CACHE_VERSION__';
-const STATIC = ['/', '/index.html', '/style.css', '/js/main.js', '/js/config.js', '/js/utils/date.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
+const STATIC = ['/', '/index.html', '/style.css', '/js/main.js', '/js/state.js', '/js/api.js', '/js/config.js', '/js/utils/date.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
 
 // SPA routes that should be served from the cached index.html
 const SPA_ROUTES = ['/guide', '/search', '/favourites', '/settings'];


### PR DESCRIPTION
## Summary
- Extracts the `state` singleton into `web/js/state.js` with empty defaults (localStorage-dependent fields populated in `init()`)
- Extracts `fetchChannels`, `fetchGuide`, and `fetchCategories` into `web/js/api.js`
- Updates `web/js/main.js` to import from the new modules and removes duplicated code
- Adds the new modules to the service worker pre-cache list in `web/sw.js`

## Test plan
- [ ] All Go tests pass (`go test ./...`)
- [ ] Build with Docker and verify the app loads correctly
- [ ] Test navigation between Guide, Search, Favourites, and Settings tabs
- [ ] Test search with simple and advanced modes, including category filtering
- [ ] Test channel preferences (hide/show, favourites)
- [ ] Test favourite searches (save, edit, delete)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)