### PR TITLE
Refactor: extract search page module into web/js/pages/search.js (#79)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -587,6 +587,67 @@ func TestIntegration_Navigation_JSFunctions(t *testing.T) {
 	}
 }
 
+// TestIntegration_Search_JSFunctions verifies that the search page module
+// and main.js together export the functions required for search functionality.
+func TestIntegration_Search_JSFunctions(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	// Check pages/search.js is served and defines the expected functions
+	resp, err := http.Get(srv.URL + "/js/pages/search.js")
+	if err != nil {
+		t.Fatalf("GET /js/pages/search.js: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /js/pages/search.js: expected 200, got %d", resp.StatusCode)
+	}
+
+	var buf strings.Builder
+	io.Copy(&buf, resp.Body) //nolint:errcheck
+	searchBody := buf.String()
+
+	for _, fn := range []string{"setupSearchPage", "triggerSearch", "renderCategoryChips", "getCurrentSearchConfig"} {
+		if !strings.Contains(searchBody, fn) {
+			t.Errorf("expected js/pages/search.js to define %s", fn)
+		}
+	}
+
+	// Check main.js imports from search.js and no longer defines these functions directly
+	resp2, err := http.Get(srv.URL + "/js/main.js")
+	if err != nil {
+		t.Fatalf("GET /js/main.js: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	var buf2 strings.Builder
+	io.Copy(&buf2, resp2.Body) //nolint:errcheck
+	mainBody := buf2.String()
+
+	if !strings.Contains(mainBody, "pages/search.js") {
+		t.Error("expected js/main.js to import from pages/search.js")
+	}
+
+	// Check that search.js is listed in the service worker cache
+	resp3, err := http.Get(srv.URL + "/sw.js")
+	if err != nil {
+		t.Fatalf("GET /sw.js: %v", err)
+	}
+	defer resp3.Body.Close()
+
+	var buf3 strings.Builder
+	io.Copy(&buf3, resp3.Body) //nolint:errcheck
+	swBody := buf3.String()
+
+	if !strings.Contains(swBody, "pages/search.js") {
+		t.Error("expected sw.js to include js/pages/search.js in the cache list")
+	}
+}
+
 func TestIntegration_ChannelIconProxy(t *testing.T) {
 	// Mock server serves both XMLTV data and icon images.
 	iconRequests := 0
@@ -958,8 +1019,8 @@ func TestIntegration_SearchPage_HTMLElements(t *testing.T) {
 	}
 }
 
-// TestIntegration_SearchPage_JSFunctions verifies that js/main.js contains
-// the functions required for the search UI.
+// TestIntegration_SearchPage_JSFunctions verifies that the search page module
+// and main.js together contain the functions required for the search UI.
 func TestIntegration_SearchPage_JSFunctions(t *testing.T) {
 	xmlBytes, err := os.ReadFile("testdata/sample.xml")
 	if err != nil {
@@ -968,33 +1029,44 @@ func TestIntegration_SearchPage_JSFunctions(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/js/main.js")
-	if err != nil {
-		t.Fatalf("GET /js/main.js: %v", err)
+	fetchBody := func(path string) string {
+		t.Helper()
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		defer resp.Body.Close()
+		var buf strings.Builder
+		io.Copy(&buf, resp.Body) //nolint:errcheck
+		return buf.String()
 	}
-	defer resp.Body.Close()
 
-	var buf strings.Builder
-	io.Copy(&buf, resp.Body) //nolint:errcheck
-	body := buf.String()
+	searchJS := fetchBody("/js/pages/search.js")
+	mainJS := fetchBody("/js/main.js")
 
+	// Search-specific functions live in pages/search.js
 	for _, fn := range []string{
 		"performSearch",
 		"fetchCategories",
 		"renderSearchResults",
 		"formatSearchDate",
 	} {
-		if !strings.Contains(body, fn) {
-			t.Errorf("expected js/main.js to define %s", fn)
+		if !strings.Contains(searchJS, fn) {
+			t.Errorf("expected js/pages/search.js to define %s", fn)
 		}
 	}
 
-	// Verify state additions
-	if !strings.Contains(body, "state.categories") {
-		t.Error("expected state.categories in js/main.js")
+	// State additions are referenced in pages/search.js
+	if !strings.Contains(searchJS, "state.categories") {
+		t.Error("expected state.categories in js/pages/search.js")
 	}
-	if !strings.Contains(body, "state.searchResults") {
-		t.Error("expected state.searchResults in js/main.js")
+	if !strings.Contains(searchJS, "state.searchResults") {
+		t.Error("expected state.searchResults in js/pages/search.js")
+	}
+
+	// main.js imports from search.js
+	if !strings.Contains(mainJS, "pages/search.js") {
+		t.Error("expected js/main.js to import from pages/search.js")
 	}
 }
 
@@ -1197,10 +1269,14 @@ func TestIntegration_ErrorLogging_JSFunctions(t *testing.T) {
 		t.Error("expected main.js to register unhandledrejection handler")
 	}
 
-	// All explicit catch sites must call logError with type: 'explicit'
-	if strings.Count(mainJS, "type: 'explicit'") < 4 {
-		t.Errorf("expected at least 4 explicit logError calls in main.js (guide load, search, favourite search, categories), got %d",
-			strings.Count(mainJS, "type: 'explicit'"))
+	searchJS := fetchBody("/js/pages/search.js")
+
+	// All explicit catch sites must call logError with type: 'explicit'.
+	// These are now split: guide load + favourite search in main.js,
+	// search fetch + categories in search.js.
+	totalExplicit := strings.Count(mainJS, "type: 'explicit'") + strings.Count(searchJS, "type: 'explicit'")
+	if totalExplicit < 4 {
+		t.Errorf("expected at least 4 explicit logError calls across main.js and search.js (guide load, search, favourite search, categories), got %d", totalExplicit)
 	}
 }
 

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -2,7 +2,7 @@ import { getTodayString, addDays, formatDateLong, formatSearchDate } from './uti
 import { state } from './state.js';
 import { fetchChannels, fetchGuide, fetchCategories, logError } from './api.js';
 import { loadPrefs, isHidden, isFavourite, toggleHidden, toggleFavourite } from './store/preferences.js';
-import { loadFavouriteSearches, addFavouriteSearch, removeFavouriteSearch, findMatchingFavourite } from './store/favourites.js';
+import { loadFavouriteSearches, removeFavouriteSearch } from './store/favourites.js';
 import { openSearchAiringModal, closeModal } from './components/modal.js';
 import {
     renderGuide, renderTimeAxis, setupScrollSync, scrollToNow,
@@ -10,6 +10,10 @@ import {
     navigateToDate, hasAiringsStartingOn,
     getDateFromURL,
 } from './pages/guide.js';
+import {
+    setupSearchPage, triggerSearch, renderCategoryChips, getCurrentSearchConfig,
+    loadSearchPageCategories,
+} from './pages/search.js';
 
 window.onerror = (message, source, lineno, colno, error) => {
     logError({ type: 'onerror', message: String(message), source, lineno, colno,
@@ -25,23 +29,6 @@ window.addEventListener('unhandledrejection', event => {
 
 function showError(message) {
     console.error(message);
-}
-
-function getCurrentSearchConfig() {
-    const q = document.getElementById('searchInput').value.trim();
-    const useAdvanced = document.getElementById('searchDescriptions').checked;
-    const includePast = document.getElementById('includePast').checked;
-    const hideRepeats = document.getElementById('hideRepeats').checked;
-    const categories = [...state.selectedCategories];
-
-    const hasAdvanced = useAdvanced || categories.length > 0;
-    return {
-        query: q,
-        mode: hasAdvanced ? 'advanced' : 'simple',
-        categories: categories,
-        includePast: includePast,
-        includeRepeats: !hideRepeats,
-    };
 }
 
 function editFavouriteSearch(id) {
@@ -127,10 +114,7 @@ function navigateToPage(page, { pushState = true } = {}) {
 
     // Load categories when entering search page
     if (page === 'search') {
-        fetchCategories().then(renderCategoryChips).catch(err => {
-            console.error('Failed to load categories:', err);
-            logError({ type: 'explicit', message: err.message, stack: err?.stack, url: location.href });
-        });
+        loadSearchPageCategories();
     }
 
     // Load favourites when entering favourites page
@@ -185,211 +169,6 @@ function renderSettingsPanel() {
         item.appendChild(hideBtn);
         list.appendChild(item);
     }
-}
-
-// ── Search ───────────────────────────────────────────────────────────────────
-
-async function performSearch() {
-    const input = document.getElementById('searchInput');
-    const q = input.value.trim();
-
-    if (q.length < 2) {
-        state.searchResults = [];
-        document.getElementById('searchResults').innerHTML = '';
-        document.getElementById('searchHint').style.display = q.length > 0 ? '' : '';
-        document.getElementById('searchHint').textContent = 'Enter at least 2 characters to search';
-        return;
-    }
-
-    document.getElementById('searchHint').style.display = 'none';
-    document.getElementById('searchSpinner').classList.add('visible');
-
-    const params = new URLSearchParams({ q });
-    const useAdvanced = document.getElementById('searchDescriptions').checked;
-    const includePast = document.getElementById('includePast').checked;
-    const hideRepeats = document.getElementById('hideRepeats').checked;
-
-    if (useAdvanced) {
-        params.set('mode', 'advanced');
-    }
-    if (includePast) {
-        params.set('include_past', 'true');
-    }
-    if (hideRepeats) {
-        params.set('include_repeats', 'false');
-    }
-    if (state.selectedCategories.size > 0) {
-        // Category filtering requires advanced mode
-        params.set('mode', 'advanced');
-        params.set('categories', [...state.selectedCategories].join(','));
-        if (!includePast) params.delete('include_past');
-    }
-
-    try {
-        const res = await fetch('/api/search?' + params);
-        if (!res.ok) throw new Error(`/api/search returned ${res.status}`);
-        state.searchResults = await res.json();
-        renderSearchResults();
-    } catch (err) {
-        showError(`Search failed: ${err.message}`);
-        logError({ type: 'explicit', message: err.message, stack: err?.stack, url: location.href });
-        document.getElementById('searchResults').innerHTML =
-            `<div class="search-empty">Search failed: ${err.message}</div>`;
-    } finally {
-        document.getElementById('searchSpinner').classList.remove('visible');
-    }
-}
-
-function triggerSearch() {
-    clearTimeout(state.searchDebounce);
-    state.searchDebounce = setTimeout(performSearch, 300);
-}
-
-function renderSearchResults() {
-    const container = document.getElementById('searchResults');
-    container.innerHTML = '';
-
-    // Build a channel name lookup from state.channels
-    const channelMap = {};
-    for (const ch of state.channels) {
-        channelMap[ch.id] = ch;
-    }
-
-    // Filter out hidden channels
-    const filtered = [];
-    for (const group of state.searchResults) {
-        const visibleAirings = group.airings.filter(a => !isHidden(a.channelId));
-        if (visibleAirings.length > 0) {
-            filtered.push({ title: group.title, airings: visibleAirings });
-        }
-    }
-
-    if (filtered.length === 0) {
-        container.innerHTML = '<div class="search-empty">No programmes found</div>';
-        return;
-    }
-
-    for (const group of filtered) {
-        const groupEl = document.createElement('div');
-        groupEl.className = 'search-group';
-
-        // Title heading with favourite star
-        const header = document.createElement('div');
-        header.className = 'search-group-header';
-
-        const titleEl = document.createElement('h3');
-        titleEl.className = 'search-group-title';
-        titleEl.textContent = group.title;
-        header.appendChild(titleEl);
-
-        const starBtn = document.createElement('button');
-        starBtn.className = 'search-fav-btn';
-        const config = getCurrentSearchConfig();
-        const existingFav = findMatchingFavourite(config.query, config.mode, config.categories);
-        starBtn.textContent = existingFav ? '\u2605' : '\u2606'; // ★ or ☆
-        starBtn.classList.toggle('active', !!existingFav);
-        starBtn.title = existingFav ? 'Remove from favourites' : 'Save as favourite';
-        starBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            const cfg = getCurrentSearchConfig();
-            const match = findMatchingFavourite(cfg.query, cfg.mode, cfg.categories);
-            if (match) {
-                removeFavouriteSearch(match.id);
-                starBtn.textContent = '\u2606';
-                starBtn.classList.remove('active');
-                starBtn.title = 'Save as favourite';
-            } else {
-                addFavouriteSearch(cfg);
-                starBtn.textContent = '\u2605';
-                starBtn.classList.add('active');
-                starBtn.title = 'Remove from favourites';
-            }
-        });
-        header.appendChild(starBtn);
-
-        groupEl.appendChild(header);
-
-        // Airings list
-        for (const airing of group.airings) {
-            const airingEl = document.createElement('div');
-            airingEl.className = 'search-airing';
-            airingEl.addEventListener('click', () => openSearchAiringModal(airing, group.title));
-
-            const channelEl = document.createElement('span');
-            channelEl.className = 'search-airing-channel';
-            channelEl.textContent = airing.channelName || airing.channelId;
-            airingEl.appendChild(channelEl);
-
-            const timeEl = document.createElement('span');
-            timeEl.className = 'search-airing-time';
-            timeEl.textContent = formatSearchDate(new Date(airing.startTime));
-            airingEl.appendChild(timeEl);
-
-            if (airing.episodeNumDisplay || airing.subTitle) {
-                const epEl = document.createElement('span');
-                epEl.className = 'search-airing-episode';
-                const parts = [];
-                if (airing.episodeNumDisplay) parts.push(airing.episodeNumDisplay);
-                if (airing.subTitle) parts.push(airing.subTitle);
-                epEl.textContent = parts.join(' - ');
-                airingEl.appendChild(epEl);
-            }
-
-            groupEl.appendChild(airingEl);
-        }
-
-        container.appendChild(groupEl);
-    }
-}
-
-function renderCategoryChips() {
-    const container = document.getElementById('categoryChips');
-    container.innerHTML = '';
-    for (const cat of state.categories) {
-        const chip = document.createElement('button');
-        chip.className = 'category-chip' + (state.selectedCategories.has(cat) ? ' selected' : '');
-        chip.textContent = cat;
-        chip.addEventListener('click', () => {
-            if (state.selectedCategories.has(cat)) {
-                state.selectedCategories.delete(cat);
-            } else {
-                state.selectedCategories.add(cat);
-            }
-            chip.classList.toggle('selected');
-            triggerSearch();
-        });
-        container.appendChild(chip);
-    }
-}
-
-function setupSearchPage() {
-    const input = document.getElementById('searchInput');
-    const clearBtn = document.getElementById('searchClear');
-    const advToggle = document.getElementById('advancedToggle');
-    const advPanel = document.getElementById('advancedOptions');
-
-    input.addEventListener('input', triggerSearch);
-
-    clearBtn.addEventListener('click', () => {
-        input.value = '';
-        state.searchResults = [];
-        state.selectedCategories.clear();
-        document.getElementById('searchResults').innerHTML = '';
-        document.getElementById('searchHint').style.display = '';
-        document.getElementById('searchHint').textContent = 'Enter at least 2 characters to search';
-        renderCategoryChips();
-    });
-
-    advToggle.addEventListener('click', () => {
-        const isOpen = advPanel.style.display !== 'none';
-        advPanel.style.display = isOpen ? 'none' : '';
-        advToggle.classList.toggle('open', !isOpen);
-    });
-
-    // Checkboxes re-trigger search
-    document.getElementById('searchDescriptions').addEventListener('change', triggerSearch);
-    document.getElementById('includePast').addEventListener('change', triggerSearch);
-    document.getElementById('hideRepeats').addEventListener('change', triggerSearch);
 }
 
 // ── Favourites page ─────────────────────────────────────────────────────────

--- a/web/js/pages/search.js
+++ b/web/js/pages/search.js
@@ -1,0 +1,229 @@
+import { formatSearchDate } from '../utils/date.js';
+import { state } from '../state.js';
+import { fetchCategories, logError } from '../api.js';
+import { isHidden } from '../store/preferences.js';
+import { addFavouriteSearch, removeFavouriteSearch, findMatchingFavourite } from '../store/favourites.js';
+import { openSearchAiringModal } from '../components/modal.js';
+
+// ── Search ───────────────────────────────────────────────────────────────────
+
+export function getCurrentSearchConfig() {
+    const q = document.getElementById('searchInput').value.trim();
+    const useAdvanced = document.getElementById('searchDescriptions').checked;
+    const includePast = document.getElementById('includePast').checked;
+    const hideRepeats = document.getElementById('hideRepeats').checked;
+    const categories = [...state.selectedCategories];
+
+    const hasAdvanced = useAdvanced || categories.length > 0;
+    return {
+        query: q,
+        mode: hasAdvanced ? 'advanced' : 'simple',
+        categories: categories,
+        includePast: includePast,
+        includeRepeats: !hideRepeats,
+    };
+}
+
+async function performSearch() {
+    const input = document.getElementById('searchInput');
+    const q = input.value.trim();
+
+    if (q.length < 2) {
+        state.searchResults = [];
+        document.getElementById('searchResults').innerHTML = '';
+        document.getElementById('searchHint').style.display = q.length > 0 ? '' : '';
+        document.getElementById('searchHint').textContent = 'Enter at least 2 characters to search';
+        return;
+    }
+
+    document.getElementById('searchHint').style.display = 'none';
+    document.getElementById('searchSpinner').classList.add('visible');
+
+    const params = new URLSearchParams({ q });
+    const useAdvanced = document.getElementById('searchDescriptions').checked;
+    const includePast = document.getElementById('includePast').checked;
+    const hideRepeats = document.getElementById('hideRepeats').checked;
+
+    if (useAdvanced) {
+        params.set('mode', 'advanced');
+    }
+    if (includePast) {
+        params.set('include_past', 'true');
+    }
+    if (hideRepeats) {
+        params.set('include_repeats', 'false');
+    }
+    if (state.selectedCategories.size > 0) {
+        // Category filtering requires advanced mode
+        params.set('mode', 'advanced');
+        params.set('categories', [...state.selectedCategories].join(','));
+        if (!includePast) params.delete('include_past');
+    }
+
+    try {
+        const res = await fetch('/api/search?' + params);
+        if (!res.ok) throw new Error(`/api/search returned ${res.status}`);
+        state.searchResults = await res.json();
+        renderSearchResults();
+    } catch (err) {
+        console.error(`Search failed: ${err.message}`);
+        logError({ type: 'explicit', message: err.message, stack: err?.stack, url: location.href });
+        document.getElementById('searchResults').innerHTML =
+            `<div class="search-empty">Search failed: ${err.message}</div>`;
+    } finally {
+        document.getElementById('searchSpinner').classList.remove('visible');
+    }
+}
+
+export function triggerSearch() {
+    clearTimeout(state.searchDebounce);
+    state.searchDebounce = setTimeout(performSearch, 300);
+}
+
+function renderSearchResults() {
+    const container = document.getElementById('searchResults');
+    container.innerHTML = '';
+
+    // Filter out hidden channels
+    const filtered = [];
+    for (const group of state.searchResults) {
+        const visibleAirings = group.airings.filter(a => !isHidden(a.channelId));
+        if (visibleAirings.length > 0) {
+            filtered.push({ title: group.title, airings: visibleAirings });
+        }
+    }
+
+    if (filtered.length === 0) {
+        container.innerHTML = '<div class="search-empty">No programmes found</div>';
+        return;
+    }
+
+    for (const group of filtered) {
+        const groupEl = document.createElement('div');
+        groupEl.className = 'search-group';
+
+        // Title heading with favourite star
+        const header = document.createElement('div');
+        header.className = 'search-group-header';
+
+        const titleEl = document.createElement('h3');
+        titleEl.className = 'search-group-title';
+        titleEl.textContent = group.title;
+        header.appendChild(titleEl);
+
+        const starBtn = document.createElement('button');
+        starBtn.className = 'search-fav-btn';
+        const config = getCurrentSearchConfig();
+        const existingFav = findMatchingFavourite(config.query, config.mode, config.categories);
+        starBtn.textContent = existingFav ? '\u2605' : '\u2606'; // ★ or ☆
+        starBtn.classList.toggle('active', !!existingFav);
+        starBtn.title = existingFav ? 'Remove from favourites' : 'Save as favourite';
+        starBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const cfg = getCurrentSearchConfig();
+            const match = findMatchingFavourite(cfg.query, cfg.mode, cfg.categories);
+            if (match) {
+                removeFavouriteSearch(match.id);
+                starBtn.textContent = '\u2606';
+                starBtn.classList.remove('active');
+                starBtn.title = 'Save as favourite';
+            } else {
+                addFavouriteSearch(cfg);
+                starBtn.textContent = '\u2605';
+                starBtn.classList.add('active');
+                starBtn.title = 'Remove from favourites';
+            }
+        });
+        header.appendChild(starBtn);
+
+        groupEl.appendChild(header);
+
+        // Airings list
+        for (const airing of group.airings) {
+            const airingEl = document.createElement('div');
+            airingEl.className = 'search-airing';
+            airingEl.addEventListener('click', () => openSearchAiringModal(airing, group.title));
+
+            const channelEl = document.createElement('span');
+            channelEl.className = 'search-airing-channel';
+            channelEl.textContent = airing.channelName || airing.channelId;
+            airingEl.appendChild(channelEl);
+
+            const timeEl = document.createElement('span');
+            timeEl.className = 'search-airing-time';
+            timeEl.textContent = formatSearchDate(new Date(airing.startTime));
+            airingEl.appendChild(timeEl);
+
+            if (airing.episodeNumDisplay || airing.subTitle) {
+                const epEl = document.createElement('span');
+                epEl.className = 'search-airing-episode';
+                const parts = [];
+                if (airing.episodeNumDisplay) parts.push(airing.episodeNumDisplay);
+                if (airing.subTitle) parts.push(airing.subTitle);
+                epEl.textContent = parts.join(' - ');
+                airingEl.appendChild(epEl);
+            }
+
+            groupEl.appendChild(airingEl);
+        }
+
+        container.appendChild(groupEl);
+    }
+}
+
+export function renderCategoryChips() {
+    const container = document.getElementById('categoryChips');
+    container.innerHTML = '';
+    for (const cat of state.categories) {
+        const chip = document.createElement('button');
+        chip.className = 'category-chip' + (state.selectedCategories.has(cat) ? ' selected' : '');
+        chip.textContent = cat;
+        chip.addEventListener('click', () => {
+            if (state.selectedCategories.has(cat)) {
+                state.selectedCategories.delete(cat);
+            } else {
+                state.selectedCategories.add(cat);
+            }
+            chip.classList.toggle('selected');
+            triggerSearch();
+        });
+        container.appendChild(chip);
+    }
+}
+
+export function setupSearchPage() {
+    const input = document.getElementById('searchInput');
+    const clearBtn = document.getElementById('searchClear');
+    const advToggle = document.getElementById('advancedToggle');
+    const advPanel = document.getElementById('advancedOptions');
+
+    input.addEventListener('input', triggerSearch);
+
+    clearBtn.addEventListener('click', () => {
+        input.value = '';
+        state.searchResults = [];
+        state.selectedCategories.clear();
+        document.getElementById('searchResults').innerHTML = '';
+        document.getElementById('searchHint').style.display = '';
+        document.getElementById('searchHint').textContent = 'Enter at least 2 characters to search';
+        renderCategoryChips();
+    });
+
+    advToggle.addEventListener('click', () => {
+        const isOpen = advPanel.style.display !== 'none';
+        advPanel.style.display = isOpen ? 'none' : '';
+        advToggle.classList.toggle('open', !isOpen);
+    });
+
+    // Checkboxes re-trigger search
+    document.getElementById('searchDescriptions').addEventListener('change', triggerSearch);
+    document.getElementById('includePast').addEventListener('change', triggerSearch);
+    document.getElementById('hideRepeats').addEventListener('change', triggerSearch);
+}
+
+export function loadSearchPageCategories() {
+    return fetchCategories().then(renderCategoryChips).catch(err => {
+        console.error('Failed to load categories:', err);
+        logError({ type: 'explicit', message: err.message, stack: err?.stack, url: location.href });
+    });
+}

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 const CACHE = 'tvguide-__CACHE_VERSION__';
-const STATIC = ['/', '/index.html', '/style.css', '/js/main.js', '/js/state.js', '/js/api.js', '/js/config.js', '/js/utils/date.js', '/js/store/preferences.js', '/js/store/favourites.js', '/js/components/modal.js', '/js/pages/guide.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
+const STATIC = ['/', '/index.html', '/style.css', '/js/main.js', '/js/state.js', '/js/api.js', '/js/config.js', '/js/utils/date.js', '/js/store/preferences.js', '/js/store/favourites.js', '/js/components/modal.js', '/js/pages/guide.js', '/js/pages/search.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
 
 // SPA routes that should be served from the cached index.html
 const SPA_ROUTES = ['/guide', '/search', '/favourites', '/settings'];


### PR DESCRIPTION
## Summary
- Extracts search functions (`performSearch`, `triggerSearch`, `renderSearchResults`, `renderCategoryChips`, `setupSearchPage`, `getCurrentSearchConfig`) from `main.js` into `web/js/pages/search.js`
- Updates `main.js` to import from the new module and removes unused imports
- Adds `js/pages/search.js` to the service worker cache list
- Updates integration tests to verify the new module structure

## Test plan
- [ ] `TestIntegration_Search_JSFunctions` — verifies `search.js` is served, defines expected functions, `main.js` imports it, and `sw.js` caches it
- [ ] `TestIntegration_SearchPage_JSFunctions` — updated to check `search.js` for search-specific functions
- [ ] `TestIntegration_ErrorLogging_JSFunctions` — updated to count `logError` calls across both `main.js` and `search.js`
- [ ] All existing tests pass (`go test ./...`)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)