### PR TITLE
feat: Explore — Now/Next mode

### DIFF
--- a/e2e/fixtures/api/explore-now-next.json
+++ b/e2e/fixtures/api/explore-now-next.json
@@ -1,0 +1,74 @@
+[
+  {
+    "channelId": "ch1",
+    "channelName": "ABC",
+    "current": {
+      "channelId": "ch1",
+      "start": "2025-06-10T13:00:00Z",
+      "stop": "2025-06-10T14:30:00Z",
+      "title": "News at Noon",
+      "isRepeat": false,
+      "isPremiere": false
+    },
+    "next": {
+      "channelId": "ch1",
+      "start": "2025-06-10T14:30:00Z",
+      "stop": "2025-06-10T15:30:00Z",
+      "title": "Afternoon Show",
+      "isRepeat": false,
+      "isPremiere": false
+    }
+  },
+  {
+    "channelId": "ch2",
+    "channelName": "SBS",
+    "current": {
+      "channelId": "ch2",
+      "start": "2025-06-10T12:00:00Z",
+      "stop": "2025-06-10T16:00:00Z",
+      "title": "Movie Marathon",
+      "isRepeat": false,
+      "isPremiere": false
+    },
+    "next": {
+      "channelId": "ch2",
+      "start": "2025-06-10T16:00:00Z",
+      "stop": "2025-06-10T17:00:00Z",
+      "title": "SBS World News",
+      "isRepeat": false,
+      "isPremiere": false
+    }
+  },
+  {
+    "channelId": "ch3",
+    "channelName": "Seven",
+    "current": null,
+    "next": {
+      "channelId": "ch3",
+      "start": "2025-06-10T17:00:00Z",
+      "stop": "2025-06-10T17:30:00Z",
+      "title": "Seven News",
+      "isRepeat": false,
+      "isPremiere": false
+    }
+  },
+  {
+    "channelId": "ch4",
+    "channelName": "Nine",
+    "current": {
+      "channelId": "ch4",
+      "start": "2025-06-10T10:00:00Z",
+      "stop": "2025-06-10T18:00:00Z",
+      "title": "Cricket",
+      "isRepeat": false,
+      "isPremiere": false
+    },
+    "next": null
+  },
+  {
+    "channelId": "ch5",
+    "channelName": "Ten",
+    "current": null,
+    "next": null
+  }
+]

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -3,6 +3,7 @@ import channelsFixture from './api/channels.json';
 import guideTodayFixture from './api/guide-today.json';
 import categoriesFixture from './api/categories.json';
 import searchResultsFixture from './api/search-results.json';
+import exploreNowNextFixture from './api/explore-now-next.json';
 
 export const FIXED_NOW = new Date('2025-06-10T14:00:00.000Z').getTime();
 
@@ -19,6 +20,7 @@ export async function setupApiRoutes(
     '/api/guide**': guideTodayFixture,
     '/api/categories': categoriesFixture,
     '/api/search**': searchResultsFixture,
+    '/api/explore/now-next': exploreNowNextFixture,
   };
 
   for (const [pattern, body] of Object.entries(defaultRoutes)) {

--- a/e2e/pages/ExplorePage.ts
+++ b/e2e/pages/ExplorePage.ts
@@ -42,4 +42,21 @@ export class ExplorePage extends AppPage {
   async activeMode(): Promise<string> {
     return (await this.activeModeButton.getAttribute('data-mode')) ?? '';
   }
+
+  // Now/Next mode
+  get nowNextList(): Locator {
+    return this.page.locator('.now-next-list');
+  }
+
+  nowNextRow(channelId: string): Locator {
+    return this.page.locator(`.now-next-row[data-channel-id="${channelId}"]`);
+  }
+
+  get loadingIndicator(): Locator {
+    return this.page.locator('.explore-loading');
+  }
+
+  get errorMessage(): Locator {
+    return this.page.locator('.explore-error');
+  }
 }

--- a/e2e/tests/explore.spec.ts
+++ b/e2e/tests/explore.spec.ts
@@ -102,14 +102,92 @@ test.describe('Explore tab — Mode switcher', () => {
     expect(await explore.activeMode()).toBe('categories');
   });
 
-  test('each mode shows placeholder content', async ({ page }) => {
+  test('non-implemented modes show placeholder content', async ({ page }) => {
     const explore = new ExplorePage(page);
     await explore.goto();
 
-    for (const mode of ['now-next', 'categories', 'premieres', 'time-slot']) {
+    for (const mode of ['categories', 'premieres', 'time-slot']) {
       await explore.clickMode(mode);
       await expect(explore.contentArea).toContainText('Coming soon');
     }
+  });
+});
+
+test.describe('Explore tab — Now/Next mode', () => {
+  test('renders a row per channel with data', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    await expect(explore.nowNextRow('ch1')).toBeVisible();
+    await expect(explore.nowNextRow('ch2')).toBeVisible();
+    await expect(explore.nowNextRow('ch3')).toBeVisible();
+    await expect(explore.nowNextRow('ch4')).toBeVisible();
+  });
+
+  test('shows channel name in each row', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    await expect(explore.nowNextRow('ch1')).toContainText('ABC');
+    await expect(explore.nowNextRow('ch2')).toContainText('SBS');
+  });
+
+  test('shows current show title with time remaining', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    // ch1: "News at Noon", stops at 14:30, now is ~14:00 → ~30 min remaining
+    await expect(explore.nowNextRow('ch1')).toContainText('News at Noon');
+    await expect(explore.nowNextRow('ch1')).toContainText(/ends in \d+ min/);
+  });
+
+  test('shows next show title with start time', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    // ch1 next: "Afternoon Show" starts at 14:30Z
+    await expect(explore.nowNextRow('ch1')).toContainText('Afternoon Show');
+  });
+
+  test('shows "Nothing airing" when current is null', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    // ch3 has no current show
+    await expect(explore.nowNextRow('ch3')).toContainText('Nothing airing');
+  });
+
+  test('omits next section when next is null', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    // ch4 has no next show — its row should exist but no "next" content
+    const row = explore.nowNextRow('ch4');
+    await expect(row).toBeVisible();
+    await expect(row.locator('.now-next-next')).not.toBeVisible();
+  });
+
+  test('channels with both null current and null next are shown at the bottom', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    // ch5 has no current and no next — should still appear but at the bottom
+    const rows = explore.nowNextList.locator('.now-next-row');
+    const count = await rows.count();
+    const lastRow = rows.nth(count - 1);
+    await expect(lastRow).toHaveAttribute('data-channel-id', 'ch5');
+  });
+
+  test('shows error state when API fails', async ({ page, setupApiRoutes }) => {
+    await setupApiRoutes({ '/api/explore/now-next': null });
+    await page.route('/api/explore/now-next', route =>
+      route.fulfill({ status: 500, body: 'Internal Server Error' })
+    );
+
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    await expect(explore.errorMessage).toBeVisible();
   });
 });
 

--- a/web/js/pages/explore.js
+++ b/web/js/pages/explore.js
@@ -1,3 +1,5 @@
+import { formatTime } from '../utils/date.js';
+
 const MODES = [
     { id: 'now-next',   label: 'Now/Next' },
     { id: 'categories', label: 'Categories' },
@@ -39,6 +41,105 @@ export function loadExplorePage() {
     // Content area
     const content = document.createElement('div');
     content.className = 'explore-content';
-    content.innerHTML = '<p>Coming soon</p>';
+
+    if (activeMode === 'now-next') {
+        renderNowNextMode(content);
+    } else {
+        content.innerHTML = '<p>Coming soon</p>';
+    }
+
     container.appendChild(content);
+}
+
+async function renderNowNextMode(container) {
+    const loading = document.createElement('div');
+    loading.className = 'explore-loading';
+    loading.textContent = 'Loading…';
+    container.appendChild(loading);
+
+    let entries;
+    try {
+        const res = await fetch('/api/explore/now-next');
+        if (!res.ok) throw new Error(`/api/explore/now-next returned ${res.status}`);
+        entries = await res.json();
+    } catch (err) {
+        container.innerHTML = '';
+        const error = document.createElement('div');
+        error.className = 'explore-error';
+        error.textContent = 'Failed to load data. Please try again.';
+        container.appendChild(error);
+        return;
+    }
+
+    container.innerHTML = '';
+
+    const now = Date.now();
+
+    // Sort: channels with both null go to the bottom
+    const withData = entries.filter(e => e.current !== null || e.next !== null);
+    const nullBoth = entries.filter(e => e.current === null && e.next === null);
+    const sorted = [...withData, ...nullBoth];
+
+    const list = document.createElement('div');
+    list.className = 'now-next-list';
+
+    for (const entry of sorted) {
+        const row = document.createElement('div');
+        row.className = 'now-next-row';
+        row.dataset.channelId = entry.channelId;
+
+        // Channel name
+        const channelName = document.createElement('div');
+        channelName.className = 'now-next-channel';
+        channelName.textContent = entry.channelName;
+        row.appendChild(channelName);
+
+        // Current show
+        const currentDiv = document.createElement('div');
+        currentDiv.className = 'now-next-current';
+        if (entry.current) {
+            const stopTime = new Date(entry.current.stop).getTime();
+            const minsRemaining = Math.floor((stopTime - now) / 60000);
+
+            const badge = document.createElement('span');
+            badge.className = 'now-badge';
+            badge.textContent = 'now';
+            currentDiv.appendChild(badge);
+
+            const title = document.createElement('span');
+            title.className = 'now-next-title';
+            title.textContent = entry.current.title;
+            currentDiv.appendChild(title);
+
+            const remaining = document.createElement('span');
+            remaining.className = 'now-next-remaining';
+            remaining.textContent = `ends in ${minsRemaining} min`;
+            currentDiv.appendChild(remaining);
+        } else {
+            currentDiv.textContent = 'Nothing airing';
+        }
+        row.appendChild(currentDiv);
+
+        // Next show
+        if (entry.next) {
+            const nextDiv = document.createElement('div');
+            nextDiv.className = 'now-next-next';
+
+            const nextTitle = document.createElement('span');
+            nextTitle.className = 'now-next-title';
+            nextTitle.textContent = entry.next.title;
+            nextDiv.appendChild(nextTitle);
+
+            const nextTime = document.createElement('span');
+            nextTime.className = 'now-next-time';
+            nextTime.textContent = formatTime(new Date(entry.next.start));
+            nextDiv.appendChild(nextTime);
+
+            row.appendChild(nextDiv);
+        }
+
+        list.appendChild(row);
+    }
+
+    container.appendChild(list);
 }

--- a/web/style/explore.css
+++ b/web/style/explore.css
@@ -52,3 +52,84 @@
     color: var(--text-secondary);
     font-size: 14px;
 }
+
+/* ── Now/Next mode ─────────────────────────────────────────────── */
+
+.explore-loading,
+.explore-error {
+    padding: 24px 0;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 14px;
+}
+
+.explore-error {
+    color: var(--text-error, #e05c5c);
+}
+
+.now-next-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.now-next-row {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px 14px;
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    grid-template-rows: auto auto;
+    gap: 4px 12px;
+}
+
+.now-next-channel {
+    grid-column: 1;
+    grid-row: 1 / 3;
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+}
+
+.now-next-current,
+.now-next-next {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    font-size: 13px;
+}
+
+.now-next-current {
+    color: var(--text-primary);
+}
+
+.now-next-next {
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+
+.now-badge {
+    background: var(--bg-programme);
+    color: var(--text-primary);
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    padding: 2px 6px;
+    border-radius: 4px;
+    letter-spacing: 0.04em;
+    flex-shrink: 0;
+}
+
+.now-next-remaining {
+    color: var(--text-secondary);
+    font-size: 12px;
+    flex-shrink: 0;
+}
+
+.now-next-time {
+    flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary
- Implements the Now/Next mode on the Explore page (closes #128)
- Fetches `GET /api/explore/now-next` and renders one row per channel showing the current show (title + time remaining + "now" badge) and next show (title + start time)
- Null current/next cases handled gracefully: "Nothing airing" for no current, next section omitted when absent, channels with both null sorted to the bottom
- Loading and error states shown appropriately

## Test plan
- [ ] 7 new UI tests in `e2e/tests/explore.spec.ts` covering all acceptance criteria
- [ ] All 101 existing tests continue to pass (`make test-ui`)
- [ ] Fixture `e2e/fixtures/api/explore-now-next.json` covers all edge cases (current+next, current only, next only, neither)

🤖 Generated with [Claude Code](https://claude.com/claude-code)