### PR TITLE
Fix: handle Traefik/Authelia authentication redirects in PWA

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1483,6 +1483,65 @@ func TestIntegration_CSSModularization_BaseHasCSSVariables(t *testing.T) {
 	}
 }
 
+// TestIntegration_AuthRedirectHandling verifies that api.js and sw.js are
+// configured to detect and handle Traefik/Authelia authentication redirects.
+func TestIntegration_AuthRedirectHandling(t *testing.T) {
+	xmlBytes, err := os.ReadFile("testdata/sample.xml")
+	if err != nil {
+		t.Fatalf("read sample.xml: %v", err)
+	}
+	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
+	srv := newIntegrationServer(t, mockSrv.URL)
+
+	t.Run("api_js_uses_redirect_manual", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/js/api.js")
+		if err != nil {
+			t.Fatalf("GET /js/api.js: %v", err)
+		}
+		defer resp.Body.Close()
+		var buf strings.Builder
+		io.Copy(&buf, resp.Body) //nolint:errcheck
+		body := buf.String()
+		if !strings.Contains(body, "redirect: 'manual'") {
+			t.Error("api.js should use redirect: 'manual' for API fetch calls to detect auth redirects")
+		}
+	})
+
+	t.Run("api_js_handles_opaqueredirect", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/js/api.js")
+		if err != nil {
+			t.Fatalf("GET /js/api.js: %v", err)
+		}
+		defer resp.Body.Close()
+		var buf strings.Builder
+		io.Copy(&buf, resp.Body) //nolint:errcheck
+		body := buf.String()
+		if !strings.Contains(body, "opaqueredirect") {
+			t.Error("api.js should check for opaqueredirect response type to handle auth redirects")
+		}
+		if !strings.Contains(body, "window.location") {
+			t.Error("api.js should trigger a page navigation when an opaqueredirect is detected")
+		}
+	})
+
+	t.Run("sw_js_rethrows_on_api_fetch_failure", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/sw.js")
+		if err != nil {
+			t.Fatalf("GET /sw.js: %v", err)
+		}
+		defer resp.Body.Close()
+		var buf strings.Builder
+		io.Copy(&buf, resp.Body) //nolint:errcheck
+		body := buf.String()
+		// The service worker should NOT silently fall back to the cache for API
+		// requests. If the network fails (e.g. due to an auth redirect), the
+		// error must propagate so the page can trigger re-authentication.
+		if strings.Contains(body, "fetch(event.request).catch(() => caches.match(event.request))") {
+			t.Error("sw.js must not fall back to stale cache on API fetch failure — re-throw so the page can handle auth redirects")
+		}
+	})
+}
+
 // TestIntegration_SPAFallback_GuidePathReturnsHTML verifies that GET /guide
 // returns index.html content (SPA fallback).
 func TestIntegration_SPAFallback_GuidePathReturnsHTML(t *testing.T) {

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -2,21 +2,33 @@
 
 import { state } from './state.js';
 
+// handleRedirect detects when Traefik/Authelia has redirected the request to a
+// login page. fetch() with redirect:'manual' returns an opaque redirect instead
+// of following a cross-origin redirect, so we trigger a full page navigation
+// which lets the browser follow the redirect chain to the login page and back.
+function handleRedirect(res) {
+    if (res.type === 'opaqueredirect') {
+        window.location.replace(window.location.href);
+        return new Promise(() => {}); // never resolves — navigation is in progress
+    }
+    return res;
+}
+
 export async function fetchChannels() {
-    const res = await fetch('/api/channels');
+    const res = await fetch('/api/channels', { redirect: 'manual' }).then(handleRedirect);
     if (!res.ok) throw new Error(`/api/channels returned ${res.status}`);
     return res.json();
 }
 
 export async function fetchGuide(dateStr) {
-    const res = await fetch(`/api/guide?date=${dateStr}`);
+    const res = await fetch(`/api/guide?date=${dateStr}`, { redirect: 'manual' }).then(handleRedirect);
     if (!res.ok) throw new Error(`/api/guide returned ${res.status}`);
     return res.json();
 }
 
 export async function fetchCategories() {
     if (state.categories.length > 0) return state.categories;
-    const res = await fetch('/api/categories');
+    const res = await fetch('/api/categories', { redirect: 'manual' }).then(handleRedirect);
     if (!res.ok) throw new Error(`/api/categories returned ${res.status}`);
     state.categories = await res.json();
     return state.categories;

--- a/web/sw.js
+++ b/web/sw.js
@@ -25,9 +25,10 @@ self.addEventListener('fetch', event => {
 
     if (url.pathname.startsWith('/api/')) {
         // Network-first for API: always try to get fresh data.
-        event.respondWith(
-            fetch(event.request).catch(() => caches.match(event.request))
-        );
+        // Do NOT fall back to cache on failure — if the network request fails
+        // (e.g. due to a Traefik/Authelia auth redirect), the error must
+        // propagate so the page can detect the opaqueredirect and re-authenticate.
+        event.respondWith(fetch(event.request));
     } else if (SPA_ROUTES.includes(url.pathname)) {
         // SPA routes: serve cached index.html (the SPA shell)
         event.respondWith(


### PR DESCRIPTION
## Summary

- Add `redirect: 'manual'` to all API `fetch()` calls in `api.js` so cross-origin 302 redirects from Traefik/Authelia are intercepted as `opaqueredirect` responses rather than causing a generic network error
- Extract redirect detection into a shared `handleRedirect()` helper that triggers `window.location.replace()` to let the browser navigate through the login flow and back
- Remove the silent cache fallback in `sw.js` for API requests so auth redirect failures propagate to the page instead of returning stale data

## Test plan

- [ ] All existing tests pass (`go test ./...`)
- [ ] `TestIntegration_AuthRedirectHandling` covers all three changes
- [ ] Manual: expire auth session, confirm browser is redirected to Authelia login and returns to the app after re-authenticating

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)