### PR TITLE
feat: implement Time Slot mode on Explore page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ The app uses a bottom navigation bar (iOS-style) with four tabs:
 | Search | `/search` | Search for programmes by title or with advanced filters |
 | Favourites | `/favourites` | Saved search favourites — shows upcoming airings for all saved searches |
 | Settings | `/settings` | Channel visibility and favourite toggles |
-| Explore | `/explore` | Browse TV by mode: Now/Next (default), Categories, Premieres, Time Slot (coming soon) |
+| Explore | `/explore` | Browse TV by mode: Now/Next (default), Categories, Premieres, Time Slot |
 
 Navigation uses the **History API** (`pushState`/`popstate`) for client-side routing without full page reloads. The top bar (date display + prev/next day buttons) is only visible on the Guide tab. The Guide tab preserves its `?date=YYYY-MM-DD` query parameter behaviour.
 

--- a/e2e/pages/ExplorePage.ts
+++ b/e2e/pages/ExplorePage.ts
@@ -101,4 +101,21 @@ export class ExplorePage extends AppPage {
   get premieresEmpty(): Locator {
     return this.page.locator('.premieres-empty');
   }
+
+  // Time Slot mode
+  get timeSlotDateInput(): Locator {
+    return this.page.locator('.time-slot-date-input');
+  }
+
+  get timeSlotTimeSelect(): Locator {
+    return this.page.locator('.time-slot-time-select');
+  }
+
+  get timeSlotList(): Locator {
+    return this.page.locator('.time-slot-list');
+  }
+
+  timeSlotRow(channelId: string): Locator {
+    return this.page.locator(`.time-slot-row[data-channel-id="${channelId}"]`);
+  }
 }

--- a/e2e/tests/explore.spec.ts
+++ b/e2e/tests/explore.spec.ts
@@ -106,7 +106,7 @@ test.describe('Explore tab — Mode switcher', () => {
     const explore = new ExplorePage(page);
     await explore.goto();
 
-    for (const mode of ['time-slot']) {
+    for (const mode of [] as string[]) {
       await explore.clickMode(mode);
       await expect(explore.contentArea).toContainText('Coming soon');
     }
@@ -673,6 +673,204 @@ test.describe('Explore tab — Premieres mode', () => {
 
     await expect(explore.premieresEmpty).toBeVisible();
     await expect(explore.premieresEmpty).toContainText('No upcoming premieres found');
+  });
+});
+
+test.describe('Explore tab — Time Slot mode', () => {
+  test('shows a date picker and time picker', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    await expect(explore.timeSlotDateInput).toBeVisible();
+    await expect(explore.timeSlotTimeSelect).toBeVisible();
+  });
+
+  test('default date is today', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    // FIXED_NOW = 2025-06-10T14:00:00Z → today is 2025-06-10
+    await expect(explore.timeSlotDateInput).toHaveValue('2025-06-10');
+  });
+
+  test('default time is current hour rounded to nearest 30 min', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    // FIXED_NOW = 14:00 UTC → 14:00 local → rounded to 14:00
+    await expect(explore.timeSlotTimeSelect).toHaveValue('14:00');
+  });
+
+  test('shows one row per channel in channel sort order', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    await expect(explore.timeSlotRow('ch1')).toBeVisible();
+    await expect(explore.timeSlotRow('ch2')).toBeVisible();
+    await expect(explore.timeSlotRow('ch3')).toBeVisible();
+    await expect(explore.timeSlotRow('ch4')).toBeVisible();
+    await expect(explore.timeSlotRow('ch5')).toBeVisible();
+  });
+
+  test('shows channel name in each row', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    await expect(explore.timeSlotRow('ch1')).toContainText('ABC');
+    await expect(explore.timeSlotRow('ch2')).toContainText('SBS');
+  });
+
+  test('shows airing title for channel with a show at the selected time', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    // At 14:00, ch1 has "Afternoon Specials" (14:00–15:00)
+    await expect(explore.timeSlotRow('ch1')).toContainText('Afternoon Specials');
+  });
+
+  test('shows start–stop times for an airing', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    // ch1 at 14:00: Afternoon Specials 14:00–15:00
+    const row = explore.timeSlotRow('ch1');
+    await expect(row.locator('.time-slot-time')).toBeVisible();
+  });
+
+  test('shows "Nothing airing" for channels with no show at the selected time', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    // At 14:00, ch2 has nothing (Film ends 13:00, Dateline starts 15:00)
+    await expect(explore.timeSlotRow('ch2')).toContainText('Nothing airing');
+    await expect(explore.timeSlotRow('ch3')).toContainText('Nothing airing');
+  });
+
+  test('URL reflects the selected date and time on load', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    expect(page.url()).toContain('mode=time-slot');
+    expect(page.url()).toContain('date=2025-06-10');
+    expect(page.url()).toContain('time=14%3A00');
+  });
+
+  test('changing time filters results client-side without re-fetching', async ({ page, setupApiRoutes }) => {
+    await setupApiRoutes({ '/api/guide**': null });
+    let fetchCount = 0;
+    await page.route('/api/guide**', async (route) => {
+      fetchCount++;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            channelId: 'ch2',
+            start: '2025-06-10T15:00:00Z',
+            stop: '2025-06-10T17:00:00Z',
+            title: 'SBS Dateline',
+            isRepeat: false,
+            isPremiere: false,
+          },
+        ]),
+      });
+    });
+
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    const fetchesBefore = fetchCount;
+
+    // Change time to 15:00 — should filter client-side
+    await explore.timeSlotTimeSelect.selectOption('15:00');
+
+    // No additional fetch should have occurred
+    expect(fetchCount).toBe(fetchesBefore);
+    // ch2 now has SBS Dateline at 15:00
+    await expect(explore.timeSlotRow('ch2')).toContainText('SBS Dateline');
+  });
+
+  test('changing time updates the URL', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    await explore.timeSlotTimeSelect.selectOption('15:00');
+
+    expect(page.url()).toContain('time=15%3A00');
+  });
+
+  test('changing date re-fetches guide data', async ({ page, setupApiRoutes }) => {
+    await setupApiRoutes({ '/api/guide**': null });
+    let lastRequestedDate = '';
+    await page.route('/api/guide**', async (route) => {
+      const url = new URL(route.request().url());
+      lastRequestedDate = url.searchParams.get('date') ?? '';
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    const explore = new ExplorePage(page);
+    await explore.goto('time-slot');
+
+    // Set date input to a new date
+    await explore.timeSlotDateInput.fill('2025-06-11');
+    await explore.timeSlotDateInput.dispatchEvent('change');
+
+    await expect(explore.timeSlotList).toBeVisible();
+    expect(lastRequestedDate).toBe('2025-06-11');
+  });
+
+  test('shows loading state while fetching guide data', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    // Navigate to a different mode first so the app fully initializes
+    await explore.goto();
+
+    // Now block subsequent guide requests
+    let resolveRoute: () => void;
+    await page.route('/api/guide**', async (route) => {
+      await new Promise<void>(r => { resolveRoute = r; });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    // Switching to time-slot triggers a new guide fetch that is now blocked
+    await explore.clickMode('time-slot');
+
+    await expect(explore.loadingIndicator).toBeVisible();
+    resolveRoute!();
+  });
+
+  test('shows error state when guide API fails', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    // Navigate to a different mode first so the app fully initializes
+    await explore.goto();
+
+    // Now route guide requests to fail
+    await page.route('/api/guide**', (route) =>
+      route.fulfill({ status: 500, body: 'Internal Server Error' })
+    );
+
+    // Switching to time-slot triggers a new guide fetch that will fail
+    await explore.clickMode('time-slot');
+
+    await expect(explore.errorMessage).toBeVisible();
+  });
+
+  test('direct navigation with date and time in URL shows correct results', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await page.goto('/explore?mode=time-slot&date=2025-06-10&time=15:00');
+    await explore.waitForAppReady();
+
+    // At 15:00, ch2 has SBS Dateline (15:00–17:00)
+    await expect(explore.timeSlotRow('ch2')).toContainText('SBS Dateline');
+    await expect(explore.timeSlotDateInput).toHaveValue('2025-06-10');
+    await expect(explore.timeSlotTimeSelect).toHaveValue('15:00');
   });
 });
 

--- a/web/js/pages/explore.js
+++ b/web/js/pages/explore.js
@@ -1,6 +1,7 @@
-import { formatTime, formatSearchDate } from '../utils/date.js';
-import { fetchCategories } from '../api.js';
+import { formatTime, formatSearchDate, getTodayString } from '../utils/date.js';
+import { fetchCategories, fetchChannels } from '../api.js';
 import { openSearchAiringModal } from '../components/modal.js';
+import { state } from '../state.js';
 
 const MODES = [
     { id: 'now-next',   label: 'Now/Next' },
@@ -50,6 +51,8 @@ export function loadExplorePage() {
         renderCategoriesMode(content);
     } else if (activeMode === 'premieres') {
         renderPremieresMode(content);
+    } else if (activeMode === 'time-slot') {
+        renderTimeSlotMode(content);
     } else {
         content.innerHTML = '<p>Coming soon</p>';
     }
@@ -292,6 +295,156 @@ async function renderPremieresMode(container) {
     }
 
     container.appendChild(list);
+}
+
+function getRoundedTime(date) {
+    const h = date.getHours();
+    const m = date.getMinutes() < 30 ? 0 : 30;
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+async function renderTimeSlotMode(container) {
+    const params = new URLSearchParams(window.location.search);
+    const now = new Date();
+
+    const selectedDate = params.get('date') || getTodayString();
+    const selectedTime = params.get('time') || getRoundedTime(now);
+
+    // Controls
+    const controls = document.createElement('div');
+    controls.className = 'time-slot-controls';
+
+    const dateInput = document.createElement('input');
+    dateInput.type = 'date';
+    dateInput.className = 'time-slot-date-input';
+    dateInput.value = selectedDate;
+    controls.appendChild(dateInput);
+
+    const timeSelect = document.createElement('select');
+    timeSelect.className = 'time-slot-time-select';
+    for (let h = 0; h < 24; h++) {
+        for (const m of [0, 30]) {
+            const timeStr = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+            const opt = document.createElement('option');
+            opt.value = timeStr;
+            opt.textContent = timeStr;
+            if (timeStr === selectedTime) opt.selected = true;
+            timeSelect.appendChild(opt);
+        }
+    }
+    controls.appendChild(timeSelect);
+
+    container.appendChild(controls);
+
+    // Results area
+    const results = document.createElement('div');
+    results.className = 'time-slot-results';
+    container.appendChild(results);
+
+    let guideData = null;
+
+    function updateURL(date, time) {
+        const newParams = new URLSearchParams(window.location.search);
+        newParams.set('mode', 'time-slot');
+        newParams.set('date', date);
+        newParams.set('time', time);
+        history.replaceState({}, '', '/explore?' + newParams.toString());
+    }
+
+    function renderResults(date, time) {
+        results.innerHTML = '';
+
+        if (guideData === null) return;
+
+        const [y, mo, d] = date.split('-').map(Number);
+        const [th, tm] = time.split(':').map(Number);
+        const selectedMs = new Date(y, mo - 1, d, th, tm, 0, 0).getTime();
+
+        const list = document.createElement('div');
+        list.className = 'time-slot-list';
+
+        for (const channel of state.channels) {
+            const row = document.createElement('div');
+            row.className = 'time-slot-row';
+            row.dataset.channelId = channel.id;
+
+            const channelEl = document.createElement('div');
+            channelEl.className = 'time-slot-channel';
+            channelEl.textContent = channel.displayName;
+            row.appendChild(channelEl);
+
+            const airing = guideData.find(a =>
+                a.channelId === channel.id &&
+                new Date(a.start).getTime() <= selectedMs &&
+                new Date(a.stop).getTime() > selectedMs
+            );
+
+            const showEl = document.createElement('div');
+            showEl.className = 'time-slot-show';
+
+            if (airing) {
+                const titleEl = document.createElement('span');
+                titleEl.className = 'time-slot-title';
+                titleEl.textContent = airing.title;
+                showEl.appendChild(titleEl);
+
+                const timeEl = document.createElement('span');
+                timeEl.className = 'time-slot-time';
+                timeEl.textContent = `${formatTime(new Date(airing.start))} – ${formatTime(new Date(airing.stop))}`;
+                showEl.appendChild(timeEl);
+            } else {
+                showEl.textContent = 'Nothing airing';
+            }
+
+            row.appendChild(showEl);
+            list.appendChild(row);
+        }
+
+        results.appendChild(list);
+    }
+
+    async function fetchAndRender(date, time) {
+        updateURL(date, time);
+
+        results.innerHTML = '';
+        const loading = document.createElement('div');
+        loading.className = 'explore-loading';
+        loading.textContent = 'Loading…';
+        results.appendChild(loading);
+
+        try {
+            const needChannels = state.channels.length === 0;
+            const [guideResult, channelData] = await Promise.all([
+                fetch(`/api/guide?date=${date}`).then(r => {
+                    if (!r.ok) throw new Error(`/api/guide returned ${r.status}`);
+                    return r.json();
+                }),
+                needChannels ? fetchChannels() : Promise.resolve(state.channels),
+            ]);
+            guideData = guideResult;
+            if (needChannels) state.channels = channelData;
+        } catch (err) {
+            results.innerHTML = '';
+            const error = document.createElement('div');
+            error.className = 'explore-error';
+            error.textContent = 'Failed to load guide data. Please try again.';
+            results.appendChild(error);
+            return;
+        }
+
+        renderResults(date, time);
+    }
+
+    dateInput.addEventListener('change', () => {
+        fetchAndRender(dateInput.value, timeSelect.value);
+    });
+
+    timeSelect.addEventListener('change', () => {
+        updateURL(dateInput.value, timeSelect.value);
+        renderResults(dateInput.value, timeSelect.value);
+    });
+
+    await fetchAndRender(selectedDate, selectedTime);
 }
 
 async function renderNowNextMode(container) {

--- a/web/style/explore.css
+++ b/web/style/explore.css
@@ -255,3 +255,77 @@
     color: var(--text-secondary);
     font-size: 14px;
 }
+
+/* ── Time Slot mode ─────────────────────────────────────────────── */
+
+.time-slot-controls {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.time-slot-date-input,
+.time-slot-time-select {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    font-size: 14px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.time-slot-date-input:focus,
+.time-slot-time-select:focus {
+    outline: none;
+    border-color: var(--text-secondary);
+}
+
+.time-slot-results {
+    flex: 1;
+}
+
+.time-slot-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.time-slot-row {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px 14px;
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    gap: 4px 12px;
+    align-items: center;
+}
+
+.time-slot-channel {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 13px;
+}
+
+.time-slot-show {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--text-secondary);
+    flex-wrap: wrap;
+}
+
+.time-slot-title {
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.time-slot-time {
+    color: var(--text-secondary);
+    font-size: 12px;
+    flex-shrink: 0;
+}


### PR DESCRIPTION
Closes #131

## Summary
- Adds Time Slot mode to the Explore page with a date picker and 30-minute-increment time selector
- Fetches `/api/guide?date=<date>` on load/date change; filters client-side on time change (no re-fetch)
- Displays one row per channel showing the airing at the selected time, or "Nothing airing"
- URL reflects `mode=time-slot&date=YYYY-MM-DD&time=HH:MM`
- Co-fetches channels alongside first guide request if `state.channels` is not yet populated (handles direct URL navigation)

## Test plan
- [ ] 13 new UI tests covering all acceptance criteria (date/time defaults, channel rows, airing display, "Nothing airing", URL reflection, client-side filtering, date re-fetch, loading state, error state, direct navigation)
- [ ] All 135 UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)