### PR TITLE
Feat: add POST /api/debug/log endpoint (#95)

### DIFF
--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+)
+
+const maxDebugBodyBytes = 64 * 1024 // 64 KB
+
+type debugLogRequest struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	Source  string `json:"source"`
+	Lineno  int    `json:"lineno"`
+	Colno   int    `json:"colno"`
+	Stack   string `json:"stack"`
+	URL     string `json:"url"`
+}
+
+func (h *Handler) postDebugLog(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxDebugBodyBytes+1))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	if int64(len(body)) > maxDebugBodyBytes {
+		http.Error(w, "request body too large", http.StatusBadRequest)
+		return
+	}
+
+	var req debugLogRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("[client-error] type=%s message=%q source=%s lineno=%d colno=%d url=%s stack=%q",
+		req.Type, req.Message, req.Source, req.Lineno, req.Colno, req.URL, req.Stack)
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/debug_test.go
+++ b/internal/api/debug_test.go
@@ -1,0 +1,59 @@
+package api_test
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestPostDebugLog(t *testing.T) {
+	srv := newSeededServer(t)
+
+	t.Run("valid JSON body returns 204", func(t *testing.T) {
+		body := `{"type":"onerror","message":"something went wrong","source":"app.js","lineno":42,"colno":7,"stack":"Error: something\n    at app.js:42","url":"/guide"}`
+		resp, err := http.Post(srv.URL+"/api/debug/log", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Errorf("status = %d, want 204", resp.StatusCode)
+		}
+	})
+
+	t.Run("empty body returns 204", func(t *testing.T) {
+		resp, err := http.Post(srv.URL+"/api/debug/log", "application/json", bytes.NewReader([]byte("{}")))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Errorf("status = %d, want 204", resp.StatusCode)
+		}
+	})
+
+	t.Run("malformed JSON returns 400", func(t *testing.T) {
+		resp, err := http.Post(srv.URL+"/api/debug/log", "application/json", strings.NewReader("not-json"))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", resp.StatusCode)
+		}
+	})
+
+	t.Run("oversized body returns 400", func(t *testing.T) {
+		large := bytes.Repeat([]byte("x"), 65*1024)
+		body := append([]byte(`{"message":"`), append(large, []byte(`"}`)...)...)
+		resp, err := http.Post(srv.URL+"/api/debug/log", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", resp.StatusCode)
+		}
+	})
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -41,6 +41,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/search", h.getSearch)
 	mux.HandleFunc("GET /api/categories", h.getCategories)
 	mux.HandleFunc("GET /images/channel/{id}", h.serveChannelIcon)
+	mux.HandleFunc("POST /api/debug/log", h.postDebugLog)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {


### PR DESCRIPTION
## Summary
- Adds `POST /api/debug/log` endpoint to capture JavaScript errors from the frontend
- Logs structured output as `[client-error]` lines visible via `docker logs`
- Rejects payloads exceeding 64 KB and malformed JSON with 400; returns 204 on success

## Test plan
- [x] Valid JSON body returns 204
- [x] Empty JSON body (`{}`) returns 204
- [x] Malformed JSON returns 400
- [x] Oversized body (>64 KB) returns 400
- [x] Full test suite passes

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)