### PR TITLE
Refactor: extract programme detail modal component (#77)

### DIFF
--- a/web/js/components/modal.js
+++ b/web/js/components/modal.js
@@ -1,0 +1,68 @@
+import { formatTime } from '../utils/date.js';
+
+// ── Programme details modal ───────────────────────────────────────────────────
+
+export function openProgrammeModal(prog) {
+    const start = new Date(prog.start);
+    const stop  = new Date(prog.stop);
+
+    // Meta row: category · rating · year
+    document.getElementById('modalCategory').textContent = prog.categories?.join(', ') ?? '';
+    document.getElementById('modalRating').textContent   = prog.contentRating ?? '';
+    document.getElementById('modalYear').textContent     = prog.year ?? '';
+    setVisible('modalRating', !!prog.contentRating);
+    setVisible('modalYear',   !!prog.year);
+
+    document.getElementById('modalTitle').textContent = prog.title;
+    document.getElementById('modalTime').textContent  = `${formatTime(start)} – ${formatTime(stop)}`;
+
+    // Episode number (prefer human-readable display format, fall back to xmltv_ns)
+    const epNum = prog.episodeNumDisplay || prog.episodeNum || '';
+    document.getElementById('modalEpisode').textContent = epNum;
+    setVisible('modalEpisode', !!epNum);
+
+    document.getElementById('modalSubtitle').textContent = prog.subTitle ?? '';
+    setVisible('modalSubtitle', !!prog.subTitle);
+
+    // Badges: Repeat / Premiere / Star rating
+    const badges = document.getElementById('modalBadges');
+    badges.innerHTML = '';
+    if (prog.isRepeat)   addBadge(badges, 'Repeat');
+    if (prog.isPremiere) addBadge(badges, 'Premiere');
+    if (prog.starRating) addBadge(badges, prog.starRating);
+
+    document.getElementById('modalDesc').textContent = prog.description || 'No description available.';
+
+    document.getElementById('modalBackdrop').classList.add('open');
+}
+
+export function openSearchAiringModal(airing, title) {
+    // Adapt the search airing shape to the programme shape used by openProgrammeModal
+    const prog = {
+        title:             title,
+        start:             airing.startTime,
+        stop:              airing.stopTime,
+        subTitle:          airing.subTitle,
+        description:       airing.description,
+        categories:        airing.categories,
+        episodeNumDisplay: airing.episodeNumDisplay,
+        isRepeat:          airing.isRepeat,
+        isPremiere:        airing.isPremiere,
+    };
+    openProgrammeModal(prog);
+}
+
+export function closeModal() {
+    document.getElementById('modalBackdrop').classList.remove('open');
+}
+
+function setVisible(id, visible) {
+    document.getElementById(id).style.display = visible ? '' : 'none';
+}
+
+function addBadge(container, text) {
+    const b = document.createElement('span');
+    b.className   = 'badge';
+    b.textContent = text;
+    container.appendChild(b);
+}

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -4,6 +4,7 @@ import { state } from './state.js';
 import { fetchChannels, fetchGuide, fetchCategories, logError } from './api.js';
 import { loadPrefs, isHidden, isFavourite, toggleHidden, toggleFavourite } from './store/preferences.js';
 import { loadFavouriteSearches, addFavouriteSearch, removeFavouriteSearch, findMatchingFavourite } from './store/favourites.js';
+import { openProgrammeModal, openSearchAiringModal, closeModal } from './components/modal.js';
 
 window.onerror = (message, source, lineno, colno, error) => {
     logError({ type: 'onerror', message: String(message), source, lineno, colno,
@@ -458,57 +459,6 @@ function renderSettingsPanel() {
     }
 }
 
-// ── Programme details modal ───────────────────────────────────────────────────
-
-function openProgrammeModal(prog) {
-    const start = new Date(prog.start);
-    const stop  = new Date(prog.stop);
-
-    // Meta row: category · rating · year
-    document.getElementById('modalCategory').textContent = prog.categories?.join(', ') ?? '';
-    document.getElementById('modalRating').textContent   = prog.contentRating ?? '';
-    document.getElementById('modalYear').textContent     = prog.year ?? '';
-    setVisible('modalRating', !!prog.contentRating);
-    setVisible('modalYear',   !!prog.year);
-
-    document.getElementById('modalTitle').textContent = prog.title;
-    document.getElementById('modalTime').textContent  = `${formatTime(start)} – ${formatTime(stop)}`;
-
-    // Episode number (prefer human-readable display format, fall back to xmltv_ns)
-    const epNum = prog.episodeNumDisplay || prog.episodeNum || '';
-    document.getElementById('modalEpisode').textContent = epNum;
-    setVisible('modalEpisode', !!epNum);
-
-    document.getElementById('modalSubtitle').textContent = prog.subTitle ?? '';
-    setVisible('modalSubtitle', !!prog.subTitle);
-
-    // Badges: Repeat / Premiere / Star rating
-    const badges = document.getElementById('modalBadges');
-    badges.innerHTML = '';
-    if (prog.isRepeat)   addBadge(badges, 'Repeat');
-    if (prog.isPremiere) addBadge(badges, 'Premiere');
-    if (prog.starRating) addBadge(badges, prog.starRating);
-
-    document.getElementById('modalDesc').textContent = prog.description || 'No description available.';
-
-    document.getElementById('modalBackdrop').classList.add('open');
-}
-
-function setVisible(id, visible) {
-    document.getElementById(id).style.display = visible ? '' : 'none';
-}
-
-function addBadge(container, text) {
-    const b = document.createElement('span');
-    b.className   = 'badge';
-    b.textContent = text;
-    container.appendChild(b);
-}
-
-function closeModal() {
-    document.getElementById('modalBackdrop').classList.remove('open');
-}
-
 // ── Search ───────────────────────────────────────────────────────────────────
 
 async function performSearch() {
@@ -662,22 +612,6 @@ function renderSearchResults() {
 
         container.appendChild(groupEl);
     }
-}
-
-function openSearchAiringModal(airing, title) {
-    // Adapt the search airing shape to the programme shape used by openProgrammeModal
-    const prog = {
-        title:             title,
-        start:             airing.startTime,
-        stop:              airing.stopTime,
-        subTitle:          airing.subTitle,
-        description:       airing.description,
-        categories:        airing.categories,
-        episodeNumDisplay: airing.episodeNumDisplay,
-        isRepeat:          airing.isRepeat,
-        isPremiere:        airing.isPremiere,
-    };
-    openProgrammeModal(prog);
 }
 
 function renderCategoryChips() {

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 const CACHE = 'tvguide-__CACHE_VERSION__';
-const STATIC = ['/', '/index.html', '/style.css', '/js/main.js', '/js/state.js', '/js/api.js', '/js/config.js', '/js/utils/date.js', '/js/store/preferences.js', '/js/store/favourites.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
+const STATIC = ['/', '/index.html', '/style.css', '/js/main.js', '/js/state.js', '/js/api.js', '/js/config.js', '/js/utils/date.js', '/js/store/preferences.js', '/js/store/favourites.js', '/js/components/modal.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
 
 // SPA routes that should be served from the cached index.html
 const SPA_ROUTES = ['/guide', '/search', '/favourites', '/settings'];


### PR DESCRIPTION
## Summary
- Extracts `openProgrammeModal`, `openSearchAiringModal`, `closeModal`, and private helpers (`setVisible`, `addBadge`) from `main.js` into `web/js/components/modal.js`
- Updates `main.js` to import the three public functions from the new module
- Adds `/js/components/modal.js` to the service worker pre-cache list

## Test plan
- [ ] Open the Guide tab and click a programme cell — modal opens with correct content
- [ ] Open the Search tab, search for a show, and click a result — modal opens correctly
- [ ] Open the Favourites tab and click an airing — modal opens correctly
- [ ] Modal closes via the close button and clicking outside
- [ ] No console errors on any tab

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)