### PR TITLE
docs: add HIDDEN_CHANNELS documentation and docker-compose example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ tvguide/
 | `IMAGE_CACHE_DIR` | `/data/images` | Directory for cached channel icon files. Files are stored at `{IMAGE_CACHE_DIR}/channels/{channel-id}.{ext}`. The directory is created on startup if absent. The `/data` volume already covers this path. |
 | `PORT` | `8080` | HTTP listen port |
 | `RSS_TTL` | `360` | Default TTL (time-to-live) in minutes for RSS feed responses. Tells feed readers how often to re-poll. Can be overridden per-request via the `ttl` query parameter on `/api/search`. Must be a positive integer; invalid values are ignored. |
-| `HIDDEN_CHANNELS` | *(unset)* | Comma-separated list of channels to exclude from all API responses. Integers are treated as LCN numbers; anything else is treated as a channel ID. Example: `ch1.xmltv.id,ch2.id,6,9,10` |
+| `HIDDEN_CHANNELS` | *(unset)* | Comma-separated list of channel IDs and/or LCN numbers to hide server-wide. Integer tokens are treated as LCN numbers; all other tokens are treated as channel IDs. Hidden channels are excluded from all API responses (`/api/channels`, `/api/guide`, `/api/search`, `/api/explore/now-next`). Example: `ch1.xmltv.id,6,9,10` |
 
 ## How to build and run
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       # RETENTION_DAYS: "7"
       # DB_PATH: "/data/tvguide.db"
       # REFRESH_ON_START: "false"
+      # HIDDEN_CHANNELS: "6,9,10"  # Comma-separated channel IDs or LCN numbers to hide for all users
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## Summary
- Updated `CLAUDE.md` `HIDDEN_CHANNELS` entry with clearer wording, specifying affected API endpoints (`/api/channels`, `/api/guide`, `/api/search`, `/api/explore/now-next`)
- Added commented-out `HIDDEN_CHANNELS` example to `docker-compose.yml`

Closes #148, closes #146

## Test plan
- Documentation-only change; no code changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)