### PR TITLE
fix: resolve errcheck and appendAssign lint findings in production code

### DIFF
--- a/internal/database/airings.go
+++ b/internal/database/airings.go
@@ -3,6 +3,7 @@ package database
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -42,7 +43,11 @@ func (d *DB) GetAirings(date time.Time) ([]model.Airing, error) {
 	if err != nil {
 		return nil, fmt.Errorf("querying airings: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("closing airing rows: %v", err)
+		}
+	}()
 
 	airings := []model.Airing{}
 	for rows.Next() {
@@ -77,7 +82,11 @@ func (d *DB) scanAirings(query string, args ...any) ([]model.Airing, error) {
 	if err != nil {
 		return nil, fmt.Errorf("querying airings: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("closing airing rows: %v", err)
+		}
+	}()
 
 	airings := []model.Airing{}
 	for rows.Next() {

--- a/internal/database/channels.go
+++ b/internal/database/channels.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"log"
 
 	"github.com/acbgbca/xmltvguide/internal/model"
 )
@@ -19,7 +20,11 @@ func (d *DB) GetChannels() ([]model.Channel, error) {
 	if err != nil {
 		return nil, fmt.Errorf("querying channels: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("closing channel rows: %v", err)
+		}
+	}()
 
 	channels := []model.Channel{}
 	for rows.Next() {

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -174,7 +175,11 @@ func columnExists(db *sql.DB, table, column string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("closing column info rows: %v", err)
+		}
+	}()
 	for rows.Next() {
 		var cid, notNull, pk int
 		var name, colType string
@@ -208,18 +213,24 @@ func Open(path string, retentionDays int, sourceURL string, imageCache *images.C
 		"PRAGMA temp_store=MEMORY", // scratch image has no /tmp; keep all temp data in RAM
 	} {
 		if _, err := db.Exec(pragma); err != nil {
-			db.Close()
+			if closeErr := db.Close(); closeErr != nil {
+				log.Printf("closing database after pragma error: %v", closeErr)
+			}
 			return nil, fmt.Errorf("setting %s: %w", pragma, err)
 		}
 	}
 
 	if _, err := db.Exec(schema); err != nil {
-		db.Close()
+		if closeErr := db.Close(); closeErr != nil {
+			log.Printf("closing database after schema error: %v", closeErr)
+		}
 		return nil, fmt.Errorf("applying schema: %w", err)
 	}
 
 	if err := applyMigrations(db); err != nil {
-		db.Close()
+		if closeErr := db.Close(); closeErr != nil {
+			log.Printf("closing database after migration error: %v", closeErr)
+		}
 		return nil, err
 	}
 

--- a/internal/database/nownext.go
+++ b/internal/database/nownext.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/acbgbca/xmltvguide/internal/model"
@@ -38,7 +39,11 @@ func (d *DB) GetNowNext() ([]model.NowNextEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("querying current airings: %w", err)
 	}
-	defer currentRows.Close()
+	defer func() {
+		if err := currentRows.Close(); err != nil {
+			log.Printf("closing current rows: %v", err)
+		}
+	}()
 
 	current := map[string]*model.Airing{}
 	for currentRows.Next() {
@@ -74,7 +79,11 @@ func (d *DB) GetNowNext() ([]model.NowNextEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("querying next airings: %w", err)
 	}
-	defer nextRows.Close()
+	defer func() {
+		if err := nextRows.Close(); err != nil {
+			log.Printf("closing next rows: %v", err)
+		}
+	}()
 
 	next := map[string]*model.Airing{}
 	for nextRows.Next() {

--- a/internal/database/refresh.go
+++ b/internal/database/refresh.go
@@ -2,7 +2,9 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -24,7 +26,11 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	if rows, err := d.db.QueryContext(ctx,
 		`SELECT id, COALESCE(icon, ''), COALESCE(icon_url, '') FROM channels`,
 	); err == nil {
-		defer rows.Close()
+		defer func() {
+			if err := rows.Close(); err != nil {
+				log.Printf("closing channel rows: %v", err)
+			}
+		}()
 		for rows.Next() {
 			var id, localPath, iconURL string
 			if rows.Scan(&id, &localPath, &iconURL) == nil {
@@ -89,13 +95,19 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	if err != nil {
 		return fmt.Errorf("beginning transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+			log.Printf("rollback error: %v", rbErr)
+		}
+	}()
 
 	// Delete any previously stored data for channels that are now hidden.
 	// Airings must be deleted before channels due to the foreign key constraint.
 	if len(d.hiddenIDs) > 0 || len(d.hiddenLCNs) > 0 {
 		idArgs, lcnArgs, filterSQL := buildHiddenFilter(d.hiddenIDs, d.hiddenLCNs)
-		deleteArgs := append(idArgs, lcnArgs...)
+		deleteArgs := make([]any, 0, len(idArgs)+len(lcnArgs))
+		deleteArgs = append(deleteArgs, idArgs...)
+		deleteArgs = append(deleteArgs, lcnArgs...)
 		if _, err := tx.Exec(
 			`DELETE FROM airings WHERE channel_id IN (SELECT id FROM channels WHERE `+filterSQL+`)`,
 			deleteArgs...,
@@ -114,7 +126,11 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	if err != nil {
 		return fmt.Errorf("preparing channel upsert: %w", err)
 	}
-	defer chStmt.Close()
+	defer func() {
+		if err := chStmt.Close(); err != nil {
+			log.Printf("closing channel statement: %v", err)
+		}
+	}()
 
 	for i, ch := range tv.Channels {
 		if hiddenChannelIDs[ch.ID] {
@@ -160,7 +176,11 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	if err != nil {
 		return fmt.Errorf("preparing overlap delete: %w", err)
 	}
-	defer deleteOverlapStmt.Close()
+	defer func() {
+		if err := deleteOverlapStmt.Close(); err != nil {
+			log.Printf("closing overlap delete statement: %v", err)
+		}
+	}()
 
 	airStmt, err := tx.Prepare(`
 		INSERT OR REPLACE INTO airings (
@@ -174,7 +194,11 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	if err != nil {
 		return fmt.Errorf("preparing airing upsert: %w", err)
 	}
-	defer airStmt.Close()
+	defer func() {
+		if err := airStmt.Close(); err != nil {
+			log.Printf("closing airing statement: %v", err)
+		}
+	}()
 
 	for _, p := range tv.Programmes {
 		if hiddenChannelIDs[p.Channel] {

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -161,7 +162,11 @@ func (d *DB) GetCategories() ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("querying categories: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("closing category rows: %v", err)
+		}
+	}()
 
 	cats := []string{}
 	for rows.Next() {
@@ -181,7 +186,11 @@ func (d *DB) scanSearchResults(query string, args ...any) ([]model.SearchResult,
 	if err != nil {
 		return nil, fmt.Errorf("querying search results: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("closing search rows: %v", err)
+		}
+	}()
 
 	var results []model.SearchResult
 	for rows.Next() {

--- a/internal/images/cache.go
+++ b/internal/images/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -53,7 +54,11 @@ func (c *Cache) Download(ctx context.Context, channelID, iconURL string) (string
 	if err != nil {
 		return "", fmt.Errorf("downloading: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("closing response body: %v", err)
+		}
+	}()
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, iconURL)
 	}

--- a/internal/xmltv/parser.go
+++ b/internal/xmltv/parser.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"time"
 )
@@ -132,7 +133,11 @@ func Fetch(ctx context.Context, client *http.Client, url string) (*TV, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetching %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("closing response body: %v", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("server returned %s for %s", resp.Status, url)


### PR DESCRIPTION
## Summary
- Fixes `appendAssign` (`gocritic`): replaced `deleteArgs := append(idArgs, lcnArgs...)` with an explicit `make` + two `append` calls to guarantee a new slice with no aliasing (`internal/database/refresh.go`)
- Fixes `errcheck`: wraps all deferred `rows.Close()`, `stmt.Close()`, `tx.Rollback()`, and `resp.Body.Close()` calls in funcs that log any returned error across `airings.go`, `channels.go`, `nownext.go`, `search.go`, `refresh.go`, `db.go`, `xmltv/parser.go`, and `images/cache.go`
- Fixes `errcheck`: logs `db.Close()` errors in `Open()` error paths rather than silently discarding them

Closes #158

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] Grep confirms no bare `defer rows.Close()`, `defer tx.Rollback()`, `defer resp.Body.Close()`, or unchecked `db.Close()` remain in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)