### PR TITLE
fix: add explicit SARIF categories so PR scans compare against main

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,7 @@ jobs:
         if: always()
         with:
           sarif_file: golangci-lint.sarif
+          category: golangci-lint
 
   lint-js:
     runs-on: ubuntu-latest
@@ -52,6 +53,7 @@ jobs:
         if: always()
         with:
           sarif_file: eslint.sarif
+          category: eslint
 
   vuln:
     runs-on: ubuntu-latest
@@ -76,6 +78,7 @@ jobs:
         if: always()
         with:
           sarif_file: osv-scanner.sarif
+          category: osv-scanner
 
   semgrep:
     runs-on: ubuntu-latest
@@ -95,6 +98,7 @@ jobs:
         if: always()
         with:
           sarif_file: semgrep.sarif
+          category: semgrep
 
   codeql:
     runs-on: ubuntu-latest
@@ -115,6 +119,8 @@ jobs:
       - uses: github/codeql-action/autobuild@v4
 
       - uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         if: always()
         with:
           sarif_file: golangci-lint.sarif
+          category: golangci-lint
 
   lint-js:
     runs-on: ubuntu-latest
@@ -52,6 +53,7 @@ jobs:
         if: always()
         with:
           sarif_file: eslint.sarif
+          category: eslint
 
   vuln:
     runs-on: ubuntu-latest
@@ -76,6 +78,7 @@ jobs:
         if: always()
         with:
           sarif_file: osv-scanner.sarif
+          category: osv-scanner
 
   semgrep:
     runs-on: ubuntu-latest
@@ -95,6 +98,7 @@ jobs:
         if: always()
         with:
           sarif_file: semgrep.sarif
+          category: semgrep
 
   codeql:
     runs-on: ubuntu-latest
@@ -115,6 +119,8 @@ jobs:
       - uses: github/codeql-action/autobuild@v4
 
       - uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}
 
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Without an explicit `category` parameter, `upload-sarif` defaults to the workflow filename as the category identifier
- Scans from `pr.yml` were filed as `pr.yml/<job>` and scans from `release.yml` as `release.yml/<job>` — GitHub couldn't match them to compute the alert diff
- Adds matching explicit categories (`golangci-lint`, `eslint`, `osv-scanner`, `semgrep`, `/language:<lang>` for CodeQL) to every `upload-sarif` and `codeql-action/analyze` step in both workflows

## Test plan

- [ ] Merge this PR — `release.yml` will run on main and register results under the new stable categories
- [ ] Open a subsequent PR and verify the Code Scanning tab shows "X alerts introduced / Y alerts fixed" without the "configuration not found" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)