### PR TITLE
feat: add CHANNEL_NAME_STRIP env var to strip words from channel display names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ tvguide/
 | `PORT` | `8080` | HTTP listen port |
 | `RSS_TTL` | `360` | Default TTL (time-to-live) in minutes for RSS feed responses. Tells feed readers how often to re-poll. Can be overridden per-request via the `ttl` query parameter on `/api/search`. Must be a positive integer; invalid values are ignored. |
 | `HIDDEN_CHANNELS` | *(unset)* | Comma-separated list of channel IDs and/or LCN numbers to hide server-wide. Integer tokens are treated as LCN numbers; all other tokens are treated as channel IDs. Hidden channels are excluded from all API responses (`/api/channels`, `/api/guide`, `/api/search`, `/api/explore/now-next`). Example: `ch1.xmltv.id,6,9,10` |
+| `CHANNEL_NAME_STRIP` | *(unset)* | Comma-separated list of words/phrases to strip from all channel display names at refresh time. Matching is case-insensitive; resulting names are trimmed of surrounding whitespace. Example: `Melbourne,Victoria` turns "ABC Melbourne" into "ABC" and "Nine Victoria" into "Nine". |
 
 ## How to build and run
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -64,7 +64,7 @@ func startMockXMLTVServer(t *testing.T, xmlContent string) *countingServer {
 func newIntegrationServer(t *testing.T, xmltvURL string) *httptest.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, xmltvURL, images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, xmltvURL, images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -399,7 +399,7 @@ func TestStartup_FreshInstall_AlwaysFetches(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -425,7 +425,7 @@ func TestStartup_ExistingData_SkipsFetch(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -459,7 +459,7 @@ func TestStartup_RefreshOnStart_FetchesEvenWithData(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -685,7 +685,7 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	db, err := database.Open(
 		filepath.Join(dir, "test.db"), 7, mockSrv.URL+"/xmltv",
 		images.NewCache(mockSrv.Client(), filepath.Join(dir, "images")),
-		nil, nil,
+		nil, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("Open: %v", err)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -40,7 +40,7 @@ func startFakeIconServer(t *testing.T) *httptest.Server {
 func newSeededServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -97,7 +97,7 @@ func newSeededServer(t *testing.T) *httptest.Server {
 func newSeededServerWithIcons(t *testing.T, iconSrv *httptest.Server) (*httptest.Server, *database.DB) {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(iconSrv.Client(), filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(iconSrv.Client(), filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestGetChannelIcon_RedownloadsIfMissing(t *testing.T) {
 func newSearchSeededServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -783,7 +783,7 @@ func TestCategories_ReturnsSortedList(t *testing.T) {
 
 func TestCategories_EmptyWhenNoData(t *testing.T) {
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -818,7 +818,7 @@ func TestCategories_EmptyWhenNoData(t *testing.T) {
 // would produce a different order.
 func TestSearch_AiringsOrderedByStartTime(t *testing.T) {
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -920,7 +920,7 @@ func (c fixedClock) Now() time.Time { return c.t }
 
 func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -1022,7 +1022,7 @@ func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 
 func TestSearch_TodayFilter_AdvancedMode(t *testing.T) {
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -1151,7 +1151,7 @@ func TestGetChannels_IconIsProxyURL(t *testing.T) {
 func newBrowseSeededServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -1421,7 +1421,7 @@ type rssEnclosure struct {
 func newRSSSeededServer(t *testing.T, rssTTL int) *httptest.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -1985,7 +1985,7 @@ func newNowNextServer(t *testing.T) (*httptest.Server, time.Time) {
 	db, err := database.Open(
 		filepath.Join(dir, "test.db"), 7, "http://test-source",
 		images.NewCache(&http.Client{}, filepath.Join(dir, "images")),
-		nil, nil,
+		nil, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("Open: %v", err)

--- a/internal/database/channel_name_strip_test.go
+++ b/internal/database/channel_name_strip_test.go
@@ -1,0 +1,155 @@
+package database_test
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/images"
+	"github.com/acbgbca/xmltvguide/internal/xmltv"
+)
+
+// openTestDBWithStripWords opens a fresh database configured with the given strip words.
+func openTestDBWithStripWords(t *testing.T, stripWords []string) *database.DB {
+	t.Helper()
+	dir := t.TempDir()
+	client := &http.Client{Transport: &failingTransport{}}
+	cache := images.NewCache(client, filepath.Join(dir, "images"))
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", cache, nil, nil, stripWords)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// stripSampleTV returns a TV with channels that have geographic suffixes to strip.
+func stripSampleTV() *xmltv.TV {
+	base := testBaseDate()
+	return &xmltv.TV{
+		Channels: []xmltv.Channel{
+			{
+				ID:           "ch1",
+				DisplayNames: []xmltv.Name{{Value: "ABC Melbourne"}},
+				LCN:          "2",
+			},
+			{
+				ID:           "ch2",
+				DisplayNames: []xmltv.Name{{Value: "Nine Victoria"}},
+			},
+			{
+				ID:           "ch3",
+				DisplayNames: []xmltv.Name{{Value: "Seven"}},
+			},
+		},
+		Programmes: []xmltv.Programme{
+			{
+				Start:   xmltv.XmltvTime{Time: base.Add(6 * time.Hour)},
+				Stop:    xmltv.XmltvTime{Time: base.Add(7 * time.Hour)},
+				Channel: "ch1",
+				Titles:  []xmltv.Name{{Value: "Morning News"}},
+			},
+		},
+	}
+}
+
+// TestRefresh_ChannelNameStrip verifies that a strip word is removed from display names.
+func TestRefresh_ChannelNameStrip(t *testing.T) {
+	db := openTestDBWithStripWords(t, []string{"Melbourne"})
+	tv := stripSampleTV()
+	if err := db.Refresh(context.Background(), tv, testBaseDate()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	channels, err := db.GetChannels()
+	if err != nil {
+		t.Fatalf("GetChannels: %v", err)
+	}
+
+	for _, ch := range channels {
+		if ch.ID == "ch1" {
+			if ch.DisplayName != "ABC" {
+				t.Errorf("expected name %q, got %q", "ABC", ch.DisplayName)
+			}
+		}
+		if ch.ID == "ch2" {
+			if ch.DisplayName != "Nine Victoria" {
+				t.Errorf("expected name %q (unaffected), got %q", "Nine Victoria", ch.DisplayName)
+			}
+		}
+	}
+}
+
+// TestRefresh_ChannelNameStrip_CaseInsensitive verifies that strip words match regardless of case.
+func TestRefresh_ChannelNameStrip_CaseInsensitive(t *testing.T) {
+	db := openTestDBWithStripWords(t, []string{"melbourne"})
+	tv := stripSampleTV()
+	if err := db.Refresh(context.Background(), tv, testBaseDate()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	channels, err := db.GetChannels()
+	if err != nil {
+		t.Fatalf("GetChannels: %v", err)
+	}
+
+	for _, ch := range channels {
+		if ch.ID == "ch1" {
+			if ch.DisplayName != "ABC" {
+				t.Errorf("expected name %q, got %q (case-insensitive strip failed)", "ABC", ch.DisplayName)
+			}
+		}
+	}
+}
+
+// TestRefresh_ChannelNameStrip_TrimSpace verifies that the result is trimmed of surrounding whitespace.
+func TestRefresh_ChannelNameStrip_TrimSpace(t *testing.T) {
+	db := openTestDBWithStripWords(t, []string{"Victoria"})
+	tv := stripSampleTV()
+	if err := db.Refresh(context.Background(), tv, testBaseDate()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	channels, err := db.GetChannels()
+	if err != nil {
+		t.Fatalf("GetChannels: %v", err)
+	}
+
+	for _, ch := range channels {
+		if ch.ID == "ch2" {
+			if ch.DisplayName != "Nine" {
+				t.Errorf("expected trimmed name %q, got %q", "Nine", ch.DisplayName)
+			}
+		}
+	}
+}
+
+// TestRefresh_ChannelNameStrip_Empty verifies that empty CHANNEL_NAME_STRIP leaves names unchanged.
+func TestRefresh_ChannelNameStrip_Empty(t *testing.T) {
+	db := openTestDBWithStripWords(t, nil)
+	tv := stripSampleTV()
+	if err := db.Refresh(context.Background(), tv, testBaseDate()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	channels, err := db.GetChannels()
+	if err != nil {
+		t.Fatalf("GetChannels: %v", err)
+	}
+
+	for _, ch := range channels {
+		switch ch.ID {
+		case "ch1":
+			if ch.DisplayName != "ABC Melbourne" {
+				t.Errorf("expected unchanged name %q, got %q", "ABC Melbourne", ch.DisplayName)
+			}
+		case "ch2":
+			if ch.DisplayName != "Nine Victoria" {
+				t.Errorf("expected unchanged name %q, got %q", "Nine Victoria", ch.DisplayName)
+			}
+		}
+	}
+}

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -57,6 +57,7 @@ type DB struct {
 	clock         Clock
 	hiddenIDs     []string
 	hiddenLCNs    []int
+	stripWords    []string
 
 	// lastRefresh and nextRefresh are kept in memory — they reflect the current
 	// process's poll cycle and reset on restart, which is intentional.
@@ -192,7 +193,9 @@ func columnExists(db *sql.DB, table, column string) (bool, error) {
 // imageCache handles icon downloading and caching; pass nil to disable icon caching.
 // hiddenIDs and hiddenLCNs specify channels to exclude from all query results;
 // pass nil (or empty slices) for no filtering.
-func Open(path string, retentionDays int, sourceURL string, imageCache *images.Cache, hiddenIDs []string, hiddenLCNs []int) (*DB, error) {
+// stripWords specifies words/phrases to strip from channel display names at refresh time;
+// matching is case-insensitive. Pass nil or empty slice for no stripping.
+func Open(path string, retentionDays int, sourceURL string, imageCache *images.Cache, hiddenIDs []string, hiddenLCNs []int, stripWords []string) (*DB, error) {
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
@@ -228,6 +231,7 @@ func Open(path string, retentionDays int, sourceURL string, imageCache *images.C
 		clock:         realClock{},
 		hiddenIDs:     hiddenIDs,
 		hiddenLCNs:    hiddenLCNs,
+		stripWords:    stripWords,
 	}, nil
 }
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -36,7 +36,7 @@ func openTestDB(t *testing.T) *database.DB {
 	dir := t.TempDir()
 	client := &http.Client{Transport: &failingTransport{}}
 	cache := images.NewCache(client, filepath.Join(dir, "images"))
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", cache, nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", cache, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -50,7 +50,7 @@ func openTestDBWithIconServer(t *testing.T, iconServer *httptest.Server) *databa
 	t.Helper()
 	dir := t.TempDir()
 	cache := images.NewCache(iconServer.Client(), filepath.Join(dir, "images"))
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", cache, nil, nil)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", cache, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/internal/database/hidden_channels_test.go
+++ b/internal/database/hidden_channels_test.go
@@ -16,7 +16,7 @@ func openTestDBHidden(t *testing.T, hiddenIDs []string, hiddenLCNs []int) *datab
 	dir := t.TempDir()
 	client := &http.Client{Transport: &failingTransport{}}
 	cache := images.NewCache(client, filepath.Join(dir, "images"))
-	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", cache, hiddenIDs, hiddenLCNs)
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", cache, hiddenIDs, hiddenLCNs, nil)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/internal/database/migrations_test.go
+++ b/internal/database/migrations_test.go
@@ -85,7 +85,7 @@ func openDBAt(t *testing.T, path string) *database.DB {
 	dir := filepath.Dir(path)
 	client := &http.Client{Transport: &failingTransport{}}
 	cache := images.NewCache(client, filepath.Join(dir, "images"))
-	db, err := database.Open(path, 7, "http://test", cache, nil, nil)
+	db, err := database.Open(path, 7, "http://test", cache, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("database.Open: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestMigration_PopulateSQL_SkipsAlreadyApplied(t *testing.T) {
 	{
 		client := &http.Client{Transport: &failingTransport{}}
 		cache := images.NewCache(client, filepath.Join(dir, "images"))
-		db1, err := database.Open(dbPath, 7, "http://test", cache, nil, nil)
+		db1, err := database.Open(dbPath, 7, "http://test", cache, nil, nil, nil)
 		if err != nil {
 			t.Fatalf("database.Open (first): %v", err)
 		}
@@ -177,7 +177,7 @@ func TestMigration_PopulateSQL_SkipsAlreadyApplied(t *testing.T) {
 
 	// Second open: migrations are already recorded — populateSQL should NOT run.
 	cache := images.NewCache(&http.Client{Transport: &failingTransport{}}, filepath.Join(dir, "images2"))
-	db2, err := database.Open(dbPath, 7, "http://test", cache, nil, nil)
+	db2, err := database.Open(dbPath, 7, "http://test", cache, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("database.Open (second): %v", err)
 	}

--- a/internal/database/refresh.go
+++ b/internal/database/refresh.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
@@ -123,6 +124,10 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 		if len(ch.DisplayNames) > 0 && ch.DisplayNames[0].Value != "" {
 			name = ch.DisplayNames[0].Value
 		}
+		for _, w := range d.stripWords {
+			name = stripWordCaseInsensitive(name, w)
+		}
+		name = strings.TrimSpace(name)
 		var icon, iconURL any
 		if ri, ok := resolved[ch.ID]; ok {
 			if ri.localPath != "" {
@@ -229,4 +234,28 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	d.mu.Unlock()
 
 	return nil
+}
+
+// stripWordCaseInsensitive removes all occurrences of word from s, case-insensitively.
+// Both s and word are lowercased for comparison; the original casing of non-matched
+// characters in s is preserved. The word must be non-empty.
+func stripWordCaseInsensitive(s, word string) string {
+	if word == "" {
+		return s
+	}
+	sLower := strings.ToLower(s)
+	wLower := strings.ToLower(word)
+	wLen := len(wLower)
+	var result strings.Builder
+	for {
+		idx := strings.Index(sLower, wLower)
+		if idx < 0 {
+			result.WriteString(s)
+			break
+		}
+		result.WriteString(s[:idx])
+		s = s[idx+wLen:]
+		sLower = sLower[idx+wLen:]
+	}
+	return result.String()
 }

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 	}
 
 	hiddenIDs, hiddenLCNs := parseHiddenChannels(os.Getenv("HIDDEN_CHANNELS"))
+	stripWords := parseStripWords(os.Getenv("CHANNEL_NAME_STRIP"))
 
 	// Ensure the database directory exists (relevant when running outside Docker).
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
@@ -80,7 +81,7 @@ func main() {
 
 	imageCache := images.NewCache(httpClient, imageCacheDir)
 
-	db, err := database.Open(dbPath, retentionDays, xmltvURL, imageCache, hiddenIDs, hiddenLCNs)
+	db, err := database.Open(dbPath, retentionDays, xmltvURL, imageCache, hiddenIDs, hiddenLCNs, stripWords)
 	if err != nil {
 		log.Fatalf("opening database: %v", err)
 	}
@@ -190,6 +191,21 @@ func spaHandler(fsys http.FileSystem) http.Handler {
 		r.URL.Path = "/"
 		fileServer.ServeHTTP(w, r)
 	})
+}
+
+// parseStripWords splits the CHANNEL_NAME_STRIP value on commas and trims whitespace.
+func parseStripWords(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var words []string
+	for _, token := range strings.Split(raw, ",") {
+		token = strings.TrimSpace(token)
+		if token != "" {
+			words = append(words, token)
+		}
+	}
+	return words
 }
 
 // parseHiddenChannels splits the HIDDEN_CHANNELS value on commas and classifies


### PR DESCRIPTION
## Summary

- Adds `CHANNEL_NAME_STRIP` environment variable (comma-separated) to strip specified words/phrases from channel display names at XMLTV refresh time
- Matching is case-insensitive; results are trimmed of surrounding whitespace
- Follows the same pattern as `HIDDEN_CHANNELS`
- Closes #151

## Test plan

- [x] `TestRefresh_ChannelNameStrip` — word is removed from display name
- [x] `TestRefresh_ChannelNameStrip_CaseInsensitive` — strip word matches regardless of case
- [x] `TestRefresh_ChannelNameStrip_TrimSpace` — result is trimmed of surrounding whitespace
- [x] `TestRefresh_ChannelNameStrip_Empty` — empty config leaves names unchanged
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)