### PR TITLE
feat: Explore — Categories mode (#129)

### DIFF
--- a/e2e/fixtures/api/search-categories.json
+++ b/e2e/fixtures/api/search-categories.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "MasterChef Australia",
+    "airings": [
+      {
+        "channelId": "ch5",
+        "channelName": "Ten",
+        "startTime": "2025-06-10T19:00:00Z",
+        "stopTime": "2025-06-10T20:30:00Z",
+        "description": "The contestants face their toughest elimination challenge yet.",
+        "categories": ["Drama"],
+        "isRepeat": false,
+        "isPremiere": true
+      }
+    ]
+  },
+  {
+    "title": "Four Corners",
+    "airings": [
+      {
+        "channelId": "ch1",
+        "channelName": "ABC",
+        "startTime": "2025-06-10T20:00:00Z",
+        "stopTime": "2025-06-10T21:30:00Z",
+        "description": "In-depth investigative journalism.",
+        "categories": ["Documentary"],
+        "isRepeat": false,
+        "isPremiere": false
+      }
+    ]
+  }
+]

--- a/e2e/pages/ExplorePage.ts
+++ b/e2e/pages/ExplorePage.ts
@@ -59,4 +59,33 @@ export class ExplorePage extends AppPage {
   get errorMessage(): Locator {
     return this.page.locator('.explore-error');
   }
+
+  // Categories mode
+  get categoryPicker(): Locator {
+    return this.page.locator('.category-picker');
+  }
+
+  categoryButton(name: string): Locator {
+    return this.page.locator(`.category-picker-btn[data-category="${name}"]`);
+  }
+
+  get categoryResults(): Locator {
+    return this.page.locator('.category-results');
+  }
+
+  get categoryBackButton(): Locator {
+    return this.page.locator('.category-back-btn');
+  }
+
+  get categoryResultsTitle(): Locator {
+    return this.page.locator('.category-results-title');
+  }
+
+  get categorySearchGroups(): Locator {
+    return this.page.locator('.category-results .search-group');
+  }
+
+  get categoryEmpty(): Locator {
+    return this.page.locator('.category-empty');
+  }
 }

--- a/e2e/tests/explore.spec.ts
+++ b/e2e/tests/explore.spec.ts
@@ -106,10 +106,211 @@ test.describe('Explore tab — Mode switcher', () => {
     const explore = new ExplorePage(page);
     await explore.goto();
 
-    for (const mode of ['categories', 'premieres', 'time-slot']) {
+    for (const mode of ['premieres', 'time-slot']) {
       await explore.clickMode(mode);
       await expect(explore.contentArea).toContainText('Coming soon');
     }
+  });
+});
+
+test.describe('Explore tab — Categories mode', () => {
+  test('shows category picker with all available categories', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+
+    await expect(explore.categoryPicker).toBeVisible();
+    await expect(explore.categoryButton('Documentary')).toBeVisible();
+    await expect(explore.categoryButton('Drama')).toBeVisible();
+    await expect(explore.categoryButton('Film')).toBeVisible();
+    await expect(explore.categoryButton('News')).toBeVisible();
+    await expect(explore.categoryButton('Sport')).toBeVisible();
+  });
+
+  test('selecting a category fetches and displays results grouped by title', async ({ page, setupApiRoutes }) => {
+    await setupApiRoutes({ '/api/search**': { title: 'Drama', airings: [] } });
+    await page.route('/api/search**', (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get('categories') === 'Drama') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              title: 'MasterChef Australia',
+              airings: [
+                {
+                  channelId: 'ch5',
+                  channelName: 'Ten',
+                  startTime: '2025-06-10T19:00:00Z',
+                  stopTime: '2025-06-10T20:30:00Z',
+                  categories: ['Drama'],
+                  isRepeat: false,
+                  isPremiere: true,
+                },
+              ],
+            },
+          ]),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+    await explore.categoryButton('Drama').click();
+
+    await expect(explore.categoryResults).toBeVisible();
+    await expect(explore.categorySearchGroups.first()).toContainText('MasterChef Australia');
+  });
+
+  test('selecting a category updates the URL', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+
+    await explore.categoryButton('Sport').click();
+
+    expect(page.url()).toContain('mode=categories');
+    expect(page.url()).toContain('category=Sport');
+  });
+
+  test('back button returns to category picker', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+
+    await explore.categoryButton('Drama').click();
+    await expect(explore.categoryBackButton).toBeVisible();
+
+    await explore.categoryBackButton.click();
+
+    await expect(explore.categoryPicker).toBeVisible();
+    await expect(explore.categoryResults).not.toBeVisible();
+  });
+
+  test('browser back from category results returns to category picker', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+
+    await explore.categoryButton('Sport').click();
+    expect(page.url()).toContain('category=Sport');
+
+    await page.goBack();
+
+    await expect(explore.categoryPicker).toBeVisible();
+    await expect(explore.categoryResults).not.toBeVisible();
+    expect(page.url()).not.toContain('category=');
+  });
+
+  test('shows loading state while fetching category results', async ({ page }) => {
+    let resolveRoute: () => void;
+    await page.route('/api/search**', async (route) => {
+      await new Promise<void>(r => { resolveRoute = r; });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+    await explore.categoryButton('Drama').click();
+
+    await expect(explore.loadingIndicator).toBeVisible();
+    resolveRoute!();
+  });
+
+  test('shows error state when category search fails', async ({ page, setupApiRoutes }) => {
+    await setupApiRoutes({ '/api/search**': null });
+    await page.route('/api/search**', (route) =>
+      route.fulfill({ status: 500, body: 'Internal Server Error' })
+    );
+
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+    await explore.categoryButton('Drama').click();
+
+    await expect(explore.errorMessage).toBeVisible();
+  });
+
+  test('shows empty state when no airings exist for a category', async ({ page, setupApiRoutes }) => {
+    await setupApiRoutes({ '/api/search**': null });
+    await page.route('/api/search**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    );
+
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+    await explore.categoryButton('Film').click();
+
+    await expect(explore.categoryEmpty).toBeVisible();
+  });
+
+  test('shows results title indicating selected category', async ({ page, setupApiRoutes }) => {
+    await setupApiRoutes({ '/api/search**': null });
+    await page.route('/api/search**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    );
+
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+    await explore.categoryButton('Sport').click();
+
+    await expect(explore.categoryResultsTitle).toContainText('Sport');
+  });
+
+  test('direct navigation to /explore?mode=categories&category=Sport shows results', async ({ page, setupApiRoutes }) => {
+    await setupApiRoutes({ '/api/search**': null });
+    await page.route('/api/search**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            title: 'The Ashes',
+            airings: [
+              {
+                channelId: 'ch2',
+                channelName: 'SBS',
+                startTime: '2025-06-10T22:00:00Z',
+                stopTime: '2025-06-11T02:00:00Z',
+                categories: ['Sport'],
+                isRepeat: false,
+                isPremiere: false,
+              },
+            ],
+          },
+        ]),
+      })
+    );
+
+    const explore = new ExplorePage(page);
+    await explore.goto();
+    await page.goto('/explore?mode=categories&category=Sport');
+    await explore.waitForAppReady();
+
+    await expect(explore.categoryResults).toBeVisible();
+    await expect(explore.categorySearchGroups.first()).toContainText('The Ashes');
+  });
+
+  test('shows error state when categories API fails', async ({ page, setupApiRoutes }) => {
+    await setupApiRoutes({ '/api/categories': null });
+    await page.route('/api/categories', (route) =>
+      route.fulfill({ status: 500, body: 'Internal Server Error' })
+    );
+
+    const explore = new ExplorePage(page);
+    await explore.goto('categories');
+
+    await expect(explore.errorMessage).toBeVisible();
   });
 });
 

--- a/web/js/pages/explore.js
+++ b/web/js/pages/explore.js
@@ -1,4 +1,6 @@
-import { formatTime } from '../utils/date.js';
+import { formatTime, formatSearchDate } from '../utils/date.js';
+import { fetchCategories } from '../api.js';
+import { openSearchAiringModal } from '../components/modal.js';
 
 const MODES = [
     { id: 'now-next',   label: 'Now/Next' },
@@ -44,11 +46,163 @@ export function loadExplorePage() {
 
     if (activeMode === 'now-next') {
         renderNowNextMode(content);
+    } else if (activeMode === 'categories') {
+        renderCategoriesMode(content);
     } else {
         content.innerHTML = '<p>Coming soon</p>';
     }
 
     container.appendChild(content);
+}
+
+async function renderCategoriesMode(container) {
+    const params = new URLSearchParams(window.location.search);
+    const selectedCategory = params.get('category');
+
+    if (selectedCategory) {
+        await renderCategoryResults(container, selectedCategory);
+    } else {
+        await renderCategoryPicker(container);
+    }
+}
+
+async function renderCategoryPicker(container) {
+    const loading = document.createElement('div');
+    loading.className = 'explore-loading';
+    loading.textContent = 'Loading…';
+    container.appendChild(loading);
+
+    let categories;
+    try {
+        categories = await fetchCategories();
+    } catch (err) {
+        container.innerHTML = '';
+        const error = document.createElement('div');
+        error.className = 'explore-error';
+        error.textContent = 'Failed to load categories. Please try again.';
+        container.appendChild(error);
+        return;
+    }
+
+    container.innerHTML = '';
+
+    const picker = document.createElement('div');
+    picker.className = 'category-picker';
+
+    for (const cat of categories) {
+        const btn = document.createElement('button');
+        btn.className = 'category-picker-btn';
+        btn.dataset.category = cat;
+        btn.textContent = cat;
+        btn.addEventListener('click', () => {
+            history.pushState({}, '', '/explore?mode=categories&category=' + encodeURIComponent(cat));
+            container.innerHTML = '';
+            renderCategoryResults(container, cat);
+        });
+        picker.appendChild(btn);
+    }
+
+    container.appendChild(picker);
+}
+
+async function renderCategoryResults(container, category) {
+    container.innerHTML = '';
+
+    // Back button
+    const backBtn = document.createElement('button');
+    backBtn.className = 'category-back-btn';
+    backBtn.textContent = '← Back';
+    backBtn.addEventListener('click', () => {
+        history.back();
+    });
+    container.appendChild(backBtn);
+
+    // Results title
+    const title = document.createElement('div');
+    title.className = 'category-results-title';
+    title.textContent = category;
+    container.appendChild(title);
+
+    // Loading indicator
+    const loading = document.createElement('div');
+    loading.className = 'explore-loading';
+    loading.textContent = 'Loading…';
+    container.appendChild(loading);
+
+    let results;
+    try {
+        const searchParams = new URLSearchParams({
+            mode: 'advanced',
+            categories: category,
+            include_past: 'false',
+        });
+        const res = await fetch('/api/search?' + searchParams);
+        if (!res.ok) throw new Error(`/api/search returned ${res.status}`);
+        results = await res.json();
+    } catch (err) {
+        loading.remove();
+        const error = document.createElement('div');
+        error.className = 'explore-error';
+        error.textContent = 'Failed to load results. Please try again.';
+        container.appendChild(error);
+        return;
+    }
+
+    loading.remove();
+
+    const resultsContainer = document.createElement('div');
+    resultsContainer.className = 'category-results';
+
+    if (results.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'category-empty';
+        empty.textContent = 'No upcoming programmes found in this category.';
+        resultsContainer.appendChild(empty);
+        container.appendChild(resultsContainer);
+        return;
+    }
+
+    for (const group of results) {
+        const groupEl = document.createElement('div');
+        groupEl.className = 'search-group';
+
+        const titleEl = document.createElement('h3');
+        titleEl.className = 'search-group-title';
+        titleEl.textContent = group.title;
+        groupEl.appendChild(titleEl);
+
+        for (const airing of group.airings) {
+            const airingEl = document.createElement('div');
+            airingEl.className = 'search-airing';
+            airingEl.addEventListener('click', () => openSearchAiringModal(airing, group.title));
+
+            const channelEl = document.createElement('span');
+            channelEl.className = 'search-airing-channel';
+            channelEl.textContent = airing.channelName || airing.channelId;
+            airingEl.appendChild(channelEl);
+
+            const timeEl = document.createElement('span');
+            timeEl.className = 'search-airing-time';
+            timeEl.textContent = formatSearchDate(new Date(airing.startTime));
+            airingEl.appendChild(timeEl);
+
+            if (airing.episodeNumDisplay || airing.subTitle) {
+                const epEl = document.createElement('span');
+                epEl.className = 'search-airing-episode';
+                const parts = [];
+                if (airing.episodeNumDisplay) parts.push(airing.episodeNumDisplay);
+                if (airing.subTitle) parts.push(airing.subTitle);
+                epEl.textContent = parts.join(' - ');
+                airingEl.appendChild(epEl);
+            }
+
+            groupEl.appendChild(airingEl);
+        }
+
+        resultsContainer.appendChild(groupEl);
+    }
+
+    container.appendChild(resultsContainer);
 }
 
 async function renderNowNextMode(container) {

--- a/web/style/explore.css
+++ b/web/style/explore.css
@@ -133,3 +133,63 @@
 .now-next-time {
     flex-shrink: 0;
 }
+
+/* ── Categories mode ─────────────────────────────────────────────── */
+
+.category-picker {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.category-picker-btn {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: 14px;
+    padding: 10px 18px;
+    border-radius: 20px;
+    white-space: nowrap;
+    transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.category-picker-btn:hover {
+    border-color: var(--text-secondary);
+    background: var(--bg-programme);
+}
+
+.category-back-btn {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 14px;
+    padding: 0 0 12px;
+    display: block;
+    text-align: left;
+}
+
+.category-back-btn:hover {
+    color: var(--text-primary);
+}
+
+.category-results-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 16px;
+}
+
+.category-results {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.category-empty {
+    padding: 24px 0;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 14px;
+}


### PR DESCRIPTION
## Summary

- Implements the Categories mode on the Explore page (closes #129)
- Two-step flow: category picker → airing results for the selected category
- URL reflects selected category (`/explore?mode=categories&category=Sport`) so browser back returns to the picker
- Reuses `.search-group`/`.search-airing` result layout from the Search page
- Loading, error, and empty states handled in both steps

## Test plan

- [x] Category picker shows all categories from `/api/categories`
- [x] Selecting a category fetches `/api/search?mode=advanced&categories=<name>&include_past=false` and displays grouped results
- [x] Back button calls `history.back()` — returns to picker
- [x] URL updates on category selection; browser back restores picker
- [x] Direct navigation to `/explore?mode=categories&category=Sport` loads results immediately
- [x] Loading indicator visible while fetching results
- [x] Error state shown when categories or search API fails
- [x] Empty state shown when no upcoming airings exist for a category
- [x] All 112 existing UI tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)