### PR TITLE
feat: Explore page foundation (tab, routing, mode switcher)

### DIFF
--- a/e2e/pages/AppPage.ts
+++ b/e2e/pages/AppPage.ts
@@ -4,7 +4,7 @@ export class AppPage {
   constructor(protected page: Page) {}
 
   // Navigation
-  async navigateTo(tab: 'guide' | 'search' | 'favourites' | 'settings'): Promise<void> {
+  async navigateTo(tab: 'guide' | 'search' | 'favourites' | 'settings' | 'explore'): Promise<void> {
     await this.page.getByRole('navigation').getByRole('button', { name: new RegExp(tab, 'i') }).click();
   }
 

--- a/e2e/pages/ExplorePage.ts
+++ b/e2e/pages/ExplorePage.ts
@@ -1,0 +1,45 @@
+import { Page, Locator } from '@playwright/test';
+import { AppPage } from './AppPage';
+
+export class ExplorePage extends AppPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto(mode?: string): Promise<void> {
+    const url = mode ? `/explore?mode=${mode}` : '/explore';
+    await this.page.goto(url);
+    await this.waitForAppReady();
+  }
+
+  // Page container
+  get pageContainer(): Locator {
+    return this.page.locator('#page-explore');
+  }
+
+  // Mode switcher
+  get modeSwitcher(): Locator {
+    return this.page.locator('.explore-mode-switcher');
+  }
+
+  modeButton(mode: string): Locator {
+    return this.page.locator(`.explore-mode-btn[data-mode="${mode}"]`);
+  }
+
+  get activeModeButton(): Locator {
+    return this.page.locator('.explore-mode-btn.active');
+  }
+
+  // Content area
+  get contentArea(): Locator {
+    return this.page.locator('.explore-content');
+  }
+
+  async clickMode(mode: string): Promise<void> {
+    await this.modeButton(mode).click();
+  }
+
+  async activeMode(): Promise<string> {
+    return (await this.activeModeButton.getAttribute('data-mode')) ?? '';
+  }
+}

--- a/e2e/tests/explore.spec.ts
+++ b/e2e/tests/explore.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '../fixtures/index';
+import { AppPage } from '../pages/AppPage';
+import { ExplorePage } from '../pages/ExplorePage';
+import { GuidePage } from '../pages/GuidePage';
+
+// FIXED_NOW = 2025-06-10T14:00:00.000Z (Tuesday, 14:00 UTC)
+
+test.describe('Explore tab — Navigation', () => {
+  test('Explore button appears in bottom nav', async ({ page }) => {
+    const guide = new GuidePage(page);
+    await guide.goto();
+
+    const exploreBtn = page.locator('.bottom-nav-btn[data-page="explore"]');
+    await expect(exploreBtn).toBeVisible();
+  });
+
+  test('clicking Explore tab shows the Explore page', async ({ page }) => {
+    const guide = new GuidePage(page);
+    await guide.goto();
+
+    await guide.navigateTo('explore');
+
+    await expect(page.locator('#page-explore')).toBeVisible();
+    expect(await guide.activeTab()).toBe('explore');
+  });
+
+  test('direct navigation to /explore loads the app on Explore tab', async ({ page }) => {
+    const app = new AppPage(page);
+    await page.goto('/explore');
+    await app.waitForAppReady();
+
+    await expect(page.locator('#page-explore')).toBeVisible();
+    const exploreBtn = page.locator('.bottom-nav-btn[data-page="explore"]');
+    await expect(exploreBtn).toHaveClass(/active/);
+  });
+
+  test('top bar is hidden on Explore tab', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    const topBarDisplay = await page.locator('#topBar').evaluate(
+      (el) => (el as HTMLElement).style.display
+    );
+    expect(topBarDisplay).toBe('none');
+  });
+});
+
+test.describe('Explore tab — Mode switcher', () => {
+  test('renders all four mode buttons', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    await expect(explore.modeButton('now-next')).toBeVisible();
+    await expect(explore.modeButton('categories')).toBeVisible();
+    await expect(explore.modeButton('premieres')).toBeVisible();
+    await expect(explore.modeButton('time-slot')).toBeVisible();
+  });
+
+  test('defaults to now-next mode', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    expect(await explore.activeMode()).toBe('now-next');
+  });
+
+  test('navigating to /explore?mode=premieres activates Premieres mode', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('premieres');
+
+    expect(await explore.activeMode()).toBe('premieres');
+  });
+
+  test('navigating to /explore?mode=categories activates Categories mode', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+
+    expect(await explore.activeMode()).toBe('categories');
+  });
+
+  test('navigating to /explore?mode=time-slot activates Time Slot mode', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    expect(await explore.activeMode()).toBe('time-slot');
+  });
+
+  test('clicking a mode button updates the URL', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    await explore.clickMode('premieres');
+
+    expect(page.url()).toContain('mode=premieres');
+  });
+
+  test('clicking a mode button activates that mode', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    await explore.clickMode('categories');
+
+    expect(await explore.activeMode()).toBe('categories');
+  });
+
+  test('each mode shows placeholder content', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    for (const mode of ['now-next', 'categories', 'premieres', 'time-slot']) {
+      await explore.clickMode(mode);
+      await expect(explore.contentArea).toContainText('Coming soon');
+    }
+  });
+});
+
+test.describe('Explore tab — Browser back/forward', () => {
+  test('browser back navigates from explore mode to previous state', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    await explore.clickMode('premieres');
+    expect(page.url()).toContain('mode=premieres');
+
+    await page.goBack();
+
+    // Should return to default mode (now-next)
+    expect(page.url()).not.toContain('mode=premieres');
+  });
+
+  test('browser forward navigates forward between modes', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    await explore.clickMode('categories');
+    await page.goBack();
+
+    await page.goForward();
+
+    expect(page.url()).toContain('mode=categories');
+    expect(await explore.activeMode()).toBe('categories');
+  });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="/style/search.css">
     <link rel="stylesheet" href="/style/favourites.css">
     <link rel="stylesheet" href="/style/settings.css">
+    <link rel="stylesheet" href="/style/explore.css">
 </head>
 <body>
 
@@ -108,6 +109,11 @@
         </div>
     </div>
 
+    <!-- Page: Explore -->
+    <div id="page-explore" style="display:none">
+        <!-- mode switcher and mode content rendered by JS -->
+    </div>
+
     <!-- Page: Settings -->
     <div class="page" id="page-settings" style="display:none">
         <div class="page-content">
@@ -135,6 +141,12 @@
                 <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
             </svg>
             <span>Favourites</span>
+        </button>
+        <button class="bottom-nav-btn" data-page="explore" aria-label="Explore">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"/><polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"/>
+            </svg>
+            <span>Explore</span>
         </button>
         <button class="bottom-nav-btn" data-page="settings" aria-label="Settings">
             <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/web/js/pages/explore.js
+++ b/web/js/pages/explore.js
@@ -1,0 +1,44 @@
+const MODES = [
+    { id: 'now-next',   label: 'Now/Next' },
+    { id: 'categories', label: 'Categories' },
+    { id: 'premieres',  label: 'Premieres' },
+    { id: 'time-slot',  label: 'Time Slot' },
+];
+
+function getModeFromURL() {
+    const params = new URLSearchParams(window.location.search);
+    const mode = params.get('mode');
+    return MODES.some(m => m.id === mode) ? mode : 'now-next';
+}
+
+export function loadExplorePage() {
+    const container = document.getElementById('page-explore');
+    container.innerHTML = '';
+
+    const activeMode = getModeFromURL();
+
+    // Mode switcher
+    const switcher = document.createElement('div');
+    switcher.className = 'explore-mode-switcher';
+
+    for (const mode of MODES) {
+        const btn = document.createElement('button');
+        btn.className = 'explore-mode-btn' + (mode.id === activeMode ? ' active' : '');
+        btn.dataset.mode = mode.id;
+        btn.textContent = mode.label;
+        btn.addEventListener('click', () => {
+            if (getModeFromURL() === mode.id) return;
+            history.pushState({}, '', '/explore?mode=' + mode.id);
+            loadExplorePage();
+        });
+        switcher.appendChild(btn);
+    }
+
+    container.appendChild(switcher);
+
+    // Content area
+    const content = document.createElement('div');
+    content.className = 'explore-content';
+    content.innerHTML = '<p>Coming soon</p>';
+    container.appendChild(content);
+}

--- a/web/js/router.js
+++ b/web/js/router.js
@@ -3,11 +3,12 @@ import { startNowLineTimer, stopNowLineTimer } from './pages/guide.js';
 import { loadSearchPageCategories } from './pages/search.js';
 import { renderFavouritesPage } from './pages/favourites.js';
 import { renderSettingsPanel } from './pages/settings.js';
+import { loadExplorePage } from './pages/explore.js';
 import { getTodayString } from './utils/date.js';
 
 // ── Routing ──────────────────────────────────────────────────────────────────
 
-export const PAGES = ['guide', 'search', 'favourites', 'settings'];
+export const PAGES = ['guide', 'search', 'favourites', 'explore', 'settings'];
 
 export function getPageFromPath() {
     const path = window.location.pathname.replace(/^\/+/, '').split('?')[0];
@@ -71,5 +72,10 @@ export function navigateToPage(page, { pushState = true } = {}) {
     // Load favourites when entering favourites page
     if (page === 'favourites') {
         renderFavouritesPage();
+    }
+
+    // Load explore page when entering explore tab
+    if (page === 'explore') {
+        loadExplorePage();
     }
 }

--- a/web/style/explore.css
+++ b/web/style/explore.css
@@ -1,0 +1,54 @@
+/* ── Explore page ─────────────────────────────────────────────── */
+
+#page-explore {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+}
+
+.explore-mode-switcher {
+    display: flex;
+    gap: 6px;
+    padding: 12px 16px 8px;
+    flex-shrink: 0;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+
+.explore-mode-switcher::-webkit-scrollbar {
+    display: none;
+}
+
+.explore-mode-btn {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 13px;
+    padding: 6px 14px;
+    border-radius: 20px;
+    white-space: nowrap;
+    transition: color 0.15s, background 0.15s, border-color 0.15s;
+    flex-shrink: 0;
+}
+
+.explore-mode-btn:hover {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+}
+
+.explore-mode-btn.active {
+    background: var(--bg-programme);
+    border-color: var(--bg-programme);
+    color: var(--text-primary);
+}
+
+.explore-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
+    color: var(--text-secondary);
+    font-size: 14px;
+}


### PR DESCRIPTION
## Summary

- Adds Explore as the 5th bottom nav tab with SPA routing and direct URL navigation (`/explore`, `/explore?mode=...`)
- Renders a segmented mode switcher with four modes: Now/Next, Categories, Premieres, Time Slot; active mode is highlighted and clicking updates the URL
- Each mode shows a placeholder `Coming soon` content area (real content added in subsequent issues)

Closes #127

## Test plan

- [x] Explore tab appears in bottom nav
- [x] Navigating to `/explore` shows the Explore page with mode switcher
- [x] Navigating to `/explore?mode=premieres` activates the Premieres mode
- [x] Clicking a mode button updates the URL and re-renders
- [x] Browser back/forward works correctly between modes
- [x] Direct navigation to `/explore` (browser refresh) works
- [x] All four mode buttons render; each shows placeholder content
- [x] All 93 Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)