### PR TITLE
fix: add ReadHeaderTimeout to HTTP server to prevent Slowloris DoS

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,8 +119,9 @@ func main() {
 	mux.Handle("/", spaHandler(http.FS(webContent)))
 
 	srv := &http.Server{
-		Addr:    ":" + port,
-		Handler: mux,
+		Addr:              ":" + port,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {


### PR DESCRIPTION
## Summary
- Adds `ReadHeaderTimeout: 10 * time.Second` to the `http.Server` struct in `main.go`
- Resolves gosec G112 finding flagged by `make lint`
- Closes #159

## Test plan
- [ ] Run `make lint` and confirm no G112 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)