### PR TITLE
feat: add GET /api/explore/now-next endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ tvguide/
 | `GET /api/search?q=...&mode=...` | Search airings. `q` (required): search text. `mode`: `simple` (title only, default) or `advanced` (title+subtitle+description). Advanced-only params: `categories` (comma-separated), `include_past` (bool, default false). Shared: `include_repeats` (bool, default true), `today` (bool, default false — when true, only returns airings starting before midnight tonight in the server's local timezone). `format`: `rss` returns RSS 2.0 XML (`application/rss+xml`) instead of JSON; omit or use any other value for JSON (default). `ttl`: RSS feed TTL in minutes (only used when `format=rss`); overrides `RSS_TTL` env var and hard-coded default of 360. Returns results grouped by title (JSON) or as flat items sorted by start time (RSS). |
 | `GET /api/categories` | Sorted JSON array of all distinct category strings |
 | `GET /images/channel/{channel-id}` | Cached channel logo. Re-downloads from upstream if the local file is missing. Returns 404 if the channel has no icon. |
+| `GET /api/explore/now-next` | For every channel, returns the currently-airing show (`current`) and the next upcoming show (`next`). Either field may be `null`. Ordered by channel sort order (lcn, then source order). |
 | `GET /` | Serves the embedded frontend (SPA shell) |
 | `GET /{any}` | SPA fallback — serves `index.html` for any path not matching API, images, or static files. Enables client-side routing via History API. |
 

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -1,0 +1,12 @@
+package api
+
+import "net/http"
+
+func (h *Handler) getNowNext(w http.ResponseWriter, r *http.Request) {
+	entries, err := h.db.GetNowNext()
+	if err != nil {
+		http.Error(w, "database error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, entries)
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -18,6 +18,7 @@ type store interface {
 	SearchSimple(query string, includeRepeats bool, today bool) ([]model.SearchResult, error)
 	SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error)
 	GetCategories() ([]string, error)
+	GetNowNext() ([]model.NowNextEntry, error)
 }
 
 // Handler holds the HTTP handler dependencies.
@@ -40,6 +41,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/status", h.getStatus)
 	mux.HandleFunc("GET /api/search", h.getSearch)
 	mux.HandleFunc("GET /api/categories", h.getCategories)
+	mux.HandleFunc("GET /api/explore/now-next", h.getNowNext)
 	mux.HandleFunc("GET /images/channel/{id}", h.serveChannelIcon)
 	mux.HandleFunc("POST /api/debug/log", h.postDebugLog)
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1736,3 +1736,157 @@ func TestSearchRSS_LastBuildDate(t *testing.T) {
 		t.Errorf("lastBuildDate should be approximately now, got %v", buildDate)
 	}
 }
+
+// newNowNextServer creates a test server seeded with three channels and
+// airings anchored to FIXED_NOW (2025-06-10T14:00:00Z):
+//   - ch1 (lcn=1): Show A airing now (13:30–14:30), Show B coming next (14:30–15:00)
+//   - ch2 (lcn=2): no current airing, Show C next (15:00–16:00)
+//   - ch3 (no lcn): no airings at all
+func newNowNextServer(t *testing.T) (*httptest.Server, time.Time) {
+	t.Helper()
+	fixedNow := time.Date(2025, 6, 10, 14, 0, 0, 0, time.UTC)
+
+	dir := t.TempDir()
+	db, err := database.Open(
+		filepath.Join(dir, "test.db"), 7, "http://test-source",
+		images.NewCache(&http.Client{}, filepath.Join(dir, "images")),
+	)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	db.SetClock(fixedClock{t: fixedNow})
+
+	tv := &xmltv.TV{
+		Channels: []xmltv.Channel{
+			{ID: "ch1", DisplayNames: []xmltv.Name{{Value: "ABC"}}, LCN: "1"},
+			{ID: "ch2", DisplayNames: []xmltv.Name{{Value: "SBS"}}, LCN: "2"},
+			{ID: "ch3", DisplayNames: []xmltv.Name{{Value: "Nine"}}},
+		},
+		Programmes: []xmltv.Programme{
+			{
+				Start:   xmltv.XmltvTime{Time: fixedNow.Add(-30 * time.Minute)},
+				Stop:    xmltv.XmltvTime{Time: fixedNow.Add(30 * time.Minute)},
+				Channel: "ch1",
+				Titles:  []xmltv.Name{{Value: "Show A"}},
+			},
+			{
+				Start:   xmltv.XmltvTime{Time: fixedNow.Add(30 * time.Minute)},
+				Stop:    xmltv.XmltvTime{Time: fixedNow.Add(60 * time.Minute)},
+				Channel: "ch1",
+				Titles:  []xmltv.Name{{Value: "Show B"}},
+			},
+			{
+				Start:   xmltv.XmltvTime{Time: fixedNow.Add(60 * time.Minute)},
+				Stop:    xmltv.XmltvTime{Time: fixedNow.Add(120 * time.Minute)},
+				Channel: "ch2",
+				Titles:  []xmltv.Name{{Value: "Show C"}},
+			},
+		},
+	}
+	if err := db.Refresh(context.Background(), tv, fixedNow.Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	handler := api.New(db, 0)
+	handler.RegisterRoutes(mux)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		srv.Close()
+		db.Close()
+	})
+	return srv, fixedNow
+}
+
+func TestGetNowNext_API_StatusOK(t *testing.T) {
+	srv, _ := newNowNextServer(t)
+	resp, err := http.Get(srv.URL + "/api/explore/now-next")
+	if err != nil {
+		t.Fatalf("GET /api/explore/now-next: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestGetNowNext_API_ResponseShape(t *testing.T) {
+	srv, fixedNow := newNowNextServer(t)
+	resp, err := http.Get(srv.URL + "/api/explore/now-next")
+	if err != nil {
+		t.Fatalf("GET /api/explore/now-next: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var entries []struct {
+		ChannelID   string `json:"channelId"`
+		ChannelName string `json:"channelName"`
+		Current     *struct {
+			Title string    `json:"title"`
+			Start time.Time `json:"start"`
+			Stop  time.Time `json:"stop"`
+		} `json:"current"`
+		Next *struct {
+			Title string    `json:"title"`
+			Start time.Time `json:"start"`
+		} `json:"next"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// ch1: current = Show A, next = Show B
+	e0 := entries[0]
+	if e0.ChannelID != "ch1" {
+		t.Errorf("entries[0].channelId = %q, want ch1", e0.ChannelID)
+	}
+	if e0.ChannelName != "ABC" {
+		t.Errorf("entries[0].channelName = %q, want ABC", e0.ChannelName)
+	}
+	if e0.Current == nil {
+		t.Fatal("entries[0].current is nil, want Show A")
+	}
+	if e0.Current.Title != "Show A" {
+		t.Errorf("entries[0].current.title = %q, want Show A", e0.Current.Title)
+	}
+	if e0.Next == nil {
+		t.Fatal("entries[0].next is nil, want Show B")
+	}
+	if e0.Next.Title != "Show B" {
+		t.Errorf("entries[0].next.title = %q, want Show B", e0.Next.Title)
+	}
+
+	// ch2: no current, next = Show C
+	e1 := entries[1]
+	if e1.ChannelID != "ch2" {
+		t.Errorf("entries[1].channelId = %q, want ch2", e1.ChannelID)
+	}
+	if e1.Current != nil {
+		t.Errorf("entries[1].current = %v, want null", e1.Current)
+	}
+	if e1.Next == nil {
+		t.Fatal("entries[1].next is nil, want Show C")
+	}
+	if e1.Next.Title != "Show C" {
+		t.Errorf("entries[1].next.title = %q, want Show C", e1.Next.Title)
+	}
+
+	// ch3: both null
+	e2 := entries[2]
+	if e2.ChannelID != "ch3" {
+		t.Errorf("entries[2].channelId = %q, want ch3", e2.ChannelID)
+	}
+	if e2.Current != nil {
+		t.Errorf("entries[2].current = %v, want null", e2.Current)
+	}
+	if e2.Next != nil {
+		t.Errorf("entries[2].next = %v, want null", e2.Next)
+	}
+
+	_ = fixedNow // used for seeding; referenced to suppress lint
+}

--- a/internal/database/clock.go
+++ b/internal/database/clock.go
@@ -11,3 +11,10 @@ type Clock interface {
 type realClock struct{}
 
 func (realClock) Now() time.Time { return time.Now() }
+
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+// FixedClock returns a Clock that always returns t. Use in tests to pin time.
+func FixedClock(t time.Time) Clock { return fixedClock{t: t} }

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -1202,3 +1202,164 @@ func TestRefresh_Upsert_NoDuplicates(t *testing.T) {
 		t.Fatalf("expected 4 airings after double refresh, got %d", len(airings))
 	}
 }
+
+// nowNextTV builds a small XMLTV dataset anchored to a fixed clock time so
+// tests are deterministic. "now" is 2025-06-10T14:00:00Z (FIXED_NOW).
+func nowNextTV() (*xmltv.TV, time.Time) {
+	now := time.Date(2025, 6, 10, 14, 0, 0, 0, time.UTC)
+	return &xmltv.TV{
+		Channels: []xmltv.Channel{
+			{ID: "ch1", DisplayNames: []xmltv.Name{{Value: "ABC"}}, LCN: "1"},
+			{ID: "ch2", DisplayNames: []xmltv.Name{{Value: "SBS"}}, LCN: "2"},
+			{ID: "ch3", DisplayNames: []xmltv.Name{{Value: "Nine"}}},
+		},
+		Programmes: []xmltv.Programme{
+			// ch1: currently airing Show A (13:30–14:30), next is Show B (14:30–15:00)
+			{
+				Start:   xmltv.XmltvTime{Time: now.Add(-30 * time.Minute)}, // 13:30
+				Stop:    xmltv.XmltvTime{Time: now.Add(30 * time.Minute)},  // 14:30
+				Channel: "ch1",
+				Titles:  []xmltv.Name{{Value: "Show A"}},
+			},
+			{
+				Start:   xmltv.XmltvTime{Time: now.Add(30 * time.Minute)},  // 14:30
+				Stop:    xmltv.XmltvTime{Time: now.Add(60 * time.Minute)},  // 15:00
+				Channel: "ch1",
+				Titles:  []xmltv.Name{{Value: "Show B"}},
+			},
+			// ch2: nothing current, next is Show C (15:00–16:00)
+			{
+				Start:   xmltv.XmltvTime{Time: now.Add(60 * time.Minute)},  // 15:00
+				Stop:    xmltv.XmltvTime{Time: now.Add(120 * time.Minute)}, // 16:00
+				Channel: "ch2",
+				Titles:  []xmltv.Name{{Value: "Show C"}},
+			},
+			// ch3: nothing at all (no airings)
+		},
+	}, now
+}
+
+func TestGetNowNext_CurrentAndNext(t *testing.T) {
+	db := openTestDB(t)
+	tv, now := nowNextTV()
+	db.SetClock(database.FixedClock(now))
+	if err := db.Refresh(context.Background(), tv, now.Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	entries, err := db.GetNowNext()
+	if err != nil {
+		t.Fatalf("GetNowNext: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// ch1: has current and next
+	e := entries[0]
+	if e.ChannelID != "ch1" {
+		t.Errorf("entries[0].ChannelID = %q, want ch1", e.ChannelID)
+	}
+	if e.ChannelName != "ABC" {
+		t.Errorf("entries[0].ChannelName = %q, want ABC", e.ChannelName)
+	}
+	if e.Current == nil {
+		t.Fatal("entries[0].Current is nil, want Show A")
+	}
+	if e.Current.Title != "Show A" {
+		t.Errorf("entries[0].Current.Title = %q, want Show A", e.Current.Title)
+	}
+	if e.Next == nil {
+		t.Fatal("entries[0].Next is nil, want Show B")
+	}
+	if e.Next.Title != "Show B" {
+		t.Errorf("entries[0].Next.Title = %q, want Show B", e.Next.Title)
+	}
+}
+
+func TestGetNowNext_NullCurrent(t *testing.T) {
+	db := openTestDB(t)
+	tv, now := nowNextTV()
+	db.SetClock(database.FixedClock(now))
+	if err := db.Refresh(context.Background(), tv, now.Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	entries, err := db.GetNowNext()
+	if err != nil {
+		t.Fatalf("GetNowNext: %v", err)
+	}
+	if len(entries) < 2 {
+		t.Fatalf("expected at least 2 entries, got %d", len(entries))
+	}
+
+	// ch2: no current airing, but has a next
+	e := entries[1]
+	if e.ChannelID != "ch2" {
+		t.Errorf("entries[1].ChannelID = %q, want ch2", e.ChannelID)
+	}
+	if e.Current != nil {
+		t.Errorf("entries[1].Current = %v, want nil", e.Current)
+	}
+	if e.Next == nil {
+		t.Fatal("entries[1].Next is nil, want Show C")
+	}
+	if e.Next.Title != "Show C" {
+		t.Errorf("entries[1].Next.Title = %q, want Show C", e.Next.Title)
+	}
+}
+
+func TestGetNowNext_BothNull(t *testing.T) {
+	db := openTestDB(t)
+	tv, now := nowNextTV()
+	db.SetClock(database.FixedClock(now))
+	if err := db.Refresh(context.Background(), tv, now.Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	entries, err := db.GetNowNext()
+	if err != nil {
+		t.Fatalf("GetNowNext: %v", err)
+	}
+	if len(entries) < 3 {
+		t.Fatalf("expected at least 3 entries, got %d", len(entries))
+	}
+
+	// ch3: no airings at all
+	e := entries[2]
+	if e.ChannelID != "ch3" {
+		t.Errorf("entries[2].ChannelID = %q, want ch3", e.ChannelID)
+	}
+	if e.Current != nil {
+		t.Errorf("entries[2].Current = %v, want nil", e.Current)
+	}
+	if e.Next != nil {
+		t.Errorf("entries[2].Next = %v, want nil", e.Next)
+	}
+}
+
+func TestGetNowNext_SortOrder(t *testing.T) {
+	db := openTestDB(t)
+	tv, now := nowNextTV()
+	db.SetClock(database.FixedClock(now))
+	if err := db.Refresh(context.Background(), tv, now.Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	entries, err := db.GetNowNext()
+	if err != nil {
+		t.Fatalf("GetNowNext: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// ch1 has lcn=1, ch2 has lcn=2, ch3 has no lcn (sort_order=3)
+	ids := []string{entries[0].ChannelID, entries[1].ChannelID, entries[2].ChannelID}
+	want := []string{"ch1", "ch2", "ch3"}
+	for i, id := range ids {
+		if id != want[i] {
+			t.Errorf("entries[%d].ChannelID = %q, want %q", i, id, want[i])
+		}
+	}
+}

--- a/internal/database/nownext.go
+++ b/internal/database/nownext.go
@@ -1,0 +1,125 @@
+package database
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/model"
+)
+
+// GetNowNext returns the current and next airing for every channel, ordered
+// by the same sort order as GetChannels (sort_order, which respects lcn).
+// Either field may be nil if no matching airing exists.
+func (d *DB) GetNowNext() ([]model.NowNextEntry, error) {
+	now := d.clock.Now().UTC().Format(time.RFC3339)
+
+	// Fetch channels in sort order.
+	channels, err := d.GetChannels()
+	if err != nil {
+		return nil, fmt.Errorf("getting channels: %w", err)
+	}
+
+	// Fetch all currently-airing programmes (start_time <= now < stop_time).
+	currentRows, err := d.db.Query(`
+		SELECT
+			channel_id, start_time, stop_time, title,
+			COALESCE(sub_title, ''), COALESCE(description, ''),
+			COALESCE(categories, '[]'),
+			COALESCE(episode_num, ''), COALESCE(episode_num_display, ''),
+			COALESCE(prog_id, ''), COALESCE(star_rating, ''),
+			COALESCE(content_rating, ''), COALESCE(year, ''),
+			COALESCE(icon, ''), COALESCE(country, ''),
+			is_repeat, is_premiere
+		FROM airings
+		WHERE start_time <= ? AND stop_time > ?
+	`, now, now)
+	if err != nil {
+		return nil, fmt.Errorf("querying current airings: %w", err)
+	}
+	defer currentRows.Close()
+
+	current := map[string]*model.Airing{}
+	for currentRows.Next() {
+		a, err := scanAiring(currentRows)
+		if err != nil {
+			return nil, err
+		}
+		current[a.ChannelID] = a
+	}
+	if err := currentRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating current airings: %w", err)
+	}
+
+	// Fetch the next upcoming airing per channel using a window function.
+	nextRows, err := d.db.Query(`
+		SELECT
+			channel_id, start_time, stop_time, title,
+			COALESCE(sub_title, ''), COALESCE(description, ''),
+			COALESCE(categories, '[]'),
+			COALESCE(episode_num, ''), COALESCE(episode_num_display, ''),
+			COALESCE(prog_id, ''), COALESCE(star_rating, ''),
+			COALESCE(content_rating, ''), COALESCE(year, ''),
+			COALESCE(icon, ''), COALESCE(country, ''),
+			is_repeat, is_premiere
+		FROM (
+			SELECT *,
+				ROW_NUMBER() OVER (PARTITION BY channel_id ORDER BY start_time) AS rn
+			FROM airings
+			WHERE start_time > ?
+		)
+		WHERE rn = 1
+	`, now)
+	if err != nil {
+		return nil, fmt.Errorf("querying next airings: %w", err)
+	}
+	defer nextRows.Close()
+
+	next := map[string]*model.Airing{}
+	for nextRows.Next() {
+		a, err := scanAiring(nextRows)
+		if err != nil {
+			return nil, err
+		}
+		next[a.ChannelID] = a
+	}
+	if err := nextRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating next airings: %w", err)
+	}
+
+	entries := make([]model.NowNextEntry, len(channels))
+	for i, ch := range channels {
+		entries[i] = model.NowNextEntry{
+			ChannelID:   ch.ID,
+			ChannelName: ch.DisplayName,
+			Current:     current[ch.ID],
+			Next:        next[ch.ID],
+		}
+	}
+	return entries, nil
+}
+
+// scanAiring scans one row (with the standard 17 airing columns) into a model.Airing.
+func scanAiring(rows *sql.Rows) (*model.Airing, error) {
+	var a model.Airing
+	var startStr, stopStr, catsJSON string
+	var isRepeat, isPremiere int
+
+	if err := rows.Scan(
+		&a.ChannelID, &startStr, &stopStr,
+		&a.Title, &a.SubTitle, &a.Description, &catsJSON,
+		&a.EpisodeNum, &a.EpisodeNumDisplay, &a.ProgID,
+		&a.StarRating, &a.ContentRating, &a.Year, &a.Icon, &a.Country,
+		&isRepeat, &isPremiere,
+	); err != nil {
+		return nil, fmt.Errorf("scanning airing: %w", err)
+	}
+
+	a.Start, _ = time.Parse(time.RFC3339, startStr)
+	a.Stop, _ = time.Parse(time.RFC3339, stopStr)
+	json.Unmarshal([]byte(catsJSON), &a.Categories) //nolint:errcheck
+	a.IsRepeat = isRepeat == 1
+	a.IsPremiere = isPremiere == 1
+	return &a, nil
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -45,3 +45,11 @@ type SearchResult struct {
 	ChannelName string  `json:"channelName"`
 	Rank        float64 `json:"-"`
 }
+
+// NowNextEntry holds the current and next airing for a single channel.
+type NowNextEntry struct {
+	ChannelID   string   `json:"channelId"`
+	ChannelName string   `json:"channelName"`
+	Current     *Airing  `json:"current"`
+	Next        *Airing  `json:"next"`
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/explore/now-next` — returns the current and next airing for every channel, ordered by sort order (lcn then source order)
- `current` is the airing where `start_time <= now < stop_time`; `next` is the earliest airing with `start_time > now`; either may be `null`
- Adds `NowNextEntry` model type, `GetNowNext()` DB method (uses `d.clock.Now()` for testability), and exported `FixedClock` helper

Closes #125

## Test plan

- [x] `TestGetNowNext_CurrentAndNext` — ch1 has current Show A and next Show B
- [x] `TestGetNowNext_NullCurrent` — ch2 has no current airing but a next (Show C)
- [x] `TestGetNowNext_BothNull` — ch3 has no airings at all (both null)
- [x] `TestGetNowNext_SortOrder` — channels are returned in lcn/sort_order
- [x] `TestGetNowNext_API_StatusOK` — endpoint returns 200
- [x] `TestGetNowNext_API_ResponseShape` — full response shape validated end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)