### PR TITLE
Docs: update CLAUDE.md to reflect modularised frontend structure (#84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ A personal PWA TV guide that parses XMLTV data and displays it as a scrollable g
 | Layer | Choice | Reason |
 |---|---|---|
 | Backend | Go (one external dep: `modernc.org/sqlite`) | Low resource usage, single binary |
-| Frontend | Vanilla JS + HTML/CSS (no framework, no build step) | Lightweight, no toolchain needed |
+| Frontend | Vanilla JS ES modules + HTML/CSS (no framework, no build step) | Lightweight, no toolchain needed |
 | Database | SQLite via `modernc.org/sqlite` (pure Go, no CGO) | Persistent storage, simple queries, no separate service |
 | Container | Docker / docker-compose | Home-lab deployment |
 | Reverse proxy | Traefik + Authelia | Handled externally, not in this repo |
@@ -36,7 +36,8 @@ tvguide/
 │   │   ├── favourites.css       # Favourites page styling
 │   │   └── settings.css         # Settings panel styling
 │   └── js/
-│       ├── main.js              # Router, init, service worker registration
+│       ├── main.js              # Entry point: init, service worker registration
+│       ├── router.js            # SPA routing (History API, page switching)
 │       ├── state.js             # Shared mutable state
 │       ├── api.js               # Fetch helpers for backend API
 │       ├── config.js            # PX_PER_MIN, ROW_HEIGHT constants


### PR DESCRIPTION
## Summary

- Added `router.js` to the project structure tree (was missing after extraction in #82)
- Corrected `main.js` comment to remove stale "Router" reference
- Updated Tech stack frontend entry to mention ES modules

## Verification

- No stale `app.js` or `style.css` references remain in CLAUDE.md
- All files in the project structure tree exist in the actual `web/` directory

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)