### PR TITLE
Feat: wire frontend JS errors to /api/debug/log (closes #96)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1132,6 +1132,60 @@ func TestIntegration_FavouritesPage_JSFunctions(t *testing.T) {
 	}
 }
 
+// TestIntegration_ErrorLogging_JSFunctions verifies that the frontend error
+// logging plumbing is in place: logError exported from api.js, global handlers
+// registered in main.js, and all catch sites wired to logError.
+func TestIntegration_ErrorLogging_JSFunctions(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	fetchBody := func(path string) string {
+		t.Helper()
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		defer resp.Body.Close()
+		var buf strings.Builder
+		io.Copy(&buf, resp.Body) //nolint:errcheck
+		return buf.String()
+	}
+
+	apiJS := fetchBody("/js/api.js")
+	mainJS := fetchBody("/js/main.js")
+
+	// api.js must export logError
+	if !strings.Contains(apiJS, "export function logError") {
+		t.Error("expected api.js to export logError")
+	}
+	if !strings.Contains(apiJS, "/api/debug/log") {
+		t.Error("expected api.js logError to POST to /api/debug/log")
+	}
+
+	// main.js must import logError from api.js
+	if !strings.Contains(mainJS, "logError") {
+		t.Error("expected main.js to import and use logError")
+	}
+
+	// Global error handlers must be registered
+	if !strings.Contains(mainJS, "window.onerror") {
+		t.Error("expected main.js to register window.onerror handler")
+	}
+	if !strings.Contains(mainJS, "unhandledrejection") {
+		t.Error("expected main.js to register unhandledrejection handler")
+	}
+
+	// All explicit catch sites must call logError with type: 'explicit'
+	if strings.Count(mainJS, "type: 'explicit'") < 4 {
+		t.Errorf("expected at least 4 explicit logError calls in main.js (guide load, search, favourite search, categories), got %d",
+			strings.Count(mainJS, "type: 'explicit'"))
+	}
+}
+
 // TestIntegration_SPAFallback_GuidePathReturnsHTML verifies that GET /guide
 // returns index.html content (SPA fallback).
 func TestIntegration_SPAFallback_GuidePathReturnsHTML(t *testing.T) {

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -21,3 +21,11 @@ export async function fetchCategories() {
     state.categories = await res.json();
     return state.categories;
 }
+
+export function logError({ type, message, source, lineno, colno, stack, url }) {
+    fetch('/api/debug/log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type, message, source, lineno, colno, stack, url }),
+    }).catch(() => {}); // never throw from the error logger
+}

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,9 +1,21 @@
 import { CONFIG } from './config.js';
 import { getTodayString, dateMidnight, formatTime, formatDateLong, minutesToHHMM, addDays, formatSearchDate } from './utils/date.js';
 import { state } from './state.js';
-import { fetchChannels, fetchGuide, fetchCategories } from './api.js';
+import { fetchChannels, fetchGuide, fetchCategories, logError } from './api.js';
 import { loadPrefs, isHidden, isFavourite, toggleHidden, toggleFavourite } from './store/preferences.js';
 import { loadFavouriteSearches, addFavouriteSearch, removeFavouriteSearch, findMatchingFavourite } from './store/favourites.js';
+
+window.onerror = (message, source, lineno, colno, error) => {
+    logError({ type: 'onerror', message: String(message), source, lineno, colno,
+                stack: error?.stack, url: location.href });
+};
+
+window.addEventListener('unhandledrejection', event => {
+    const err = event.reason;
+    logError({ type: 'unhandledrejection',
+                message: err instanceof Error ? err.message : String(err),
+                stack: err?.stack, url: location.href });
+});
 
 function showError(message) {
     console.error(message);
@@ -111,6 +123,7 @@ function navigateToPage(page, { pushState = true } = {}) {
     if (page === 'search') {
         fetchCategories().then(renderCategoryChips).catch(err => {
             console.error('Failed to load categories:', err);
+            logError({ type: 'explicit', message: err.message, stack: err?.stack, url: location.href });
         });
     }
 
@@ -541,6 +554,7 @@ async function performSearch() {
         renderSearchResults();
     } catch (err) {
         showError(`Search failed: ${err.message}`);
+        logError({ type: 'explicit', message: err.message, stack: err?.stack, url: location.href });
         document.getElementById('searchResults').innerHTML =
             `<div class="search-empty">Search failed: ${err.message}</div>`;
     } finally {
@@ -771,6 +785,7 @@ async function executeFavouriteSearches() {
             renderFavouriteResults();
         } catch (err) {
             showError(`Favourite search "${fav.name}" failed: ${err.message}`);
+            logError({ type: 'explicit', message: err.message, stack: err?.stack, url: location.href });
             state.favouriteResults[fav.id] = { error: err.message };
         }
     });
@@ -974,6 +989,7 @@ async function init() {
 
     } catch (err) {
         showError(`Failed to load guide data: ${err.message}`);
+        logError({ type: 'explicit', message: err.message, stack: err?.stack, url: location.href });
         document.getElementById('loadingText').textContent =
             `Failed to load guide data. Is the server running?\n${err.message}`;
         return; // leave loading screen visible as an error state


### PR DESCRIPTION
## Summary

- Adds `logError()` helper to `api.js` that fire-and-forgets a POST to `/api/debug/log`
- Registers `window.onerror` and `unhandledrejection` global handlers in `main.js` so all uncaught JS errors are submitted to the server
- Wires all four explicit catch sites (guide load, search, favourite search, categories) to also call `logError` with `type: 'explicit'`
- Adds `TestIntegration_ErrorLogging_JSFunctions` to verify the plumbing is in place

Closes #96

## Test plan

- [x] `TestIntegration_ErrorLogging_JSFunctions` passes — verifies `logError` export, global handlers, and 4 explicit call sites
- [x] All existing tests pass (`go test ./...`)
- [ ] Full browser-based UI tests deferred to #97 (Playwright setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)