### PR TITLE
Refactor: extract router module and finalise main.js (#82)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1202,14 +1202,19 @@ func TestIntegration_FavouritesPage_JSFunctions(t *testing.T) {
 		}
 	}
 
-	// editFavouriteSearch remains in main.js (cross-page navigation)
-	if !strings.Contains(mainJS, "editFavouriteSearch") {
-		t.Error("expected js/main.js to reference editFavouriteSearch")
+	// editFavouriteSearch has moved to pages/search.js (alongside router import)
+	searchJS := fetchBody("/js/pages/search.js")
+	if !strings.Contains(searchJS, "editFavouriteSearch") {
+		t.Error("expected editFavouriteSearch to be defined in js/pages/search.js")
+	}
+	if strings.Contains(mainJS, "function editFavouriteSearch") {
+		t.Error("expected editFavouriteSearch NOT to be defined directly in js/main.js")
 	}
 
-	// main.js imports renderFavouritesPage from pages/favourites.js
-	if !strings.Contains(mainJS, "pages/favourites.js") {
-		t.Error("expected js/main.js to import from pages/favourites.js")
+	// router.js now imports renderFavouritesPage from pages/favourites.js
+	routerJS := fetchBody("/js/router.js")
+	if !strings.Contains(routerJS, "pages/favourites.js") {
+		t.Error("expected js/router.js to import from pages/favourites.js")
 	}
 
 	// State references live in pages/favourites.js

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,21 +1,17 @@
 import { getTodayString, addDays, formatDateLong } from './utils/date.js';
 import { state } from './state.js';
-import { fetchChannels, fetchGuide, fetchCategories, logError } from './api.js';
+import { fetchChannels, fetchGuide, logError } from './api.js';
 import { loadPrefs } from './store/preferences.js';
 import { loadFavouriteSearches } from './store/favourites.js';
 import { closeModal } from './components/modal.js';
 import {
     renderGuide, renderTimeAxis, setupScrollSync, scrollToNow,
-    startNowLineTimer, stopNowLineTimer,
     navigateToDate, hasAiringsStartingOn,
     getDateFromURL,
 } from './pages/guide.js';
-import {
-    setupSearchPage, triggerSearch, renderCategoryChips, getCurrentSearchConfig,
-    loadSearchPageCategories,
-} from './pages/search.js';
-import { initFavouritesPage, renderFavouritesPage } from './pages/favourites.js';
+import { setupSearchPage } from './pages/search.js';
 import { renderSettingsPanel } from './pages/settings.js';
+import { getPageFromPath, navigateToPage } from './router.js';
 
 window.onerror = (message, source, lineno, colno, error) => {
     logError({ type: 'onerror', message: String(message), source, lineno, colno,
@@ -29,103 +25,6 @@ window.addEventListener('unhandledrejection', event => {
                 stack: err?.stack, url: location.href });
 });
 
-function showError(message) {
-    console.error(message);
-}
-
-function editFavouriteSearch(id) {
-    const fav = state.favouriteSearches.find(f => f.id === id);
-    if (!fav) return;
-
-    // Navigate to search page
-    navigateToPage('search');
-
-    // Pre-fill search input
-    document.getElementById('searchInput').value = fav.query;
-
-    // Pre-fill advanced options
-    const isAdvanced = fav.mode === 'advanced';
-    document.getElementById('searchDescriptions').checked = isAdvanced;
-    document.getElementById('includePast').checked = fav.includePast || false;
-    document.getElementById('hideRepeats').checked = fav.includeRepeats === false;
-
-    // Pre-fill categories
-    state.selectedCategories.clear();
-    if (fav.categories) {
-        for (const cat of fav.categories) {
-            state.selectedCategories.add(cat);
-        }
-    }
-
-    // Show advanced panel if needed
-    if (isAdvanced || (fav.categories && fav.categories.length > 0)) {
-        document.getElementById('advancedOptions').style.display = '';
-        document.getElementById('advancedToggle').classList.add('open');
-    }
-
-    // Render category chips and trigger search
-    fetchCategories().then(renderCategoryChips).catch(err => console.warn('Failed to load categories:', err));
-    triggerSearch();
-}
-
-// ── Routing ──────────────────────────────────────────────────────────────────
-
-const PAGES = ['guide', 'search', 'favourites', 'settings'];
-
-function getPageFromPath() {
-    const path = window.location.pathname.replace(/^\/+/, '').split('?')[0];
-    if (PAGES.includes(path)) return path;
-    return 'guide';
-}
-
-function navigateToPage(page, { pushState = true } = {}) {
-    if (!PAGES.includes(page)) page = 'guide';
-    state.activePage = page;
-
-    // Update URL
-    if (pushState) {
-        const url = page === 'guide' ? '/' + (window.location.search || '') : '/' + page;
-        history.pushState({}, '', url);
-    }
-
-    // Show/hide pages
-    for (const p of PAGES) {
-        const el = document.getElementById('page-' + p);
-        if (el) el.style.display = p === page ? '' : 'none';
-    }
-
-    // Update bottom nav active state
-    document.querySelectorAll('.bottom-nav-btn').forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.page === page);
-    });
-
-    // Top bar is only visible on the Guide tab
-    document.getElementById('topBar').style.display = page === 'guide' ? '' : 'none';
-
-    // Start/stop the now-line timer based on whether Guide is active
-    if (page === 'guide') {
-        startNowLineTimer();
-    } else {
-        stopNowLineTimer();
-    }
-
-    // Render settings when switching to that page
-    if (page === 'settings') {
-        renderSettingsPanel();
-    }
-
-    // Load categories when entering search page
-    if (page === 'search') {
-        loadSearchPageCategories();
-    }
-
-    // Load favourites when entering favourites page
-    if (page === 'favourites') {
-        renderFavouritesPage();
-    }
-}
-
-
 // ── Initialisation ────────────────────────────────────────────────────────────
 
 async function init() {
@@ -138,9 +37,6 @@ async function init() {
 
     // Resolve the active date from the URL (falls back to today)
     state.currentDate = getDateFromURL();
-
-    // Wire up cross-page callbacks
-    initFavouritesPage({ editFavouriteSearch });
 
     // Render static parts that don't depend on data
     renderTimeAxis();
@@ -203,7 +99,7 @@ async function init() {
         }, 50);
 
     } catch (err) {
-        showError(`Failed to load guide data: ${err.message}`);
+        console.error(`Failed to load guide data: ${err.message}`);
         logError({ type: 'explicit', message: err.message, stack: err?.stack, url: location.href });
         document.getElementById('loadingText').textContent =
             `Failed to load guide data. Is the server running?\n${err.message}`;

--- a/web/js/pages/favourites.js
+++ b/web/js/pages/favourites.js
@@ -4,12 +4,7 @@ import { formatSearchDate } from '../utils/date.js';
 import { isHidden } from '../store/preferences.js';
 import { removeFavouriteSearch } from '../store/favourites.js';
 import { openSearchAiringModal } from '../components/modal.js';
-
-let _editFavouriteSearch;
-
-export function initFavouritesPage({ editFavouriteSearch }) {
-    _editFavouriteSearch = editFavouriteSearch;
-}
+import { editFavouriteSearch } from './search.js';
 
 export function renderFavouritesPage() {
     const list = document.getElementById('favouritesList');
@@ -104,7 +99,7 @@ function renderFavouriteResults() {
         editBtn.className = 'fav-action-btn';
         editBtn.textContent = 'Edit';
         editBtn.title = 'Edit this search';
-        editBtn.addEventListener('click', () => _editFavouriteSearch(fav.id));
+        editBtn.addEventListener('click', () => editFavouriteSearch(fav.id));
         actions.appendChild(editBtn);
 
         const deleteBtn = document.createElement('button');

--- a/web/js/pages/search.js
+++ b/web/js/pages/search.js
@@ -4,6 +4,7 @@ import { fetchCategories, logError } from '../api.js';
 import { isHidden } from '../store/preferences.js';
 import { addFavouriteSearch, removeFavouriteSearch, findMatchingFavourite } from '../store/favourites.js';
 import { openSearchAiringModal } from '../components/modal.js';
+import { navigateToPage } from '../router.js';
 
 // ── Search ───────────────────────────────────────────────────────────────────
 
@@ -226,4 +227,39 @@ export function loadSearchPageCategories() {
         console.error('Failed to load categories:', err);
         logError({ type: 'explicit', message: err.message, stack: err?.stack, url: location.href });
     });
+}
+
+export function editFavouriteSearch(id) {
+    const fav = state.favouriteSearches.find(f => f.id === id);
+    if (!fav) return;
+
+    // Navigate to search page
+    navigateToPage('search');
+
+    // Pre-fill search input
+    document.getElementById('searchInput').value = fav.query;
+
+    // Pre-fill advanced options
+    const isAdvanced = fav.mode === 'advanced';
+    document.getElementById('searchDescriptions').checked = isAdvanced;
+    document.getElementById('includePast').checked = fav.includePast || false;
+    document.getElementById('hideRepeats').checked = fav.includeRepeats === false;
+
+    // Pre-fill categories
+    state.selectedCategories.clear();
+    if (fav.categories) {
+        for (const cat of fav.categories) {
+            state.selectedCategories.add(cat);
+        }
+    }
+
+    // Show advanced panel if needed
+    if (isAdvanced || (fav.categories && fav.categories.length > 0)) {
+        document.getElementById('advancedOptions').style.display = '';
+        document.getElementById('advancedToggle').classList.add('open');
+    }
+
+    // Render category chips and trigger search
+    fetchCategories().then(renderCategoryChips).catch(err => console.warn('Failed to load categories:', err));
+    triggerSearch();
 }

--- a/web/js/router.js
+++ b/web/js/router.js
@@ -1,0 +1,62 @@
+import { state } from './state.js';
+import { startNowLineTimer, stopNowLineTimer } from './pages/guide.js';
+import { loadSearchPageCategories } from './pages/search.js';
+import { renderFavouritesPage } from './pages/favourites.js';
+import { renderSettingsPanel } from './pages/settings.js';
+
+// ── Routing ──────────────────────────────────────────────────────────────────
+
+export const PAGES = ['guide', 'search', 'favourites', 'settings'];
+
+export function getPageFromPath() {
+    const path = window.location.pathname.replace(/^\/+/, '').split('?')[0];
+    if (PAGES.includes(path)) return path;
+    return 'guide';
+}
+
+export function navigateToPage(page, { pushState = true } = {}) {
+    if (!PAGES.includes(page)) page = 'guide';
+    state.activePage = page;
+
+    // Update URL
+    if (pushState) {
+        const url = page === 'guide' ? '/' + (window.location.search || '') : '/' + page;
+        history.pushState({}, '', url);
+    }
+
+    // Show/hide pages
+    for (const p of PAGES) {
+        const el = document.getElementById('page-' + p);
+        if (el) el.style.display = p === page ? '' : 'none';
+    }
+
+    // Update bottom nav active state
+    document.querySelectorAll('.bottom-nav-btn').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.page === page);
+    });
+
+    // Top bar is only visible on the Guide tab
+    document.getElementById('topBar').style.display = page === 'guide' ? '' : 'none';
+
+    // Start/stop the now-line timer based on whether Guide is active
+    if (page === 'guide') {
+        startNowLineTimer();
+    } else {
+        stopNowLineTimer();
+    }
+
+    // Render settings when switching to that page
+    if (page === 'settings') {
+        renderSettingsPanel();
+    }
+
+    // Load categories when entering search page
+    if (page === 'search') {
+        loadSearchPageCategories();
+    }
+
+    // Load favourites when entering favourites page
+    if (page === 'favourites') {
+        renderFavouritesPage();
+    }
+}

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 const CACHE = 'tvguide-__CACHE_VERSION__';
-const STATIC = ['/', '/index.html', '/style.css', '/js/main.js', '/js/state.js', '/js/api.js', '/js/config.js', '/js/utils/date.js', '/js/store/preferences.js', '/js/store/favourites.js', '/js/components/modal.js', '/js/pages/guide.js', '/js/pages/search.js', '/js/pages/favourites.js', '/js/pages/settings.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
+const STATIC = ['/', '/index.html', '/style.css', '/js/main.js', '/js/router.js', '/js/state.js', '/js/api.js', '/js/config.js', '/js/utils/date.js', '/js/store/preferences.js', '/js/store/favourites.js', '/js/components/modal.js', '/js/pages/guide.js', '/js/pages/search.js', '/js/pages/favourites.js', '/js/pages/settings.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
 
 // SPA routes that should be served from the cached index.html
 const SPA_ROUTES = ['/guide', '/search', '/favourites', '/settings'];


### PR DESCRIPTION
## Summary

- Creates `web/js/router.js` with `PAGES`, `getPageFromPath()`, and `navigateToPage()`, imported by all pages that need routing
- Moves `editFavouriteSearch` from `main.js` to `pages/search.js` (it imports `navigateToPage` from router)
- Updates `pages/favourites.js` to import `editFavouriteSearch` directly from `search.js`, removing the old callback pattern
- Slims `main.js` from 239 → 134 lines: pure orchestration (imports, error handlers, `init()`, service worker)
- Adds `/js/router.js` to the service worker static asset cache
- Updates `TestIntegration_FavouritesPage_JSFunctions` to reflect the new module boundaries

Closes #82

## Test plan

- [ ] All Go tests pass (`go test ./...`)
- [ ] Docker build succeeds
- [ ] Tab navigation works — active indicator updates correctly
- [ ] Top bar is only visible on the Guide tab
- [ ] URL updates on tab switch; direct URL navigation works
- [ ] Browser back/forward buttons work correctly
- [ ] Edit button on Favourites page navigates to Search and pre-fills the form
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)