### PR TITLE
Resolve noctx linter rule: propagate context.Context throughout (#163)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -117,7 +117,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	t.Run("index_html", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/")
+		resp, err := httpGet(t, srv.URL+"/")
 		if err != nil {
 			t.Fatalf("GET /: %v", err)
 		}
@@ -138,7 +138,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("app_js_removed", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/app.js")
+		resp, err := httpGet(t, srv.URL+"/app.js")
 		if err != nil {
 			t.Fatalf("GET /app.js: %v", err)
 		}
@@ -152,7 +152,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("main_js", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/js/main.js")
+		resp, err := httpGet(t, srv.URL+"/js/main.js")
 		if err != nil {
 			t.Fatalf("GET /js/main.js: %v", err)
 		}
@@ -167,7 +167,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("index_uses_module_script", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/")
+		resp, err := httpGet(t, srv.URL+"/")
 		if err != nil {
 			t.Fatalf("GET /: %v", err)
 		}
@@ -187,7 +187,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("sw_caches_main_js", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/sw.js")
+		resp, err := httpGet(t, srv.URL+"/sw.js")
 		if err != nil {
 			t.Fatalf("GET /sw.js: %v", err)
 		}
@@ -204,7 +204,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("manifest_json", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/manifest.json")
+		resp, err := httpGet(t, srv.URL+"/manifest.json")
 		if err != nil {
 			t.Fatalf("GET /manifest.json: %v", err)
 		}
@@ -215,7 +215,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("manifest_includes_png_icons", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/manifest.json")
+		resp, err := httpGet(t, srv.URL+"/manifest.json")
 		if err != nil {
 			t.Fatalf("GET /manifest.json: %v", err)
 		}
@@ -245,7 +245,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("apple_touch_icon", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/apple-touch-icon.png")
+		resp, err := httpGet(t, srv.URL+"/apple-touch-icon.png")
 		if err != nil {
 			t.Fatalf("GET /apple-touch-icon.png: %v", err)
 		}
@@ -260,7 +260,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("index_has_apple_touch_icon_link", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/")
+		resp, err := httpGet(t, srv.URL+"/")
 		if err != nil {
 			t.Fatalf("GET /: %v", err)
 		}
@@ -274,7 +274,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("sw_caches_icon_files", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/sw.js")
+		resp, err := httpGet(t, srv.URL+"/sw.js")
 		if err != nil {
 			t.Fatalf("GET /sw.js: %v", err)
 		}
@@ -299,7 +299,7 @@ func TestIntegration_Channels(t *testing.T) {
 
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL+"/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -322,8 +322,8 @@ func TestIntegration_Channels(t *testing.T) {
 // 7-day retention window as time passes.
 func sampleXMLTVForDate(baseDate time.Time) string {
 	const layout = "20060102150405 +0000"
-	prevEvening := baseDate.Add(-time.Hour)        // 23:00 the previous day
-	earlyMorning := baseDate.Add(time.Hour)         // 01:00 today
+	prevEvening := baseDate.Add(-time.Hour) // 23:00 the previous day
+	earlyMorning := baseDate.Add(time.Hour) // 01:00 today
 	morning6 := baseDate.Add(6 * time.Hour)
 	morning7 := baseDate.Add(7 * time.Hour)
 	morning630 := baseDate.Add(6*time.Hour + 30*time.Minute)
@@ -385,7 +385,7 @@ func TestIntegration_Guide(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	dateStr := base.Format("2006-01-02")
-	resp, err := httpGet(t, srv.URL + "/api/guide?date=" + dateStr)
+	resp, err := httpGet(t, srv.URL+"/api/guide?date="+dateStr)
 	if err != nil {
 		t.Fatalf("GET /api/guide: %v", err)
 	}
@@ -504,7 +504,7 @@ func TestIntegration_Status(t *testing.T) {
 
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/api/status")
+	resp, err := httpGet(t, srv.URL+"/api/status")
 	if err != nil {
 		t.Fatalf("GET /api/status: %v", err)
 	}
@@ -535,7 +535,7 @@ func TestIntegration_Navigation_ButtonsEnabled(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/")
+	resp, err := httpGet(t, srv.URL+"/")
 	if err != nil {
 		t.Fatalf("GET /: %v", err)
 	}
@@ -564,7 +564,7 @@ func TestIntegration_Navigation_JSFunctions(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	// Check main.js references the guide-related functions (via imports)
-	resp, err := httpGet(t, srv.URL + "/js/main.js")
+	resp, err := httpGet(t, srv.URL+"/js/main.js")
 	if err != nil {
 		t.Fatalf("GET /js/main.js: %v", err)
 	}
@@ -581,7 +581,7 @@ func TestIntegration_Navigation_JSFunctions(t *testing.T) {
 	}
 
 	// Check pages/guide.js defines the guide-specific URL and navigation functions
-	resp2, err := httpGet(t, srv.URL + "/js/pages/guide.js")
+	resp2, err := httpGet(t, srv.URL+"/js/pages/guide.js")
 	if err != nil {
 		t.Fatalf("GET /js/pages/guide.js: %v", err)
 	}
@@ -609,7 +609,7 @@ func TestIntegration_Search_JSFunctions(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	// Check pages/search.js is served and defines the expected functions
-	resp, err := httpGet(t, srv.URL + "/js/pages/search.js")
+	resp, err := httpGet(t, srv.URL+"/js/pages/search.js")
 	if err != nil {
 		t.Fatalf("GET /js/pages/search.js: %v", err)
 	}
@@ -629,7 +629,7 @@ func TestIntegration_Search_JSFunctions(t *testing.T) {
 	}
 
 	// Check main.js imports from search.js and no longer defines these functions directly
-	resp2, err := httpGet(t, srv.URL + "/js/main.js")
+	resp2, err := httpGet(t, srv.URL+"/js/main.js")
 	if err != nil {
 		t.Fatalf("GET /js/main.js: %v", err)
 	}
@@ -644,7 +644,7 @@ func TestIntegration_Search_JSFunctions(t *testing.T) {
 	}
 
 	// Check that search.js is listed in the service worker cache
-	resp3, err := httpGet(t, srv.URL + "/sw.js")
+	resp3, err := httpGet(t, srv.URL+"/sw.js")
 	if err != nil {
 		t.Fatalf("GET /sw.js: %v", err)
 	}
@@ -717,7 +717,7 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	// /api/channels must return proxy URL for ch1, empty icon for ch2.
-	resp, err := httpGet(t, srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL+"/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -748,7 +748,7 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	}
 
 	// GET /images/channel/ch1 must serve the cached PNG.
-	iconResp, err := httpGet(t, srv.URL + "/images/channel/ch1")
+	iconResp, err := httpGet(t, srv.URL+"/images/channel/ch1")
 	if err != nil {
 		t.Fatalf("GET /images/channel/ch1: %v", err)
 	}
@@ -763,7 +763,7 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	}
 
 	// GET /images/channel/ch2 must return 404 (no icon).
-	noIconResp, err := httpGet(t, srv.URL + "/images/channel/ch2")
+	noIconResp, err := httpGet(t, srv.URL+"/images/channel/ch2")
 	if err != nil {
 		t.Fatalf("GET /images/channel/ch2: %v", err)
 	}
@@ -781,7 +781,7 @@ func TestIntegration_Search(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	// Search for "News" — sample.xml has "Morning News" and "World News"
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&mode=advanced&include_past=true")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&mode=advanced&include_past=true")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -828,7 +828,7 @@ func TestIntegration_Categories(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, sampleXMLTVForDate(base))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/api/categories")
+	resp, err := httpGet(t, srv.URL+"/api/categories")
 	if err != nil {
 		t.Fatalf("GET /api/categories: %v", err)
 	}
@@ -865,7 +865,7 @@ func TestIntegration_Search_MissingQuery(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/api/search")
+	resp, err := httpGet(t, srv.URL+"/api/search")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -886,7 +886,7 @@ func TestIntegration_SPAFallback_SearchReturnsHTML(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/search")
+	resp, err := httpGet(t, srv.URL+"/search")
 	if err != nil {
 		t.Fatalf("GET /search: %v", err)
 	}
@@ -916,7 +916,7 @@ func TestIntegration_SPAFallback_FavouritesReturnsHTML(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/favourites")
+	resp, err := httpGet(t, srv.URL+"/favourites")
 	if err != nil {
 		t.Fatalf("GET /favourites: %v", err)
 	}
@@ -946,7 +946,7 @@ func TestIntegration_SPAFallback_SettingsReturnsHTML(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/settings")
+	resp, err := httpGet(t, srv.URL+"/settings")
 	if err != nil {
 		t.Fatalf("GET /settings: %v", err)
 	}
@@ -971,7 +971,7 @@ func TestIntegration_SearchPage_HTMLElements(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/search")
+	resp, err := httpGet(t, srv.URL+"/search")
 	if err != nil {
 		t.Fatalf("GET /search: %v", err)
 	}
@@ -1043,7 +1043,7 @@ func TestIntegration_SearchPage_JSFunctions(t *testing.T) {
 
 	fetchBody := func(path string) string {
 		t.Helper()
-		resp, err := httpGet(t, srv.URL + path)
+		resp, err := httpGet(t, srv.URL+path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
@@ -1092,7 +1092,7 @@ func TestIntegration_SPAFallback_APINotCaught(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL+"/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -1114,7 +1114,7 @@ func TestIntegration_SPAFallback_StaticFileNotCaught(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/style/base.css")
+	resp, err := httpGet(t, srv.URL+"/style/base.css")
 	if err != nil {
 		t.Fatalf("GET /style/base.css: %v", err)
 	}
@@ -1139,7 +1139,7 @@ func TestIntegration_FavouritesPage_HTMLElements(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/favourites")
+	resp, err := httpGet(t, srv.URL+"/favourites")
 	if err != nil {
 		t.Fatalf("GET /favourites: %v", err)
 	}
@@ -1186,7 +1186,7 @@ func TestIntegration_FavouritesPage_JSFunctions(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	fetchBody := func(path string) string {
-		resp, err := httpGet(t, srv.URL + path)
+		resp, err := httpGet(t, srv.URL+path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
@@ -1265,7 +1265,7 @@ func TestIntegration_FavouritesPage_Module(t *testing.T) {
 
 	fetchBody := func(path string) string {
 		t.Helper()
-		resp, err := httpGet(t, srv.URL + path)
+		resp, err := httpGet(t, srv.URL+path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
@@ -1305,7 +1305,7 @@ func TestIntegration_ErrorLogging_JSFunctions(t *testing.T) {
 
 	fetchBody := func(path string) string {
 		t.Helper()
-		resp, err := httpGet(t, srv.URL + path)
+		resp, err := httpGet(t, srv.URL+path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
@@ -1373,7 +1373,7 @@ func TestIntegration_CSSModularization_FilesServed(t *testing.T) {
 		"/style/settings.css",
 	}
 	for _, path := range cssFiles {
-		resp, err := httpGet(t, srv.URL + path)
+		resp, err := httpGet(t, srv.URL+path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
@@ -1398,7 +1398,7 @@ func TestIntegration_CSSModularization_IndexLoadsModularCSS(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/")
+	resp, err := httpGet(t, srv.URL+"/")
 	if err != nil {
 		t.Fatalf("GET /: %v", err)
 	}
@@ -1437,7 +1437,7 @@ func TestIntegration_CSSModularization_ServiceWorkerCachesAll(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/sw.js")
+	resp, err := httpGet(t, srv.URL+"/sw.js")
 	if err != nil {
 		t.Fatalf("GET /sw.js: %v", err)
 	}
@@ -1476,7 +1476,7 @@ func TestIntegration_CSSModularization_BaseHasCSSVariables(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/style/base.css")
+	resp, err := httpGet(t, srv.URL+"/style/base.css")
 	if err != nil {
 		t.Fatalf("GET /style/base.css: %v", err)
 	}
@@ -1506,7 +1506,7 @@ func TestIntegration_AuthRedirectHandling(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	t.Run("api_js_uses_redirect_manual", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/js/api.js")
+		resp, err := httpGet(t, srv.URL+"/js/api.js")
 		if err != nil {
 			t.Fatalf("GET /js/api.js: %v", err)
 		}
@@ -1520,7 +1520,7 @@ func TestIntegration_AuthRedirectHandling(t *testing.T) {
 	})
 
 	t.Run("api_js_handles_opaqueredirect", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/js/api.js")
+		resp, err := httpGet(t, srv.URL+"/js/api.js")
 		if err != nil {
 			t.Fatalf("GET /js/api.js: %v", err)
 		}
@@ -1537,7 +1537,7 @@ func TestIntegration_AuthRedirectHandling(t *testing.T) {
 	})
 
 	t.Run("sw_js_rethrows_on_api_fetch_failure", func(t *testing.T) {
-		resp, err := httpGet(t, srv.URL + "/sw.js")
+		resp, err := httpGet(t, srv.URL+"/sw.js")
 		if err != nil {
 			t.Fatalf("GET /sw.js: %v", err)
 		}
@@ -1564,7 +1564,7 @@ func TestIntegration_SPAFallback_GuidePathReturnsHTML(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := httpGet(t, srv.URL + "/guide?date=2026-04-01")
+	resp, err := httpGet(t, srv.URL+"/guide?date=2026-04-01")
 	if err != nil {
 		t.Fatalf("GET /guide: %v", err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -96,6 +96,17 @@ func newIntegrationServer(t *testing.T, xmltvURL string) *httptest.Server {
 	return srv
 }
 
+// httpGet performs a GET request with a background context.
+// It is a context-aware replacement for http.Get in tests.
+func httpGet(t *testing.T, url string) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}
+
 func TestIntegration_StaticFiles(t *testing.T) {
 	xmlBytes, err := os.ReadFile("testdata/sample.xml")
 	if err != nil {
@@ -106,7 +117,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	t.Run("index_html", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/")
+		resp, err := httpGet(t, srv.URL + "/")
 		if err != nil {
 			t.Fatalf("GET /: %v", err)
 		}
@@ -127,7 +138,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("app_js_removed", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/app.js")
+		resp, err := httpGet(t, srv.URL + "/app.js")
 		if err != nil {
 			t.Fatalf("GET /app.js: %v", err)
 		}
@@ -141,7 +152,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("main_js", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/js/main.js")
+		resp, err := httpGet(t, srv.URL + "/js/main.js")
 		if err != nil {
 			t.Fatalf("GET /js/main.js: %v", err)
 		}
@@ -156,7 +167,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("index_uses_module_script", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/")
+		resp, err := httpGet(t, srv.URL + "/")
 		if err != nil {
 			t.Fatalf("GET /: %v", err)
 		}
@@ -176,7 +187,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("sw_caches_main_js", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/sw.js")
+		resp, err := httpGet(t, srv.URL + "/sw.js")
 		if err != nil {
 			t.Fatalf("GET /sw.js: %v", err)
 		}
@@ -193,7 +204,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("manifest_json", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/manifest.json")
+		resp, err := httpGet(t, srv.URL + "/manifest.json")
 		if err != nil {
 			t.Fatalf("GET /manifest.json: %v", err)
 		}
@@ -204,7 +215,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("manifest_includes_png_icons", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/manifest.json")
+		resp, err := httpGet(t, srv.URL + "/manifest.json")
 		if err != nil {
 			t.Fatalf("GET /manifest.json: %v", err)
 		}
@@ -234,7 +245,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("apple_touch_icon", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/apple-touch-icon.png")
+		resp, err := httpGet(t, srv.URL + "/apple-touch-icon.png")
 		if err != nil {
 			t.Fatalf("GET /apple-touch-icon.png: %v", err)
 		}
@@ -249,7 +260,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("index_has_apple_touch_icon_link", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/")
+		resp, err := httpGet(t, srv.URL + "/")
 		if err != nil {
 			t.Fatalf("GET /: %v", err)
 		}
@@ -263,7 +274,7 @@ func TestIntegration_StaticFiles(t *testing.T) {
 	})
 
 	t.Run("sw_caches_icon_files", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/sw.js")
+		resp, err := httpGet(t, srv.URL + "/sw.js")
 		if err != nil {
 			t.Fatalf("GET /sw.js: %v", err)
 		}
@@ -288,7 +299,7 @@ func TestIntegration_Channels(t *testing.T) {
 
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL + "/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -374,7 +385,7 @@ func TestIntegration_Guide(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	dateStr := base.Format("2006-01-02")
-	resp, err := http.Get(srv.URL + "/api/guide?date=" + dateStr)
+	resp, err := httpGet(t, srv.URL + "/api/guide?date=" + dateStr)
 	if err != nil {
 		t.Fatalf("GET /api/guide: %v", err)
 	}
@@ -412,7 +423,7 @@ func TestStartup_FreshInstall_AlwaysFetches(t *testing.T) {
 	if count := mockSrv.requestCount(); count != 1 {
 		t.Errorf("expected 1 XMLTV request on fresh install, got %d", count)
 	}
-	if !db.HasData() {
+	if !db.HasData(context.Background()) {
 		t.Error("expected database to contain data after initial fetch")
 	}
 }
@@ -493,7 +504,7 @@ func TestIntegration_Status(t *testing.T) {
 
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/api/status")
+	resp, err := httpGet(t, srv.URL + "/api/status")
 	if err != nil {
 		t.Fatalf("GET /api/status: %v", err)
 	}
@@ -524,7 +535,7 @@ func TestIntegration_Navigation_ButtonsEnabled(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/")
+	resp, err := httpGet(t, srv.URL + "/")
 	if err != nil {
 		t.Fatalf("GET /: %v", err)
 	}
@@ -553,7 +564,7 @@ func TestIntegration_Navigation_JSFunctions(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	// Check main.js references the guide-related functions (via imports)
-	resp, err := http.Get(srv.URL + "/js/main.js")
+	resp, err := httpGet(t, srv.URL + "/js/main.js")
 	if err != nil {
 		t.Fatalf("GET /js/main.js: %v", err)
 	}
@@ -570,7 +581,7 @@ func TestIntegration_Navigation_JSFunctions(t *testing.T) {
 	}
 
 	// Check pages/guide.js defines the guide-specific URL and navigation functions
-	resp2, err := http.Get(srv.URL + "/js/pages/guide.js")
+	resp2, err := httpGet(t, srv.URL + "/js/pages/guide.js")
 	if err != nil {
 		t.Fatalf("GET /js/pages/guide.js: %v", err)
 	}
@@ -598,7 +609,7 @@ func TestIntegration_Search_JSFunctions(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	// Check pages/search.js is served and defines the expected functions
-	resp, err := http.Get(srv.URL + "/js/pages/search.js")
+	resp, err := httpGet(t, srv.URL + "/js/pages/search.js")
 	if err != nil {
 		t.Fatalf("GET /js/pages/search.js: %v", err)
 	}
@@ -618,7 +629,7 @@ func TestIntegration_Search_JSFunctions(t *testing.T) {
 	}
 
 	// Check main.js imports from search.js and no longer defines these functions directly
-	resp2, err := http.Get(srv.URL + "/js/main.js")
+	resp2, err := httpGet(t, srv.URL + "/js/main.js")
 	if err != nil {
 		t.Fatalf("GET /js/main.js: %v", err)
 	}
@@ -633,7 +644,7 @@ func TestIntegration_Search_JSFunctions(t *testing.T) {
 	}
 
 	// Check that search.js is listed in the service worker cache
-	resp3, err := http.Get(srv.URL + "/sw.js")
+	resp3, err := httpGet(t, srv.URL + "/sw.js")
 	if err != nil {
 		t.Fatalf("GET /sw.js: %v", err)
 	}
@@ -706,7 +717,7 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	// /api/channels must return proxy URL for ch1, empty icon for ch2.
-	resp, err := http.Get(srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL + "/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -737,7 +748,7 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	}
 
 	// GET /images/channel/ch1 must serve the cached PNG.
-	iconResp, err := http.Get(srv.URL + "/images/channel/ch1")
+	iconResp, err := httpGet(t, srv.URL + "/images/channel/ch1")
 	if err != nil {
 		t.Fatalf("GET /images/channel/ch1: %v", err)
 	}
@@ -752,7 +763,7 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	}
 
 	// GET /images/channel/ch2 must return 404 (no icon).
-	noIconResp, err := http.Get(srv.URL + "/images/channel/ch2")
+	noIconResp, err := httpGet(t, srv.URL + "/images/channel/ch2")
 	if err != nil {
 		t.Fatalf("GET /images/channel/ch2: %v", err)
 	}
@@ -770,7 +781,7 @@ func TestIntegration_Search(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	// Search for "News" — sample.xml has "Morning News" and "World News"
-	resp, err := http.Get(srv.URL + "/api/search?q=News&mode=advanced&include_past=true")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&mode=advanced&include_past=true")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -817,7 +828,7 @@ func TestIntegration_Categories(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, sampleXMLTVForDate(base))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/api/categories")
+	resp, err := httpGet(t, srv.URL + "/api/categories")
 	if err != nil {
 		t.Fatalf("GET /api/categories: %v", err)
 	}
@@ -854,7 +865,7 @@ func TestIntegration_Search_MissingQuery(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/api/search")
+	resp, err := httpGet(t, srv.URL + "/api/search")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -875,7 +886,7 @@ func TestIntegration_SPAFallback_SearchReturnsHTML(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/search")
+	resp, err := httpGet(t, srv.URL + "/search")
 	if err != nil {
 		t.Fatalf("GET /search: %v", err)
 	}
@@ -905,7 +916,7 @@ func TestIntegration_SPAFallback_FavouritesReturnsHTML(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/favourites")
+	resp, err := httpGet(t, srv.URL + "/favourites")
 	if err != nil {
 		t.Fatalf("GET /favourites: %v", err)
 	}
@@ -935,7 +946,7 @@ func TestIntegration_SPAFallback_SettingsReturnsHTML(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/settings")
+	resp, err := httpGet(t, srv.URL + "/settings")
 	if err != nil {
 		t.Fatalf("GET /settings: %v", err)
 	}
@@ -960,7 +971,7 @@ func TestIntegration_SearchPage_HTMLElements(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/search")
+	resp, err := httpGet(t, srv.URL + "/search")
 	if err != nil {
 		t.Fatalf("GET /search: %v", err)
 	}
@@ -1032,7 +1043,7 @@ func TestIntegration_SearchPage_JSFunctions(t *testing.T) {
 
 	fetchBody := func(path string) string {
 		t.Helper()
-		resp, err := http.Get(srv.URL + path)
+		resp, err := httpGet(t, srv.URL + path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
@@ -1081,7 +1092,7 @@ func TestIntegration_SPAFallback_APINotCaught(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL + "/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -1103,7 +1114,7 @@ func TestIntegration_SPAFallback_StaticFileNotCaught(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/style/base.css")
+	resp, err := httpGet(t, srv.URL + "/style/base.css")
 	if err != nil {
 		t.Fatalf("GET /style/base.css: %v", err)
 	}
@@ -1128,7 +1139,7 @@ func TestIntegration_FavouritesPage_HTMLElements(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/favourites")
+	resp, err := httpGet(t, srv.URL + "/favourites")
 	if err != nil {
 		t.Fatalf("GET /favourites: %v", err)
 	}
@@ -1175,7 +1186,7 @@ func TestIntegration_FavouritesPage_JSFunctions(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	fetchBody := func(path string) string {
-		resp, err := http.Get(srv.URL + path)
+		resp, err := httpGet(t, srv.URL + path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
@@ -1254,7 +1265,7 @@ func TestIntegration_FavouritesPage_Module(t *testing.T) {
 
 	fetchBody := func(path string) string {
 		t.Helper()
-		resp, err := http.Get(srv.URL + path)
+		resp, err := httpGet(t, srv.URL + path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
@@ -1294,7 +1305,7 @@ func TestIntegration_ErrorLogging_JSFunctions(t *testing.T) {
 
 	fetchBody := func(path string) string {
 		t.Helper()
-		resp, err := http.Get(srv.URL + path)
+		resp, err := httpGet(t, srv.URL + path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
@@ -1362,7 +1373,7 @@ func TestIntegration_CSSModularization_FilesServed(t *testing.T) {
 		"/style/settings.css",
 	}
 	for _, path := range cssFiles {
-		resp, err := http.Get(srv.URL + path)
+		resp, err := httpGet(t, srv.URL + path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
@@ -1387,7 +1398,7 @@ func TestIntegration_CSSModularization_IndexLoadsModularCSS(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/")
+	resp, err := httpGet(t, srv.URL + "/")
 	if err != nil {
 		t.Fatalf("GET /: %v", err)
 	}
@@ -1426,7 +1437,7 @@ func TestIntegration_CSSModularization_ServiceWorkerCachesAll(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/sw.js")
+	resp, err := httpGet(t, srv.URL + "/sw.js")
 	if err != nil {
 		t.Fatalf("GET /sw.js: %v", err)
 	}
@@ -1465,7 +1476,7 @@ func TestIntegration_CSSModularization_BaseHasCSSVariables(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/style/base.css")
+	resp, err := httpGet(t, srv.URL + "/style/base.css")
 	if err != nil {
 		t.Fatalf("GET /style/base.css: %v", err)
 	}
@@ -1495,7 +1506,7 @@ func TestIntegration_AuthRedirectHandling(t *testing.T) {
 	srv := newIntegrationServer(t, mockSrv.URL)
 
 	t.Run("api_js_uses_redirect_manual", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/js/api.js")
+		resp, err := httpGet(t, srv.URL + "/js/api.js")
 		if err != nil {
 			t.Fatalf("GET /js/api.js: %v", err)
 		}
@@ -1509,7 +1520,7 @@ func TestIntegration_AuthRedirectHandling(t *testing.T) {
 	})
 
 	t.Run("api_js_handles_opaqueredirect", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/js/api.js")
+		resp, err := httpGet(t, srv.URL + "/js/api.js")
 		if err != nil {
 			t.Fatalf("GET /js/api.js: %v", err)
 		}
@@ -1526,7 +1537,7 @@ func TestIntegration_AuthRedirectHandling(t *testing.T) {
 	})
 
 	t.Run("sw_js_rethrows_on_api_fetch_failure", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/sw.js")
+		resp, err := httpGet(t, srv.URL + "/sw.js")
 		if err != nil {
 			t.Fatalf("GET /sw.js: %v", err)
 		}
@@ -1553,7 +1564,7 @@ func TestIntegration_SPAFallback_GuidePathReturnsHTML(t *testing.T) {
 	mockSrv := startMockXMLTVServer(t, string(xmlBytes))
 	srv := newIntegrationServer(t, mockSrv.URL)
 
-	resp, err := http.Get(srv.URL + "/guide?date=2026-04-01")
+	resp, err := httpGet(t, srv.URL + "/guide?date=2026-04-01")
 	if err != nil {
 		t.Fatalf("GET /guide: %v", err)
 	}

--- a/internal/api/categories.go
+++ b/internal/api/categories.go
@@ -3,7 +3,7 @@ package api
 import "net/http"
 
 func (h *Handler) getCategories(w http.ResponseWriter, r *http.Request) {
-	cats, err := h.db.GetCategories()
+	cats, err := h.db.GetCategories(r.Context())
 	if err != nil {
 		http.Error(w, "database error", http.StatusInternalServerError)
 		return

--- a/internal/api/channels.go
+++ b/internal/api/channels.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *Handler) getChannels(w http.ResponseWriter, r *http.Request) {
-	channels, err := h.db.GetChannels()
+	channels, err := h.db.GetChannels(r.Context())
 	if err != nil {
 		http.Error(w, "database error", http.StatusInternalServerError)
 		return

--- a/internal/api/debug_test.go
+++ b/internal/api/debug_test.go
@@ -12,7 +12,7 @@ func TestPostDebugLog(t *testing.T) {
 
 	t.Run("valid JSON body returns 204", func(t *testing.T) {
 		body := `{"type":"onerror","message":"something went wrong","source":"app.js","lineno":42,"colno":7,"stack":"Error: something\n    at app.js:42","url":"/guide"}`
-		resp, err := http.Post(srv.URL+"/api/debug/log", "application/json", strings.NewReader(body))
+		resp, err := httpPost(t, srv.URL+"/api/debug/log", strings.NewReader(body))
 		if err != nil {
 			t.Fatalf("POST: %v", err)
 		}
@@ -23,7 +23,7 @@ func TestPostDebugLog(t *testing.T) {
 	})
 
 	t.Run("empty body returns 204", func(t *testing.T) {
-		resp, err := http.Post(srv.URL+"/api/debug/log", "application/json", bytes.NewReader([]byte("{}")))
+		resp, err := httpPost(t, srv.URL+"/api/debug/log", bytes.NewReader([]byte("{}")))
 		if err != nil {
 			t.Fatalf("POST: %v", err)
 		}
@@ -34,7 +34,7 @@ func TestPostDebugLog(t *testing.T) {
 	})
 
 	t.Run("malformed JSON returns 400", func(t *testing.T) {
-		resp, err := http.Post(srv.URL+"/api/debug/log", "application/json", strings.NewReader("not-json"))
+		resp, err := httpPost(t, srv.URL+"/api/debug/log", strings.NewReader("not-json"))
 		if err != nil {
 			t.Fatalf("POST: %v", err)
 		}
@@ -47,7 +47,7 @@ func TestPostDebugLog(t *testing.T) {
 	t.Run("oversized body returns 400", func(t *testing.T) {
 		large := bytes.Repeat([]byte("x"), 65*1024)
 		body := append([]byte(`{"message":"`), append(large, []byte(`"}`)...)...)
-		resp, err := http.Post(srv.URL+"/api/debug/log", "application/json", bytes.NewReader(body))
+		resp, err := httpPost(t, srv.URL+"/api/debug/log", bytes.NewReader(body))
 		if err != nil {
 			t.Fatalf("POST: %v", err)
 		}

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -3,7 +3,7 @@ package api
 import "net/http"
 
 func (h *Handler) getNowNext(w http.ResponseWriter, r *http.Request) {
-	entries, err := h.db.GetNowNext()
+	entries, err := h.db.GetNowNext(r.Context())
 	if err != nil {
 		http.Error(w, "database error", http.StatusInternalServerError)
 		return

--- a/internal/api/guide.go
+++ b/internal/api/guide.go
@@ -18,7 +18,7 @@ func (h *Handler) getGuide(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	airings, err := h.db.GetAirings(date)
+	airings, err := h.db.GetAirings(r.Context(), date)
 	if err != nil {
 		http.Error(w, "database error", http.StatusInternalServerError)
 		return

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -11,15 +11,15 @@ import (
 
 // store is the narrow interface the Handler needs from the database layer.
 type store interface {
-	GetChannels() ([]model.Channel, error)
-	GetAirings(date time.Time) ([]model.Airing, error)
+	GetChannels(ctx context.Context) ([]model.Channel, error)
+	GetAirings(ctx context.Context, date time.Time) ([]model.Airing, error)
 	GetStatus() model.Status
 	EnsureChannelIcon(ctx context.Context, channelID string) (string, error)
-	SearchSimple(query string, includeRepeats bool, today bool) ([]model.SearchResult, error)
-	SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error)
-	SearchBrowse(categories []string, isPremiere bool, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error)
-	GetCategories() ([]string, error)
-	GetNowNext() ([]model.NowNextEntry, error)
+	SearchSimple(ctx context.Context, query string, includeRepeats bool, today bool) ([]model.SearchResult, error)
+	SearchAdvanced(ctx context.Context, query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error)
+	SearchBrowse(ctx context.Context, categories []string, isPremiere bool, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error)
+	GetCategories(ctx context.Context) ([]string, error)
+	GetNowNext(ctx context.Context) ([]model.NowNextEntry, error)
 }
 
 // Handler holds the HTTP handler dependencies.

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -134,7 +134,7 @@ func newSeededServerWithIcons(t *testing.T, iconSrv *httptest.Server) (*httptest
 
 func TestGetChannels_Count(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL+"/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestGetChannels_Count(t *testing.T) {
 
 func TestGetChannels_Order(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL+"/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestGetChannels_Order(t *testing.T) {
 
 func TestGetChannels_LCN(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL+"/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestGetChannels_LCN(t *testing.T) {
 
 func TestGetChannels_ContentType(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL+"/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestGetChannels_ContentType(t *testing.T) {
 func TestGetGuide_Date(t *testing.T) {
 	srv := newSeededServer(t)
 	today := time.Now().UTC().Format("2006-01-02")
-	resp, err := httpGet(t, srv.URL + "/api/guide?date=" + today)
+	resp, err := httpGet(t, srv.URL+"/api/guide?date="+today)
 	if err != nil {
 		t.Fatalf("GET /api/guide: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestGetGuide_Date(t *testing.T) {
 
 func TestGetGuide_NoDate(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/guide")
+	resp, err := httpGet(t, srv.URL+"/api/guide")
 	if err != nil {
 		t.Fatalf("GET /api/guide: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestGetGuide_NoDate(t *testing.T) {
 func TestGetGuide_EmptyDate_ReturnsEmptyArray(t *testing.T) {
 	srv := newSeededServer(t)
 	// Use a date far in the future with no airings
-	resp, err := httpGet(t, srv.URL + "/api/guide?date=2099-01-01")
+	resp, err := httpGet(t, srv.URL+"/api/guide?date=2099-01-01")
 	if err != nil {
 		t.Fatalf("GET /api/guide: %v", err)
 	}
@@ -289,7 +289,7 @@ func TestGetGuide_EmptyDate_ReturnsEmptyArray(t *testing.T) {
 
 func TestGetGuide_InvalidDate(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/guide?date=notadate")
+	resp, err := httpGet(t, srv.URL+"/api/guide?date=notadate")
 	if err != nil {
 		t.Fatalf("GET /api/guide: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestGetGuide_InvalidDate(t *testing.T) {
 
 func TestGetStatus_SourceURL(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/status")
+	resp, err := httpGet(t, srv.URL+"/api/status")
 	if err != nil {
 		t.Fatalf("GET /api/status: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestGetStatus_SourceURL(t *testing.T) {
 
 func TestGetStatus_ContentType(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/status")
+	resp, err := httpGet(t, srv.URL+"/api/status")
 	if err != nil {
 		t.Fatalf("GET /api/status: %v", err)
 	}
@@ -339,7 +339,7 @@ func TestGetChannelIcon_ServesFile(t *testing.T) {
 	iconSrv := startFakeIconServer(t)
 	srv, _ := newSeededServerWithIcons(t, iconSrv)
 
-	resp, err := httpGet(t, srv.URL + "/images/channel/ch1")
+	resp, err := httpGet(t, srv.URL+"/images/channel/ch1")
 	if err != nil {
 		t.Fatalf("GET /images/channel/ch1: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestGetChannelIcon_ReturnsNotFoundForNoIcon(t *testing.T) {
 	iconSrv := startFakeIconServer(t)
 	srv, _ := newSeededServerWithIcons(t, iconSrv)
 
-	resp, err := httpGet(t, srv.URL + "/images/channel/ch2")
+	resp, err := httpGet(t, srv.URL+"/images/channel/ch2")
 	if err != nil {
 		t.Fatalf("GET /images/channel/ch2: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestGetChannelIcon_ReturnsNotFoundForNoIcon(t *testing.T) {
 func TestGetChannelIcon_ReturnsNotFoundForUnknownChannel(t *testing.T) {
 	srv := newSeededServer(t)
 
-	resp, err := httpGet(t, srv.URL + "/images/channel/doesnotexist")
+	resp, err := httpGet(t, srv.URL+"/images/channel/doesnotexist")
 	if err != nil {
 		t.Fatalf("GET /images/channel/doesnotexist: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestGetChannelIcon_RedownloadsIfMissing(t *testing.T) {
 	srv, db := newSeededServerWithIcons(t, iconSrv)
 
 	// Get the icon once to populate the cache.
-	resp, err := httpGet(t, srv.URL + "/images/channel/ch1")
+	resp, err := httpGet(t, srv.URL+"/images/channel/ch1")
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Fatalf("initial icon request: status=%d err=%v", resp.StatusCode, err)
 	}
@@ -408,7 +408,7 @@ func TestGetChannelIcon_RedownloadsIfMissing(t *testing.T) {
 	os.Remove(localPath)
 
 	// The handler should re-download and still return 200.
-	resp2, err := httpGet(t, srv.URL + "/images/channel/ch1")
+	resp2, err := httpGet(t, srv.URL+"/images/channel/ch1")
 	if err != nil {
 		t.Fatalf("GET after cache delete: %v", err)
 	}
@@ -511,7 +511,7 @@ func TestSearch_MissingQuery_Returns400(t *testing.T) {
 	srv := newSearchSeededServer(t)
 
 	// No q parameter
-	resp, err := httpGet(t, srv.URL + "/api/search")
+	resp, err := httpGet(t, srv.URL+"/api/search")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -521,7 +521,7 @@ func TestSearch_MissingQuery_Returns400(t *testing.T) {
 	}
 
 	// Empty q parameter
-	resp2, err := httpGet(t, srv.URL + "/api/search?q=")
+	resp2, err := httpGet(t, srv.URL+"/api/search?q=")
 	if err != nil {
 		t.Fatalf("GET /api/search?q=: %v", err)
 	}
@@ -533,7 +533,7 @@ func TestSearch_MissingQuery_Returns400(t *testing.T) {
 
 func TestSearch_SimpleMode_ReturnsTitleMatches(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -572,7 +572,7 @@ func TestSearch_SimpleMode_ReturnsTitleMatches(t *testing.T) {
 
 func TestSearch_SimpleMode_GroupsByTitle(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -609,7 +609,7 @@ func TestSearch_SimpleMode_GroupsByTitle(t *testing.T) {
 
 func TestSearch_SimpleMode_ChannelNamePopulated(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -636,7 +636,7 @@ func TestSearch_SimpleMode_ChannelNamePopulated(t *testing.T) {
 
 func TestSearch_SimpleMode_ExcludesRepeats(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&include_repeats=false")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&include_repeats=false")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -662,7 +662,7 @@ func TestSearch_SimpleMode_ExcludesRepeats(t *testing.T) {
 
 func TestSearch_AdvancedMode_MatchesDescription(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=news&mode=advanced")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=news&mode=advanced")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -686,7 +686,7 @@ func TestSearch_AdvancedMode_MatchesDescription(t *testing.T) {
 
 func TestSearch_AdvancedMode_CategoryFilter(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=news&mode=advanced&categories=Documentary")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=news&mode=advanced&categories=Documentary")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -715,7 +715,7 @@ func TestSearch_AdvancedMode_CategoryFilter(t *testing.T) {
 
 func TestSearch_AdvancedMode_IncludePast(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&mode=advanced&include_past=true")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&mode=advanced&include_past=true")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -739,7 +739,7 @@ func TestSearch_AdvancedMode_IncludePast(t *testing.T) {
 
 func TestSearch_ContentType(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -755,7 +755,7 @@ func TestSearch_ContentType(t *testing.T) {
 
 func TestCategories_ReturnsSortedList(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/categories")
+	resp, err := httpGet(t, srv.URL+"/api/categories")
 	if err != nil {
 		t.Fatalf("GET /api/categories: %v", err)
 	}
@@ -798,7 +798,7 @@ func TestCategories_EmptyWhenNoData(t *testing.T) {
 		db.Close()
 	})
 
-	resp, err := httpGet(t, srv.URL + "/api/categories")
+	resp, err := httpGet(t, srv.URL+"/api/categories")
 	if err != nil {
 		t.Fatalf("GET /api/categories: %v", err)
 	}
@@ -873,7 +873,7 @@ func TestSearch_AiringsOrderedByStartTime(t *testing.T) {
 		db.Close()
 	})
 
-	resp, err := httpGet(t, srv.URL + "/api/search?q=cricket&mode=advanced")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=cricket&mode=advanced")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -970,7 +970,7 @@ func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	})
 
 	// With today=true, only today's airing should be returned
-	resp, err := httpGet(t, srv.URL + "/api/search?q=Show&today=true")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=Show&today=true")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -998,7 +998,7 @@ func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	}
 
 	// Without today filter, both should be returned
-	resp2, err := httpGet(t, srv.URL + "/api/search?q=Show")
+	resp2, err := httpGet(t, srv.URL+"/api/search?q=Show")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -1070,7 +1070,7 @@ func TestSearch_TodayFilter_AdvancedMode(t *testing.T) {
 		db.Close()
 	})
 
-	resp, err := httpGet(t, srv.URL + "/api/search?q=Match&mode=advanced&today=true")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=Match&mode=advanced&today=true")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -1088,7 +1088,7 @@ func TestSearch_TodayFilter_AdvancedMode(t *testing.T) {
 
 func TestCategories_ContentType(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/categories")
+	resp, err := httpGet(t, srv.URL+"/api/categories")
 	if err != nil {
 		t.Fatalf("GET /api/categories: %v", err)
 	}
@@ -1104,7 +1104,7 @@ func TestGetChannels_IconIsProxyURL(t *testing.T) {
 	iconSrv := startFakeIconServer(t)
 	srv, _ := newSeededServerWithIcons(t, iconSrv)
 
-	resp, err := httpGet(t, srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL+"/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -1212,7 +1212,7 @@ func TestSearch_EmptyQ_NoFilters_Returns400(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
 	// No q and no browse filters
-	resp, err := httpGet(t, srv.URL + "/api/search")
+	resp, err := httpGet(t, srv.URL+"/api/search")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -1229,7 +1229,7 @@ func TestSearch_EmptyQ_NoFilters_Returns400(t *testing.T) {
 func TestSearch_Browse_IsPremiere_Returns200(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
-	resp, err := httpGet(t, srv.URL + "/api/search?is_premiere=true")
+	resp, err := httpGet(t, srv.URL+"/api/search?is_premiere=true")
 	if err != nil {
 		t.Fatalf("GET /api/search?is_premiere=true: %v", err)
 	}
@@ -1243,7 +1243,7 @@ func TestSearch_Browse_IsPremiere_Returns200(t *testing.T) {
 func TestSearch_Browse_IsPremiere_ReturnsOnlyPremieres(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
-	resp, err := httpGet(t, srv.URL + "/api/search?is_premiere=true")
+	resp, err := httpGet(t, srv.URL+"/api/search?is_premiere=true")
 	if err != nil {
 		t.Fatalf("GET /api/search?is_premiere=true: %v", err)
 	}
@@ -1290,7 +1290,7 @@ func TestSearch_Browse_IsPremiere_ReturnsOnlyPremieres(t *testing.T) {
 func TestSearch_Browse_Categories_Returns200(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
-	resp, err := httpGet(t, srv.URL + "/api/search?categories=Sport")
+	resp, err := httpGet(t, srv.URL+"/api/search?categories=Sport")
 	if err != nil {
 		t.Fatalf("GET /api/search?categories=Sport: %v", err)
 	}
@@ -1304,7 +1304,7 @@ func TestSearch_Browse_Categories_Returns200(t *testing.T) {
 func TestSearch_Browse_Categories_ReturnsMatchingAirings(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
-	resp, err := httpGet(t, srv.URL + "/api/search?categories=Sport")
+	resp, err := httpGet(t, srv.URL+"/api/search?categories=Sport")
 	if err != nil {
 		t.Fatalf("GET /api/search?categories=Sport: %v", err)
 	}
@@ -1351,7 +1351,7 @@ func TestSearch_Browse_Categories_ReturnsMatchingAirings(t *testing.T) {
 func TestSearch_Browse_NonEmptyQ_StillWorksAsSimpleSearch(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
-	resp, err := httpGet(t, srv.URL + "/api/search?q=Drama")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=Drama")
 	if err != nil {
 		t.Fatalf("GET /api/search?q=Drama: %v", err)
 	}
@@ -1434,9 +1434,9 @@ func newRSSSeededServer(t *testing.T, rssTTL int) *httptest.Server {
 		},
 		Programmes: []xmltv.Programme{
 			{
-				Start:           xmltv.XmltvTime{Time: now.Add(1 * time.Hour)},
-				Stop:            xmltv.XmltvTime{Time: now.Add(2 * time.Hour)},
-				Channel:         "ch1",
+				Start:       xmltv.XmltvTime{Time: now.Add(1 * time.Hour)},
+				Stop:        xmltv.XmltvTime{Time: now.Add(2 * time.Hour)},
+				Channel:     "ch1",
 				Titles:      []xmltv.Name{{Value: "Morning News"}},
 				SubTitles:   []xmltv.Name{{Value: "Early Edition"}},
 				Descs:       []xmltv.Name{{Value: "Start your day with the latest headlines."}},
@@ -1495,7 +1495,7 @@ func parseRSS(t *testing.T, body []byte) rssRoot {
 
 func TestSearchRSS_ContentType(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1512,7 +1512,7 @@ func TestSearchRSS_ContentType(t *testing.T) {
 
 func TestSearchRSS_ValidXML(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1531,7 +1531,7 @@ func TestSearchRSS_ValidXML(t *testing.T) {
 
 func TestSearchRSS_ItemsNotGrouped(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1548,7 +1548,7 @@ func TestSearchRSS_ItemsNotGrouped(t *testing.T) {
 
 func TestSearchRSS_SortedByStartTime(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1569,7 +1569,7 @@ func TestSearchRSS_SortedByStartTime(t *testing.T) {
 
 func TestSearchRSS_ItemFields(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1636,7 +1636,7 @@ func TestSearchRSS_ItemFields(t *testing.T) {
 
 func TestSearchRSS_DescriptionHTML(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1680,7 +1680,7 @@ func TestSearchRSS_DescriptionHTML(t *testing.T) {
 
 func TestSearchRSS_DescriptionOmitsEmptyFields(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=Sports&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=Sports&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1712,7 +1712,7 @@ func TestSearchRSS_DescriptionOmitsEmptyFields(t *testing.T) {
 
 func TestSearchRSS_RepeatFlag(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1735,7 +1735,7 @@ func TestSearchRSS_RepeatFlag(t *testing.T) {
 
 func TestSearchRSS_NoEnclosureWithoutIcon(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=Sports&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=Sports&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1757,7 +1757,7 @@ func TestSearchRSS_NoEnclosureWithoutIcon(t *testing.T) {
 
 func TestSearchRSS_DefaultTTL(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1773,7 +1773,7 @@ func TestSearchRSS_DefaultTTL(t *testing.T) {
 
 func TestSearchRSS_EnvVarTTL(t *testing.T) {
 	srv := newRSSSeededServer(t, 120)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1789,7 +1789,7 @@ func TestSearchRSS_EnvVarTTL(t *testing.T) {
 
 func TestSearchRSS_QueryParamTTL(t *testing.T) {
 	srv := newRSSSeededServer(t, 120)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&ttl=30")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss&ttl=30")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1805,7 +1805,7 @@ func TestSearchRSS_QueryParamTTL(t *testing.T) {
 
 func TestSearchRSS_InvalidQueryParamTTL_FallsBackToEnvVar(t *testing.T) {
 	srv := newRSSSeededServer(t, 120)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&ttl=notanumber")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss&ttl=notanumber")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1821,7 +1821,7 @@ func TestSearchRSS_InvalidQueryParamTTL_FallsBackToEnvVar(t *testing.T) {
 
 func TestSearchRSS_ZeroQueryParamTTL_FallsBack(t *testing.T) {
 	srv := newRSSSeededServer(t, 120)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&ttl=0")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss&ttl=0")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1837,7 +1837,7 @@ func TestSearchRSS_ZeroQueryParamTTL_FallsBack(t *testing.T) {
 
 func TestSearchRSS_NegativeQueryParamTTL_FallsBack(t *testing.T) {
 	srv := newRSSSeededServer(t, 120)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&ttl=-5")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss&ttl=-5")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1855,7 +1855,7 @@ func TestSearchRSS_NegativeQueryParamTTL_FallsBack(t *testing.T) {
 
 func TestSearchRSS_JSONUnchangedWithoutFormat(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1886,7 +1886,7 @@ func TestSearchRSS_JSONUnchangedWithoutFormat(t *testing.T) {
 func TestSearchRSS_WorksWithAllSearchParams(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
 	// Test format=rss with advanced mode and categories
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&mode=advanced&categories=News")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss&mode=advanced&categories=News")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1923,7 +1923,7 @@ func TestSearchRSS_ChannelDescription(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
 
 	// Simple mode
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1937,7 +1937,7 @@ func TestSearchRSS_ChannelDescription(t *testing.T) {
 	}
 
 	// Advanced mode with categories
-	resp2, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&mode=advanced&categories=News,Sport")
+	resp2, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss&mode=advanced&categories=News,Sport")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1954,7 +1954,7 @@ func TestSearchRSS_ChannelDescription(t *testing.T) {
 func TestSearchRSS_LastBuildDate(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
 	before := time.Now()
-	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL+"/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -2037,7 +2037,7 @@ func newNowNextServer(t *testing.T) (*httptest.Server, time.Time) {
 
 func TestGetNowNext_API_StatusOK(t *testing.T) {
 	srv, _ := newNowNextServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/explore/now-next")
+	resp, err := httpGet(t, srv.URL+"/api/explore/now-next")
 	if err != nil {
 		t.Fatalf("GET /api/explore/now-next: %v", err)
 	}
@@ -2049,7 +2049,7 @@ func TestGetNowNext_API_StatusOK(t *testing.T) {
 
 func TestGetNowNext_API_ResponseShape(t *testing.T) {
 	srv, fixedNow := newNowNextServer(t)
-	resp, err := httpGet(t, srv.URL + "/api/explore/now-next")
+	resp, err := httpGet(t, srv.URL+"/api/explore/now-next")
 	if err != nil {
 		t.Fatalf("GET /api/explore/now-next: %v", err)
 	}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -134,7 +134,7 @@ func newSeededServerWithIcons(t *testing.T, iconSrv *httptest.Server) (*httptest
 
 func TestGetChannels_Count(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL + "/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestGetChannels_Count(t *testing.T) {
 
 func TestGetChannels_Order(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL + "/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestGetChannels_Order(t *testing.T) {
 
 func TestGetChannels_LCN(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL + "/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestGetChannels_LCN(t *testing.T) {
 
 func TestGetChannels_ContentType(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL + "/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestGetChannels_ContentType(t *testing.T) {
 func TestGetGuide_Date(t *testing.T) {
 	srv := newSeededServer(t)
 	today := time.Now().UTC().Format("2006-01-02")
-	resp, err := http.Get(srv.URL + "/api/guide?date=" + today)
+	resp, err := httpGet(t, srv.URL + "/api/guide?date=" + today)
 	if err != nil {
 		t.Fatalf("GET /api/guide: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestGetGuide_Date(t *testing.T) {
 
 func TestGetGuide_NoDate(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/guide")
+	resp, err := httpGet(t, srv.URL + "/api/guide")
 	if err != nil {
 		t.Fatalf("GET /api/guide: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestGetGuide_NoDate(t *testing.T) {
 func TestGetGuide_EmptyDate_ReturnsEmptyArray(t *testing.T) {
 	srv := newSeededServer(t)
 	// Use a date far in the future with no airings
-	resp, err := http.Get(srv.URL + "/api/guide?date=2099-01-01")
+	resp, err := httpGet(t, srv.URL + "/api/guide?date=2099-01-01")
 	if err != nil {
 		t.Fatalf("GET /api/guide: %v", err)
 	}
@@ -289,7 +289,7 @@ func TestGetGuide_EmptyDate_ReturnsEmptyArray(t *testing.T) {
 
 func TestGetGuide_InvalidDate(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/guide?date=notadate")
+	resp, err := httpGet(t, srv.URL + "/api/guide?date=notadate")
 	if err != nil {
 		t.Fatalf("GET /api/guide: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestGetGuide_InvalidDate(t *testing.T) {
 
 func TestGetStatus_SourceURL(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/status")
+	resp, err := httpGet(t, srv.URL + "/api/status")
 	if err != nil {
 		t.Fatalf("GET /api/status: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestGetStatus_SourceURL(t *testing.T) {
 
 func TestGetStatus_ContentType(t *testing.T) {
 	srv := newSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/status")
+	resp, err := httpGet(t, srv.URL + "/api/status")
 	if err != nil {
 		t.Fatalf("GET /api/status: %v", err)
 	}
@@ -339,7 +339,7 @@ func TestGetChannelIcon_ServesFile(t *testing.T) {
 	iconSrv := startFakeIconServer(t)
 	srv, _ := newSeededServerWithIcons(t, iconSrv)
 
-	resp, err := http.Get(srv.URL + "/images/channel/ch1")
+	resp, err := httpGet(t, srv.URL + "/images/channel/ch1")
 	if err != nil {
 		t.Fatalf("GET /images/channel/ch1: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestGetChannelIcon_ReturnsNotFoundForNoIcon(t *testing.T) {
 	iconSrv := startFakeIconServer(t)
 	srv, _ := newSeededServerWithIcons(t, iconSrv)
 
-	resp, err := http.Get(srv.URL + "/images/channel/ch2")
+	resp, err := httpGet(t, srv.URL + "/images/channel/ch2")
 	if err != nil {
 		t.Fatalf("GET /images/channel/ch2: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestGetChannelIcon_ReturnsNotFoundForNoIcon(t *testing.T) {
 func TestGetChannelIcon_ReturnsNotFoundForUnknownChannel(t *testing.T) {
 	srv := newSeededServer(t)
 
-	resp, err := http.Get(srv.URL + "/images/channel/doesnotexist")
+	resp, err := httpGet(t, srv.URL + "/images/channel/doesnotexist")
 	if err != nil {
 		t.Fatalf("GET /images/channel/doesnotexist: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestGetChannelIcon_RedownloadsIfMissing(t *testing.T) {
 	srv, db := newSeededServerWithIcons(t, iconSrv)
 
 	// Get the icon once to populate the cache.
-	resp, err := http.Get(srv.URL + "/images/channel/ch1")
+	resp, err := httpGet(t, srv.URL + "/images/channel/ch1")
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Fatalf("initial icon request: status=%d err=%v", resp.StatusCode, err)
 	}
@@ -408,7 +408,7 @@ func TestGetChannelIcon_RedownloadsIfMissing(t *testing.T) {
 	os.Remove(localPath)
 
 	// The handler should re-download and still return 200.
-	resp2, err := http.Get(srv.URL + "/images/channel/ch1")
+	resp2, err := httpGet(t, srv.URL + "/images/channel/ch1")
 	if err != nil {
 		t.Fatalf("GET after cache delete: %v", err)
 	}
@@ -511,7 +511,7 @@ func TestSearch_MissingQuery_Returns400(t *testing.T) {
 	srv := newSearchSeededServer(t)
 
 	// No q parameter
-	resp, err := http.Get(srv.URL + "/api/search")
+	resp, err := httpGet(t, srv.URL + "/api/search")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -521,7 +521,7 @@ func TestSearch_MissingQuery_Returns400(t *testing.T) {
 	}
 
 	// Empty q parameter
-	resp2, err := http.Get(srv.URL + "/api/search?q=")
+	resp2, err := httpGet(t, srv.URL + "/api/search?q=")
 	if err != nil {
 		t.Fatalf("GET /api/search?q=: %v", err)
 	}
@@ -533,7 +533,7 @@ func TestSearch_MissingQuery_Returns400(t *testing.T) {
 
 func TestSearch_SimpleMode_ReturnsTitleMatches(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/search?q=News")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -572,7 +572,7 @@ func TestSearch_SimpleMode_ReturnsTitleMatches(t *testing.T) {
 
 func TestSearch_SimpleMode_GroupsByTitle(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/search?q=News")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -609,7 +609,7 @@ func TestSearch_SimpleMode_GroupsByTitle(t *testing.T) {
 
 func TestSearch_SimpleMode_ChannelNamePopulated(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/search?q=News")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -636,7 +636,7 @@ func TestSearch_SimpleMode_ChannelNamePopulated(t *testing.T) {
 
 func TestSearch_SimpleMode_ExcludesRepeats(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&include_repeats=false")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&include_repeats=false")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -662,7 +662,7 @@ func TestSearch_SimpleMode_ExcludesRepeats(t *testing.T) {
 
 func TestSearch_AdvancedMode_MatchesDescription(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/search?q=news&mode=advanced")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=news&mode=advanced")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -686,7 +686,7 @@ func TestSearch_AdvancedMode_MatchesDescription(t *testing.T) {
 
 func TestSearch_AdvancedMode_CategoryFilter(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/search?q=news&mode=advanced&categories=Documentary")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=news&mode=advanced&categories=Documentary")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -715,7 +715,7 @@ func TestSearch_AdvancedMode_CategoryFilter(t *testing.T) {
 
 func TestSearch_AdvancedMode_IncludePast(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&mode=advanced&include_past=true")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&mode=advanced&include_past=true")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -739,7 +739,7 @@ func TestSearch_AdvancedMode_IncludePast(t *testing.T) {
 
 func TestSearch_ContentType(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/search?q=News")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -755,7 +755,7 @@ func TestSearch_ContentType(t *testing.T) {
 
 func TestCategories_ReturnsSortedList(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/categories")
+	resp, err := httpGet(t, srv.URL + "/api/categories")
 	if err != nil {
 		t.Fatalf("GET /api/categories: %v", err)
 	}
@@ -798,7 +798,7 @@ func TestCategories_EmptyWhenNoData(t *testing.T) {
 		db.Close()
 	})
 
-	resp, err := http.Get(srv.URL + "/api/categories")
+	resp, err := httpGet(t, srv.URL + "/api/categories")
 	if err != nil {
 		t.Fatalf("GET /api/categories: %v", err)
 	}
@@ -873,7 +873,7 @@ func TestSearch_AiringsOrderedByStartTime(t *testing.T) {
 		db.Close()
 	})
 
-	resp, err := http.Get(srv.URL + "/api/search?q=cricket&mode=advanced")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=cricket&mode=advanced")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -970,7 +970,7 @@ func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	})
 
 	// With today=true, only today's airing should be returned
-	resp, err := http.Get(srv.URL + "/api/search?q=Show&today=true")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=Show&today=true")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -998,7 +998,7 @@ func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	}
 
 	// Without today filter, both should be returned
-	resp2, err := http.Get(srv.URL + "/api/search?q=Show")
+	resp2, err := httpGet(t, srv.URL + "/api/search?q=Show")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -1070,7 +1070,7 @@ func TestSearch_TodayFilter_AdvancedMode(t *testing.T) {
 		db.Close()
 	})
 
-	resp, err := http.Get(srv.URL + "/api/search?q=Match&mode=advanced&today=true")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=Match&mode=advanced&today=true")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -1088,7 +1088,7 @@ func TestSearch_TodayFilter_AdvancedMode(t *testing.T) {
 
 func TestCategories_ContentType(t *testing.T) {
 	srv := newSearchSeededServer(t)
-	resp, err := http.Get(srv.URL + "/api/categories")
+	resp, err := httpGet(t, srv.URL + "/api/categories")
 	if err != nil {
 		t.Fatalf("GET /api/categories: %v", err)
 	}
@@ -1104,7 +1104,7 @@ func TestGetChannels_IconIsProxyURL(t *testing.T) {
 	iconSrv := startFakeIconServer(t)
 	srv, _ := newSeededServerWithIcons(t, iconSrv)
 
-	resp, err := http.Get(srv.URL + "/api/channels")
+	resp, err := httpGet(t, srv.URL + "/api/channels")
 	if err != nil {
 		t.Fatalf("GET /api/channels: %v", err)
 	}
@@ -1212,7 +1212,7 @@ func TestSearch_EmptyQ_NoFilters_Returns400(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
 	// No q and no browse filters
-	resp, err := http.Get(srv.URL + "/api/search")
+	resp, err := httpGet(t, srv.URL + "/api/search")
 	if err != nil {
 		t.Fatalf("GET /api/search: %v", err)
 	}
@@ -1229,7 +1229,7 @@ func TestSearch_EmptyQ_NoFilters_Returns400(t *testing.T) {
 func TestSearch_Browse_IsPremiere_Returns200(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
-	resp, err := http.Get(srv.URL + "/api/search?is_premiere=true")
+	resp, err := httpGet(t, srv.URL + "/api/search?is_premiere=true")
 	if err != nil {
 		t.Fatalf("GET /api/search?is_premiere=true: %v", err)
 	}
@@ -1243,7 +1243,7 @@ func TestSearch_Browse_IsPremiere_Returns200(t *testing.T) {
 func TestSearch_Browse_IsPremiere_ReturnsOnlyPremieres(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
-	resp, err := http.Get(srv.URL + "/api/search?is_premiere=true")
+	resp, err := httpGet(t, srv.URL + "/api/search?is_premiere=true")
 	if err != nil {
 		t.Fatalf("GET /api/search?is_premiere=true: %v", err)
 	}
@@ -1290,7 +1290,7 @@ func TestSearch_Browse_IsPremiere_ReturnsOnlyPremieres(t *testing.T) {
 func TestSearch_Browse_Categories_Returns200(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
-	resp, err := http.Get(srv.URL + "/api/search?categories=Sport")
+	resp, err := httpGet(t, srv.URL + "/api/search?categories=Sport")
 	if err != nil {
 		t.Fatalf("GET /api/search?categories=Sport: %v", err)
 	}
@@ -1304,7 +1304,7 @@ func TestSearch_Browse_Categories_Returns200(t *testing.T) {
 func TestSearch_Browse_Categories_ReturnsMatchingAirings(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
-	resp, err := http.Get(srv.URL + "/api/search?categories=Sport")
+	resp, err := httpGet(t, srv.URL + "/api/search?categories=Sport")
 	if err != nil {
 		t.Fatalf("GET /api/search?categories=Sport: %v", err)
 	}
@@ -1351,7 +1351,7 @@ func TestSearch_Browse_Categories_ReturnsMatchingAirings(t *testing.T) {
 func TestSearch_Browse_NonEmptyQ_StillWorksAsSimpleSearch(t *testing.T) {
 	srv := newBrowseSeededServer(t)
 
-	resp, err := http.Get(srv.URL + "/api/search?q=Drama")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=Drama")
 	if err != nil {
 		t.Fatalf("GET /api/search?q=Drama: %v", err)
 	}
@@ -1495,7 +1495,7 @@ func parseRSS(t *testing.T, body []byte) rssRoot {
 
 func TestSearchRSS_ContentType(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1512,7 +1512,7 @@ func TestSearchRSS_ContentType(t *testing.T) {
 
 func TestSearchRSS_ValidXML(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1531,7 +1531,7 @@ func TestSearchRSS_ValidXML(t *testing.T) {
 
 func TestSearchRSS_ItemsNotGrouped(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1548,7 +1548,7 @@ func TestSearchRSS_ItemsNotGrouped(t *testing.T) {
 
 func TestSearchRSS_SortedByStartTime(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1569,7 +1569,7 @@ func TestSearchRSS_SortedByStartTime(t *testing.T) {
 
 func TestSearchRSS_ItemFields(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1636,7 +1636,7 @@ func TestSearchRSS_ItemFields(t *testing.T) {
 
 func TestSearchRSS_DescriptionHTML(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1680,7 +1680,7 @@ func TestSearchRSS_DescriptionHTML(t *testing.T) {
 
 func TestSearchRSS_DescriptionOmitsEmptyFields(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=Sports&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=Sports&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1712,7 +1712,7 @@ func TestSearchRSS_DescriptionOmitsEmptyFields(t *testing.T) {
 
 func TestSearchRSS_RepeatFlag(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1735,7 +1735,7 @@ func TestSearchRSS_RepeatFlag(t *testing.T) {
 
 func TestSearchRSS_NoEnclosureWithoutIcon(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=Sports&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=Sports&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1757,7 +1757,7 @@ func TestSearchRSS_NoEnclosureWithoutIcon(t *testing.T) {
 
 func TestSearchRSS_DefaultTTL(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1773,7 +1773,7 @@ func TestSearchRSS_DefaultTTL(t *testing.T) {
 
 func TestSearchRSS_EnvVarTTL(t *testing.T) {
 	srv := newRSSSeededServer(t, 120)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1789,7 +1789,7 @@ func TestSearchRSS_EnvVarTTL(t *testing.T) {
 
 func TestSearchRSS_QueryParamTTL(t *testing.T) {
 	srv := newRSSSeededServer(t, 120)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss&ttl=30")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&ttl=30")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1805,7 +1805,7 @@ func TestSearchRSS_QueryParamTTL(t *testing.T) {
 
 func TestSearchRSS_InvalidQueryParamTTL_FallsBackToEnvVar(t *testing.T) {
 	srv := newRSSSeededServer(t, 120)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss&ttl=notanumber")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&ttl=notanumber")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1821,7 +1821,7 @@ func TestSearchRSS_InvalidQueryParamTTL_FallsBackToEnvVar(t *testing.T) {
 
 func TestSearchRSS_ZeroQueryParamTTL_FallsBack(t *testing.T) {
 	srv := newRSSSeededServer(t, 120)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss&ttl=0")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&ttl=0")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1837,7 +1837,7 @@ func TestSearchRSS_ZeroQueryParamTTL_FallsBack(t *testing.T) {
 
 func TestSearchRSS_NegativeQueryParamTTL_FallsBack(t *testing.T) {
 	srv := newRSSSeededServer(t, 120)
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss&ttl=-5")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&ttl=-5")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1855,7 +1855,7 @@ func TestSearchRSS_NegativeQueryParamTTL_FallsBack(t *testing.T) {
 
 func TestSearchRSS_JSONUnchangedWithoutFormat(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
-	resp, err := http.Get(srv.URL + "/api/search?q=News")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1886,7 +1886,7 @@ func TestSearchRSS_JSONUnchangedWithoutFormat(t *testing.T) {
 func TestSearchRSS_WorksWithAllSearchParams(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
 	// Test format=rss with advanced mode and categories
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss&mode=advanced&categories=News")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&mode=advanced&categories=News")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1923,7 +1923,7 @@ func TestSearchRSS_ChannelDescription(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
 
 	// Simple mode
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1937,7 +1937,7 @@ func TestSearchRSS_ChannelDescription(t *testing.T) {
 	}
 
 	// Advanced mode with categories
-	resp2, err := http.Get(srv.URL + "/api/search?q=News&format=rss&mode=advanced&categories=News,Sport")
+	resp2, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss&mode=advanced&categories=News,Sport")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -1954,7 +1954,7 @@ func TestSearchRSS_ChannelDescription(t *testing.T) {
 func TestSearchRSS_LastBuildDate(t *testing.T) {
 	srv := newRSSSeededServer(t, 0)
 	before := time.Now()
-	resp, err := http.Get(srv.URL + "/api/search?q=News&format=rss")
+	resp, err := httpGet(t, srv.URL + "/api/search?q=News&format=rss")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -2037,7 +2037,7 @@ func newNowNextServer(t *testing.T) (*httptest.Server, time.Time) {
 
 func TestGetNowNext_API_StatusOK(t *testing.T) {
 	srv, _ := newNowNextServer(t)
-	resp, err := http.Get(srv.URL + "/api/explore/now-next")
+	resp, err := httpGet(t, srv.URL + "/api/explore/now-next")
 	if err != nil {
 		t.Fatalf("GET /api/explore/now-next: %v", err)
 	}
@@ -2049,7 +2049,7 @@ func TestGetNowNext_API_StatusOK(t *testing.T) {
 
 func TestGetNowNext_API_ResponseShape(t *testing.T) {
 	srv, fixedNow := newNowNextServer(t)
-	resp, err := http.Get(srv.URL + "/api/explore/now-next")
+	resp, err := httpGet(t, srv.URL + "/api/explore/now-next")
 	if err != nil {
 		t.Fatalf("GET /api/explore/now-next: %v", err)
 	}

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -55,12 +55,12 @@ func (h *Handler) getSearch(w http.ResponseWriter, r *http.Request) {
 	case q == "":
 		// Browse mode: bypass FTS, query airings table directly.
 		includePast := r.URL.Query().Get("include_past") == "true"
-		results, err = h.db.SearchBrowse(categories, isPremiere, includePast, includeRepeats, today)
+		results, err = h.db.SearchBrowse(r.Context(), categories, isPremiere, includePast, includeRepeats, today)
 	case mode == "advanced":
 		includePast := r.URL.Query().Get("include_past") == "true"
-		results, err = h.db.SearchAdvanced(q, categories, includePast, includeRepeats, today)
+		results, err = h.db.SearchAdvanced(r.Context(), q, categories, includePast, includeRepeats, today)
 	default:
-		results, err = h.db.SearchSimple(q, includeRepeats, today)
+		results, err = h.db.SearchSimple(r.Context(), q, includeRepeats, today)
 	}
 
 	if err != nil {

--- a/internal/api/testhelpers_test.go
+++ b/internal/api/testhelpers_test.go
@@ -1,0 +1,31 @@
+package api_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// httpGet performs a GET request with a background context.
+// It is a context-aware replacement for http.Get in tests.
+func httpGet(t *testing.T, url string) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}
+
+// httpPost performs a POST request with a background context and JSON content type.
+// It is a context-aware replacement for http.Post in tests.
+func httpPost(t *testing.T, url string, body io.Reader) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return http.DefaultClient.Do(req)
+}

--- a/internal/database/airings.go
+++ b/internal/database/airings.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -13,11 +14,11 @@ import (
 
 // GetAirings returns all airings that overlap with the given calendar date,
 // interpreted in the server's local timezone.
-func (d *DB) GetAirings(date time.Time) ([]model.Airing, error) {
+func (d *DB) GetAirings(ctx context.Context, date time.Time) ([]model.Airing, error) {
 	dayStart := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.Local).UTC()
 	dayEnd := dayStart.Add(24 * time.Hour)
 
-	rows, err := d.db.Query(`
+	rows, err := d.db.QueryContext(ctx, `
 		SELECT
 			channel_id,
 			start_time,

--- a/internal/database/channel_name_strip_test.go
+++ b/internal/database/channel_name_strip_test.go
@@ -64,7 +64,7 @@ func TestRefresh_ChannelNameStrip(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestRefresh_ChannelNameStrip_CaseInsensitive(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestRefresh_ChannelNameStrip_TrimSpace(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestRefresh_ChannelNameStrip_Empty(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}

--- a/internal/database/channels.go
+++ b/internal/database/channels.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
@@ -11,8 +12,8 @@ import (
 // GetChannels returns all channels ordered by their source sort order.
 // The Icon field contains the proxy URL (/images/channel/{id}) for channels
 // that have an icon; it is empty for channels without one.
-func (d *DB) GetChannels() ([]model.Channel, error) {
-	rows, err := d.db.Query(`
+func (d *DB) GetChannels(ctx context.Context) ([]model.Channel, error) {
+	rows, err := d.db.QueryContext(ctx, `
 		SELECT id, display_name, COALESCE(icon_url, ''), lcn
 		FROM channels
 		ORDER BY sort_order

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -256,7 +256,7 @@ func (d *DB) GetStatus() model.Status {
 // HasData reports whether the database contains any channels.
 func (d *DB) HasData(ctx context.Context) bool {
 	var count int
-	d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM channels`).Scan(&count) //nolint:errcheck // zero count on error is the safe default
+	d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM channels`).Scan(&count) //nolint:errcheck,gosec // zero count on error is the safe default
 	return count > 0
 }
 

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
@@ -103,12 +104,15 @@ var migrations = []struct {
 }
 
 func applyMigrations(db *sql.DB) error {
-	if _, err := db.Exec(createMigrationsTable); err != nil {
+	// Migrations run at startup before the server accepts requests;
+	// context.Background() is appropriate — migrations are not cancellable.
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, createMigrationsTable); err != nil {
 		return fmt.Errorf("creating migrations table: %w", err)
 	}
 	for _, m := range migrations {
 		var count int
-		if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE version = ?`, m.version).Scan(&count); err != nil {
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM schema_migrations WHERE version = ?`, m.version).Scan(&count); err != nil {
 			return fmt.Errorf("checking migration %d: %w", m.version, err)
 		}
 		if count > 0 {
@@ -120,21 +124,21 @@ func applyMigrations(db *sql.DB) error {
 		if already, err := migrationAlreadyApplied(db, m.version); err != nil {
 			return fmt.Errorf("pre-checking migration %d: %w", m.version, err)
 		} else if already {
-			if _, err := db.Exec(`INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
+			if _, err := db.ExecContext(ctx, `INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
 				m.version, time.Now().UTC().Format(time.RFC3339)); err != nil {
 				return fmt.Errorf("recording migration %d: %w", m.version, err)
 			}
 			continue
 		}
-		if _, err := db.Exec(m.sql); err != nil {
+		if _, err := db.ExecContext(ctx, m.sql); err != nil {
 			return fmt.Errorf("applying migration %d: %w", m.version, err)
 		}
 		if m.populateSQL != "" {
-			if _, err := db.Exec(m.populateSQL); err != nil {
+			if _, err := db.ExecContext(ctx, m.populateSQL); err != nil {
 				return fmt.Errorf("populating migration %d: %w", m.version, err)
 			}
 		}
-		if _, err := db.Exec(`INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
+		if _, err := db.ExecContext(ctx, `INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
 			m.version, time.Now().UTC().Format(time.RFC3339)); err != nil {
 			return fmt.Errorf("recording migration %d: %w", m.version, err)
 		}
@@ -162,7 +166,7 @@ func migrationAlreadyApplied(db *sql.DB, version int) (bool, error) {
 // tableExists reports whether a table (or virtual table) exists in the database.
 func tableExists(db *sql.DB, table string) (bool, error) {
 	var count int
-	err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE name = ?`, table).Scan(&count)
+	err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM sqlite_master WHERE name = ?`, table).Scan(&count)
 	if err != nil {
 		return false, err
 	}
@@ -172,7 +176,7 @@ func tableExists(db *sql.DB, table string) (bool, error) {
 // columnExists reports whether the named column is present in the given table.
 func columnExists(db *sql.DB, table, column string) (bool, error) {
 	var count int
-	err := db.QueryRow("SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?", table, column).Scan(&count)
+	err := db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?", table, column).Scan(&count)
 	if err != nil {
 		return false, err
 	}
@@ -191,13 +195,14 @@ func Open(path string, retentionDays int, sourceURL string, imageCache *images.C
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
 
+	startupCtx := context.Background()
 	for _, pragma := range []string{
 		"PRAGMA journal_mode=WAL",
 		"PRAGMA foreign_keys=ON",
 		"PRAGMA synchronous=NORMAL",
 		"PRAGMA temp_store=MEMORY", // scratch image has no /tmp; keep all temp data in RAM
 	} {
-		if _, err := db.Exec(pragma); err != nil {
+		if _, err := db.ExecContext(startupCtx, pragma); err != nil {
 			if closeErr := db.Close(); closeErr != nil {
 				log.Printf("closing database after pragma error: %v", closeErr)
 			}
@@ -205,7 +210,7 @@ func Open(path string, retentionDays int, sourceURL string, imageCache *images.C
 		}
 	}
 
-	if _, err := db.Exec(schema); err != nil {
+	if _, err := db.ExecContext(startupCtx, schema); err != nil {
 		if closeErr := db.Close(); closeErr != nil {
 			log.Printf("closing database after schema error: %v", closeErr)
 		}
@@ -249,9 +254,9 @@ func (d *DB) GetStatus() model.Status {
 }
 
 // HasData reports whether the database contains any channels.
-func (d *DB) HasData() bool {
+func (d *DB) HasData(ctx context.Context) bool {
 	var count int
-	d.db.QueryRow(`SELECT COUNT(*) FROM channels`).Scan(&count) //nolint:errcheck // zero count on error is the safe default
+	d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM channels`).Scan(&count) //nolint:errcheck // zero count on error is the safe default
 	return count > 0
 }
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -196,7 +196,7 @@ func sampleTV() *xmltv.TV {
 
 func TestOpen_EmptyDB(t *testing.T) {
 	db := openTestDB(t)
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestRefresh_ChannelCount(t *testing.T) {
 	if err := db.Refresh(context.Background(), sampleTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestRefresh_ChannelOrder(t *testing.T) {
 	if err := db.Refresh(context.Background(), sampleTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestRefresh_ChannelFields(t *testing.T) {
 	if err := db.Refresh(context.Background(), sampleTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestRefresh_ChannelLCN(t *testing.T) {
 	if err := db.Refresh(context.Background(), sampleTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -307,7 +307,7 @@ func TestRefresh_IconDownloaded(t *testing.T) {
 	if err := db.Refresh(context.Background(), tv, time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -428,7 +428,7 @@ func TestRefresh_FTSRebuildSucceedsOnSubsequentRefresh(t *testing.T) {
 	// FTS search must return results after the rebuild.
 	// Use SearchAdvanced with includePast=true so the result is not
 	// dependent on what time of day the test runs.
-	results, err := db.SearchAdvanced("Morning News", nil, true, true, false)
+	results, err := db.SearchAdvanced(context.Background(), "Morning News", nil, true, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced after second refresh: %v", err)
 	}
@@ -558,7 +558,7 @@ func TestGetAirings_SxxExxEpisodeMapping(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	date := testBaseDate()
-	airings, err := db.GetAirings(date)
+	airings, err := db.GetAirings(context.Background(), date)
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
@@ -586,7 +586,7 @@ func TestGetAirings_OverlapDate(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	date := testBaseDate()
-	airings, err := db.GetAirings(date)
+	airings, err := db.GetAirings(context.Background(), date)
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
@@ -601,7 +601,7 @@ func TestGetAirings_ExcludesOtherDate(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	date := testBaseDate().AddDate(0, 0, -2)
-	airings, err := db.GetAirings(date)
+	airings, err := db.GetAirings(context.Background(), date)
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
@@ -616,7 +616,7 @@ func TestGetAirings_FieldMapping(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	date := testBaseDate()
-	airings, err := db.GetAirings(date)
+	airings, err := db.GetAirings(context.Background(), date)
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
@@ -653,7 +653,7 @@ func TestGetAirings_PremiereFlagAndCategories(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	date := testBaseDate()
-	airings, err := db.GetAirings(date)
+	airings, err := db.GetAirings(context.Background(), date)
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
@@ -697,11 +697,11 @@ func TestGetAirings_PremiereFlagAndCategories(t *testing.T) {
 func TestFTS5_Available(t *testing.T) {
 	db := openTestDB(t)
 	// Attempt to create a simple FTS5 table. If this fails, FTS5 is not compiled in.
-	_, err := db.ExecRaw(`CREATE VIRTUAL TABLE IF NOT EXISTS fts5_test USING fts5(content)`)
+	_, err := db.ExecRaw(context.Background(), `CREATE VIRTUAL TABLE IF NOT EXISTS fts5_test USING fts5(content)`)
 	if err != nil {
 		t.Fatalf("FTS5 not available in modernc.org/sqlite: %v", err)
 	}
-	_, err = db.ExecRaw(`DROP TABLE fts5_test`)
+	_, err = db.ExecRaw(context.Background(), `DROP TABLE fts5_test`)
 	if err != nil {
 		t.Fatalf("dropping FTS5 test table: %v", err)
 	}
@@ -781,7 +781,7 @@ func TestSearchSimple_MatchesTitle(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true, false)
+	results, err := db.SearchSimple(context.Background(), "News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -807,7 +807,7 @@ func TestSearchSimple_ExcludesDescriptionOnlyMatches(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true, false)
+	results, err := db.SearchSimple(context.Background(), "News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -823,7 +823,7 @@ func TestSearchSimple_ExcludesFinishedAirings(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true, false)
+	results, err := db.SearchSimple(context.Background(), "News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -839,7 +839,7 @@ func TestSearchSimple_ExcludesRepeats(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", false, false)
+	results, err := db.SearchSimple(context.Background(), "News", false, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -855,7 +855,7 @@ func TestSearchSimple_IncludesRepeats(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true, false)
+	results, err := db.SearchSimple(context.Background(), "News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -876,7 +876,7 @@ func TestSearchAdvanced_MatchesTitleSubtitleDescription(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	// "news" should match in title (Morning News, Evening News) AND subtitle/description (Documentary Special)
-	results, err := db.SearchAdvanced("news", nil, false, true, false)
+	results, err := db.SearchAdvanced(context.Background(), "news", nil, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -898,7 +898,7 @@ func TestSearchAdvanced_FiltersByCategory(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	// Search for "news" but filter to "Documentary" category only
-	results, err := db.SearchAdvanced("news", []string{"Documentary"}, false, true, false)
+	results, err := db.SearchAdvanced(context.Background(), "news", []string{"Documentary"}, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -923,7 +923,7 @@ func TestSearchAdvanced_IncludesPastAirings(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchAdvanced("News", nil, true, true, false)
+	results, err := db.SearchAdvanced(context.Background(), "News", nil, true, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -943,7 +943,7 @@ func TestSearchAdvanced_ExcludesFinishedAirings(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchAdvanced("News", nil, false, true, false)
+	results, err := db.SearchAdvanced(context.Background(), "News", nil, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -959,7 +959,7 @@ func TestSearchAdvanced_ExcludesRepeats(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchAdvanced("News", nil, false, false, false)
+	results, err := db.SearchAdvanced(context.Background(), "News", nil, false, false, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -976,7 +976,7 @@ func TestSearchAdvanced_CombinesCategoryAndText(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	// Search for "sport" filtered to "Entertainment" category
-	results, err := db.SearchAdvanced("sport", []string{"Entertainment"}, false, true, false)
+	results, err := db.SearchAdvanced(context.Background(), "sport", []string{"Entertainment"}, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -995,7 +995,7 @@ func TestSearchSimple_IncludesCurrentlyAiring(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true, false)
+	results, err := db.SearchSimple(context.Background(), "News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -1015,7 +1015,7 @@ func TestSearchAdvanced_IncludesCurrentlyAiring(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchAdvanced("News", nil, false, true, false)
+	results, err := db.SearchAdvanced(context.Background(), "News", nil, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -1051,7 +1051,7 @@ func TestSearchSimple_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTVWithTomorrow(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchSimple("News", true, true)
+	results, err := db.SearchSimple(context.Background(), "News", true, true)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -1071,7 +1071,7 @@ func TestSearchSimple_TodayFilter_IncludesToday(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 	// Without today filter, tomorrow's airing should be included
-	results, err := db.SearchSimple("News", true, false)
+	results, err := db.SearchSimple(context.Background(), "News", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple: %v", err)
 	}
@@ -1091,7 +1091,7 @@ func TestSearchAdvanced_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTVWithTomorrow(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchAdvanced("News", nil, false, true, true)
+	results, err := db.SearchAdvanced(context.Background(), "News", nil, false, true, true)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -1110,7 +1110,7 @@ func TestSearchAdvanced_TodayFilter_IncludesToday(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTVWithTomorrow(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchAdvanced("News", nil, false, true, false)
+	results, err := db.SearchAdvanced(context.Background(), "News", nil, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -1130,7 +1130,7 @@ func TestGetCategories_ReturnsSorted(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	cats, err := db.GetCategories()
+	cats, err := db.GetCategories(context.Background())
 	if err != nil {
 		t.Fatalf("GetCategories: %v", err)
 	}
@@ -1147,7 +1147,7 @@ func TestGetCategories_ReturnsSorted(t *testing.T) {
 
 func TestGetCategories_EmptyWhenNoData(t *testing.T) {
 	db := openTestDB(t)
-	cats, err := db.GetCategories()
+	cats, err := db.GetCategories(context.Background())
 	if err != nil {
 		t.Fatalf("GetCategories: %v", err)
 	}
@@ -1166,7 +1166,7 @@ func TestRefresh_PopulatesFTSAndCategories(t *testing.T) {
 	}
 
 	// FTS should be populated — simple search should work
-	results, err := db.SearchSimple("Morning", true, false)
+	results, err := db.SearchSimple(context.Background(), "Morning", true, false)
 	if err != nil {
 		t.Fatalf("SearchSimple after Refresh: %v", err)
 	}
@@ -1175,7 +1175,7 @@ func TestRefresh_PopulatesFTSAndCategories(t *testing.T) {
 	}
 
 	// Categories should be populated
-	cats, err := db.GetCategories()
+	cats, err := db.GetCategories(context.Background())
 	if err != nil {
 		t.Fatalf("GetCategories after Refresh: %v", err)
 	}
@@ -1194,7 +1194,7 @@ func TestRefresh_Upsert_NoDuplicates(t *testing.T) {
 		t.Fatalf("second Refresh: %v", err)
 	}
 	date := testBaseDate()
-	airings, err := db.GetAirings(date)
+	airings, err := db.GetAirings(context.Background(), date)
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
@@ -1247,7 +1247,7 @@ func TestGetNowNext_CurrentAndNext(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 
-	entries, err := db.GetNowNext()
+	entries, err := db.GetNowNext(context.Background())
 	if err != nil {
 		t.Fatalf("GetNowNext: %v", err)
 	}
@@ -1285,7 +1285,7 @@ func TestGetNowNext_NullCurrent(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 
-	entries, err := db.GetNowNext()
+	entries, err := db.GetNowNext(context.Background())
 	if err != nil {
 		t.Fatalf("GetNowNext: %v", err)
 	}
@@ -1317,7 +1317,7 @@ func TestGetNowNext_BothNull(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 
-	entries, err := db.GetNowNext()
+	entries, err := db.GetNowNext(context.Background())
 	if err != nil {
 		t.Fatalf("GetNowNext: %v", err)
 	}
@@ -1361,7 +1361,7 @@ func TestSearchBrowse_IsPremiere_ReturnsOnlyPremieres(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTVWithPremiere(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchBrowse(nil, true, false, true, false)
+	results, err := db.SearchBrowse(context.Background(), nil, true, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchBrowse: %v", err)
 	}
@@ -1389,7 +1389,7 @@ func TestSearchBrowse_Categories_ReturnsMatchingCategory(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchBrowse([]string{"Sport"}, false, false, true, false)
+	results, err := db.SearchBrowse(context.Background(), []string{"Sport"}, false, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchBrowse: %v", err)
 	}
@@ -1415,7 +1415,7 @@ func TestSearchBrowse_ExcludesPastAirings(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTVWithPremiere(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchBrowse(nil, true, false, true, false)
+	results, err := db.SearchBrowse(context.Background(), nil, true, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchBrowse: %v", err)
 	}
@@ -1431,7 +1431,7 @@ func TestSearchBrowse_SortedByStartTime(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchBrowse([]string{"News"}, false, false, true, false)
+	results, err := db.SearchBrowse(context.Background(), []string{"News"}, false, false, true, false)
 	if err != nil {
 		t.Fatalf("SearchBrowse: %v", err)
 	}
@@ -1449,7 +1449,7 @@ func TestSearchBrowse_ExcludesRepeats(t *testing.T) {
 	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
-	results, err := db.SearchBrowse([]string{"News"}, false, false, false, false)
+	results, err := db.SearchBrowse(context.Background(), []string{"News"}, false, false, false, false)
 	if err != nil {
 		t.Fatalf("SearchBrowse: %v", err)
 	}
@@ -1468,7 +1468,7 @@ func TestGetNowNext_SortOrder(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 
-	entries, err := db.GetNowNext()
+	entries, err := db.GetNowNext(context.Background())
 	if err != nil {
 		t.Fatalf("GetNowNext: %v", err)
 	}
@@ -1483,6 +1483,128 @@ func TestGetNowNext_SortOrder(t *testing.T) {
 		if id != want[i] {
 			t.Errorf("entries[%d].ChannelID = %q, want %q", i, id, want[i])
 		}
+	}
+}
+
+// --- Context propagation tests ---
+// These tests verify that all public DB methods accept a context.Context parameter.
+// They fail to compile until the method signatures are updated (TDD step 1).
+
+func TestGetChannels_AcceptsContext(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	channels, err := db.GetChannels(ctx)
+	if err != nil {
+		t.Fatalf("GetChannels(ctx): %v", err)
+	}
+	if channels == nil {
+		t.Fatal("expected non-nil slice")
+	}
+}
+
+func TestGetAirings_AcceptsContext(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), sampleTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	ctx := context.Background()
+	airings, err := db.GetAirings(ctx, testBaseDate())
+	if err != nil {
+		t.Fatalf("GetAirings(ctx, date): %v", err)
+	}
+	if airings == nil {
+		t.Fatal("expected non-nil slice")
+	}
+}
+
+func TestGetNowNext_AcceptsContext(t *testing.T) {
+	db := openTestDB(t)
+	tv, now := nowNextTV()
+	db.SetClock(database.FixedClock(now))
+	if err := db.Refresh(context.Background(), tv, now.Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	ctx := context.Background()
+	entries, err := db.GetNowNext(ctx)
+	if err != nil {
+		t.Fatalf("GetNowNext(ctx): %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least 1 entry")
+	}
+}
+
+func TestSearchSimple_AcceptsContext(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	ctx := context.Background()
+	results, err := db.SearchSimple(ctx, "News", true, false)
+	if err != nil {
+		t.Fatalf("SearchSimple(ctx, ...): %v", err)
+	}
+	if results == nil {
+		t.Fatal("expected non-nil slice")
+	}
+}
+
+func TestSearchAdvanced_AcceptsContext(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	ctx := context.Background()
+	results, err := db.SearchAdvanced(ctx, "news", nil, false, true, false)
+	if err != nil {
+		t.Fatalf("SearchAdvanced(ctx, ...): %v", err)
+	}
+	if results == nil {
+		t.Fatal("expected non-nil slice")
+	}
+}
+
+func TestSearchBrowse_AcceptsContext(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	ctx := context.Background()
+	results, err := db.SearchBrowse(ctx, []string{"News"}, false, false, true, false)
+	if err != nil {
+		t.Fatalf("SearchBrowse(ctx, ...): %v", err)
+	}
+	if results == nil {
+		t.Fatal("expected non-nil slice")
+	}
+}
+
+func TestGetCategories_AcceptsContext(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Refresh(context.Background(), searchTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	ctx := context.Background()
+	cats, err := db.GetCategories(ctx)
+	if err != nil {
+		t.Fatalf("GetCategories(ctx): %v", err)
+	}
+	if cats == nil {
+		t.Fatal("expected non-nil slice")
+	}
+}
+
+func TestHasData_AcceptsContext(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	if db.HasData(ctx) {
+		t.Error("expected HasData to return false on empty database")
+	}
+	if err := db.Refresh(context.Background(), sampleTV(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if !db.HasData(ctx) {
+		t.Error("expected HasData to return true after Refresh")
 	}
 }
 
@@ -1547,7 +1669,7 @@ func TestRefresh_OverlappingAiringIsReplaced(t *testing.T) {
 		t.Fatalf("updated Refresh: %v", err)
 	}
 
-	airings, err := db.GetAirings(testBaseDate())
+	airings, err := db.GetAirings(context.Background(), testBaseDate())
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}

--- a/internal/database/hidden_channels_test.go
+++ b/internal/database/hidden_channels_test.go
@@ -39,7 +39,7 @@ func TestHiddenChannels_Empty(t *testing.T) {
 	db := openTestDBHidden(t, nil, nil)
 	refreshHiddenTestData(t, db)
 
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestHiddenChannels_ByID_GetChannels(t *testing.T) {
 	db := openTestDBHidden(t, []string{"ch1"}, nil)
 	refreshHiddenTestData(t, db)
 
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestHiddenChannels_ByID_GetAirings(t *testing.T) {
 	db := openTestDBHidden(t, []string{"ch1"}, nil)
 	refreshHiddenTestData(t, db)
 
-	airings, err := db.GetAirings(testBaseDate())
+	airings, err := db.GetAirings(context.Background(), testBaseDate())
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestHiddenChannels_ByLCN_GetChannels(t *testing.T) {
 	db := openTestDBHidden(t, nil, []int{2})
 	refreshHiddenTestData(t, db)
 
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestHiddenChannels_ByLCN_GetAirings(t *testing.T) {
 	db := openTestDBHidden(t, nil, []int{2})
 	refreshHiddenTestData(t, db)
 
-	airings, err := db.GetAirings(testBaseDate())
+	airings, err := db.GetAirings(context.Background(), testBaseDate())
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestHiddenChannels_Mixed(t *testing.T) {
 	db := openTestDBHidden(t, []string{"ch2"}, []int{2})
 	refreshHiddenTestData(t, db)
 
-	channels, err := db.GetChannels()
+	channels, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestHiddenChannels_Mixed(t *testing.T) {
 		t.Errorf("expected 0 channels with both ch1 (LCN 2) and ch2 (ID) hidden, got %d", len(channels))
 	}
 
-	airings, err := db.GetAirings(testBaseDate())
+	airings, err := db.GetAirings(context.Background(), testBaseDate())
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestHiddenChannels_ByID_GetNowNext(t *testing.T) {
 	db := openTestDBHidden(t, []string{"ch1"}, nil)
 	refreshHiddenTestData(t, db)
 
-	entries, err := db.GetNowNext()
+	entries, err := db.GetNowNext(context.Background())
 	if err != nil {
 		t.Fatalf("GetNowNext: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestHiddenChannels_ByID_Search(t *testing.T) {
 	refreshHiddenTestData(t, db)
 
 	t.Run("SearchSimple", func(t *testing.T) {
-		results, err := db.SearchSimple("Morning News", true, false)
+		results, err := db.SearchSimple(context.Background(), "Morning News", true, false)
 		if err != nil {
 			t.Fatalf("SearchSimple: %v", err)
 		}
@@ -179,7 +179,7 @@ func TestHiddenChannels_ByID_Search(t *testing.T) {
 	})
 
 	t.Run("SearchAdvanced", func(t *testing.T) {
-		results, err := db.SearchAdvanced("Morning", nil, true, true, false)
+		results, err := db.SearchAdvanced(context.Background(), "Morning", nil, true, true, false)
 		if err != nil {
 			t.Fatalf("SearchAdvanced: %v", err)
 		}
@@ -191,7 +191,7 @@ func TestHiddenChannels_ByID_Search(t *testing.T) {
 	})
 
 	t.Run("SearchBrowse", func(t *testing.T) {
-		results, err := db.SearchBrowse(nil, false, true, true, false)
+		results, err := db.SearchBrowse(context.Background(), nil, false, true, true, false)
 		if err != nil {
 			t.Fatalf("SearchBrowse: %v", err)
 		}

--- a/internal/database/migrations_test.go
+++ b/internal/database/migrations_test.go
@@ -1,6 +1,7 @@
 package database_test
 
 import (
+	"context"
 	"database/sql"
 	"net/http"
 	"path/filepath"
@@ -55,22 +56,23 @@ CREATE INDEX IF NOT EXISTS idx_airings_stop   ON airings(stop_time);
 // database prior to migrations 3 and 4 being applied.
 func createPreMigrationDB(t *testing.T, path string, channelID string, categories string) {
 	t.Helper()
+	ctx := context.Background()
 	rawDB, err := sql.Open("sqlite", path)
 	if err != nil {
 		t.Fatalf("createPreMigrationDB: open: %v", err)
 	}
 	defer rawDB.Close()
 
-	if _, err := rawDB.Exec(preMigrationSchema); err != nil {
+	if _, err := rawDB.ExecContext(ctx, preMigrationSchema); err != nil {
 		t.Fatalf("createPreMigrationDB: schema: %v", err)
 	}
-	if _, err := rawDB.Exec(
+	if _, err := rawDB.ExecContext(ctx,
 		`INSERT INTO channels (id, display_name, sort_order) VALUES (?, ?, 1)`,
 		channelID, "Test Channel",
 	); err != nil {
 		t.Fatalf("createPreMigrationDB: insert channel: %v", err)
 	}
-	if _, err := rawDB.Exec(`
+	if _, err := rawDB.ExecContext(ctx, `
 		INSERT INTO airings (channel_id, start_time, stop_time, title, categories)
 		VALUES (?, '2025-01-01T10:00:00Z', '2025-01-01T11:00:00Z', 'Test Show', ?)`,
 		channelID, categories,
@@ -106,7 +108,7 @@ func TestMigration_PopulateSQL_RunsOnNewMigration(t *testing.T) {
 	db := openDBAt(t, dbPath)
 
 	// categories should be populated from the existing airing.
-	cats, err := db.GetCategories()
+	cats, err := db.GetCategories(context.Background())
 	if err != nil {
 		t.Fatalf("GetCategories: %v", err)
 	}
@@ -125,7 +127,7 @@ func TestMigration_PopulateSQL_RunsOnNewMigration(t *testing.T) {
 	}
 
 	// airings_fts should be populated — searching with includePast=true should find the airing.
-	results, err := db.SearchAdvanced("Test Show", nil, true, true, false)
+	results, err := db.SearchAdvanced(context.Background(), "Test Show", nil, true, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}
@@ -160,13 +162,14 @@ func TestMigration_PopulateSQL_SkipsAlreadyApplied(t *testing.T) {
 	if err != nil {
 		t.Fatalf("raw open: %v", err)
 	}
-	if _, err := rawDB.Exec(
+	ctx := context.Background()
+	if _, err := rawDB.ExecContext(ctx,
 		`INSERT INTO channels (id, display_name, sort_order) VALUES ('ch1', 'Test Channel', 1)`,
 	); err != nil {
 		rawDB.Close()
 		t.Fatalf("insert channel: %v", err)
 	}
-	if _, err := rawDB.Exec(`
+	if _, err := rawDB.ExecContext(ctx, `
 		INSERT INTO airings (channel_id, start_time, stop_time, title, categories)
 		VALUES ('ch1', '2025-01-01T10:00:00Z', '2025-01-01T11:00:00Z', 'Test Show', '["Sports"]')`,
 	); err != nil {
@@ -183,7 +186,7 @@ func TestMigration_PopulateSQL_SkipsAlreadyApplied(t *testing.T) {
 	}
 	defer db2.Close()
 
-	cats, err := db2.GetCategories()
+	cats, err := db2.GetCategories(context.Background())
 	if err != nil {
 		t.Fatalf("GetCategories: %v", err)
 	}
@@ -191,7 +194,7 @@ func TestMigration_PopulateSQL_SkipsAlreadyApplied(t *testing.T) {
 		t.Errorf("expected categories to be empty (populateSQL should not re-run), got %v", cats)
 	}
 
-	results, err := db2.SearchAdvanced("Test Show", nil, true, true, false)
+	results, err := db2.SearchAdvanced(context.Background(), "Test Show", nil, true, true, false)
 	if err != nil {
 		t.Fatalf("SearchAdvanced: %v", err)
 	}

--- a/internal/database/nownext.go
+++ b/internal/database/nownext.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -13,17 +14,17 @@ import (
 // GetNowNext returns the current and next airing for every channel, ordered
 // by the same sort order as GetChannels (sort_order, which respects lcn).
 // Either field may be nil if no matching airing exists.
-func (d *DB) GetNowNext() ([]model.NowNextEntry, error) {
+func (d *DB) GetNowNext(ctx context.Context) ([]model.NowNextEntry, error) {
 	now := d.clock.Now().UTC().Format(time.RFC3339)
 
 	// Fetch channels in sort order.
-	channels, err := d.GetChannels()
+	channels, err := d.GetChannels(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting channels: %w", err)
 	}
 
 	// Fetch all currently-airing programmes (start_time <= now < stop_time).
-	currentRows, err := d.db.Query(`
+	currentRows, err := d.db.QueryContext(ctx, `
 		SELECT
 			channel_id, start_time, stop_time, title,
 			COALESCE(sub_title, ''), COALESCE(description, ''),
@@ -58,7 +59,7 @@ func (d *DB) GetNowNext() ([]model.NowNextEntry, error) {
 	}
 
 	// Fetch the next upcoming airing per channel using a window function.
-	nextRows, err := d.db.Query(`
+	nextRows, err := d.db.QueryContext(ctx, `
 		SELECT
 			channel_id, start_time, stop_time, title,
 			COALESCE(sub_title, ''), COALESCE(description, ''),

--- a/internal/database/refresh.go
+++ b/internal/database/refresh.go
@@ -108,13 +108,13 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 		deleteArgs := make([]any, 0, len(idArgs)+len(lcnArgs))
 		deleteArgs = append(deleteArgs, idArgs...)
 		deleteArgs = append(deleteArgs, lcnArgs...)
-		if _, err := tx.ExecContext(ctx,
+		if _, err := tx.ExecContext(ctx, //nolint:gosec // filterSQL contains only ? placeholders, no user values
 			`DELETE FROM airings WHERE channel_id IN (SELECT id FROM channels WHERE `+filterSQL+`)`,
 			deleteArgs...,
 		); err != nil {
 			return fmt.Errorf("deleting airings for hidden channels: %w", err)
 		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM channels WHERE `+filterSQL, deleteArgs...); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM channels WHERE `+filterSQL, deleteArgs...); err != nil { //nolint:gosec // filterSQL contains only ? placeholders, no user values
 			return fmt.Errorf("deleting hidden channels: %w", err)
 		}
 	}

--- a/internal/database/refresh.go
+++ b/internal/database/refresh.go
@@ -91,7 +91,7 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	}
 
 	// Phase 3: Write everything to the database in a single transaction.
-	tx, err := d.db.Begin()
+	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("beginning transaction: %w", err)
 	}
@@ -108,18 +108,18 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 		deleteArgs := make([]any, 0, len(idArgs)+len(lcnArgs))
 		deleteArgs = append(deleteArgs, idArgs...)
 		deleteArgs = append(deleteArgs, lcnArgs...)
-		if _, err := tx.Exec(
+		if _, err := tx.ExecContext(ctx,
 			`DELETE FROM airings WHERE channel_id IN (SELECT id FROM channels WHERE `+filterSQL+`)`,
 			deleteArgs...,
 		); err != nil {
 			return fmt.Errorf("deleting airings for hidden channels: %w", err)
 		}
-		if _, err := tx.Exec(`DELETE FROM channels WHERE `+filterSQL, deleteArgs...); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM channels WHERE `+filterSQL, deleteArgs...); err != nil {
 			return fmt.Errorf("deleting hidden channels: %w", err)
 		}
 	}
 
-	chStmt, err := tx.Prepare(`
+	chStmt, err := tx.PrepareContext(ctx, `
 		INSERT OR REPLACE INTO channels (id, display_name, icon, sort_order, lcn, icon_url)
 		VALUES (?, ?, ?, ?, ?, ?)
 	`)
@@ -157,7 +157,7 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 				lcn = n
 			}
 		}
-		if _, err := chStmt.Exec(ch.ID, name, icon, i, lcn, iconURL); err != nil {
+		if _, err := chStmt.ExecContext(ctx, ch.ID, name, icon, i, lcn, iconURL); err != nil {
 			return fmt.Errorf("upserting channel %s: %w", ch.ID, err)
 		}
 	}
@@ -166,7 +166,7 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	// time range overlaps the incoming airing but has a different start_time.
 	// This handles schedule shifts where a show's start time changes slightly —
 	// the old record would otherwise remain alongside the new one.
-	deleteOverlapStmt, err := tx.Prepare(`
+	deleteOverlapStmt, err := tx.PrepareContext(ctx, `
 		DELETE FROM airings
 		WHERE channel_id = ?
 		AND start_time != ?
@@ -182,7 +182,7 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 		}
 	}()
 
-	airStmt, err := tx.Prepare(`
+	airStmt, err := tx.PrepareContext(ctx, `
 		INSERT OR REPLACE INTO airings (
 			channel_id, start_time, stop_time,
 			title, sub_title, description, categories,
@@ -209,7 +209,7 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 		startStr := a.Start.UTC().Format(time.RFC3339)
 		stopStr := a.Stop.UTC().Format(time.RFC3339)
 
-		if _, err := deleteOverlapStmt.Exec(a.ChannelID, startStr, stopStr, startStr); err != nil {
+		if _, err := deleteOverlapStmt.ExecContext(ctx, a.ChannelID, startStr, stopStr, startStr); err != nil {
 			return fmt.Errorf("deleting overlapping airings: %w", err)
 		}
 
@@ -219,7 +219,7 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 		}
 		catsJSON, _ := json.Marshal(cats)
 
-		if _, err := airStmt.Exec(
+		if _, err := airStmt.ExecContext(ctx,
 			a.ChannelID,
 			startStr,
 			stopStr,
@@ -243,15 +243,15 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	}
 
 	cutoff := d.clock.Now().AddDate(0, 0, -d.retentionDays).UTC().Format(time.RFC3339)
-	if _, err := tx.Exec(`DELETE FROM airings WHERE stop_time < ?`, cutoff); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM airings WHERE stop_time < ?`, cutoff); err != nil {
 		return fmt.Errorf("pruning airings: %w", err)
 	}
 
 	// Rebuild FTS index: clear and repopulate from airings table.
-	if _, err := tx.Exec(`DELETE FROM airings_fts`); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM airings_fts`); err != nil {
 		return fmt.Errorf("clearing FTS index: %w", err)
 	}
-	if _, err := tx.Exec(`
+	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO airings_fts (channel_id, start_time, title, sub_title, description)
 		SELECT channel_id, start_time, title, COALESCE(sub_title, ''), COALESCE(description, '')
 		FROM airings
@@ -260,10 +260,10 @@ func (d *DB) Refresh(ctx context.Context, tv *xmltv.TV, nextRefresh time.Time) e
 	}
 
 	// Rebuild categories table from distinct values in airings.categories JSON arrays.
-	if _, err := tx.Exec(`DELETE FROM categories`); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM categories`); err != nil {
 		return fmt.Errorf("clearing categories: %w", err)
 	}
-	if _, err := tx.Exec(`
+	if _, err := tx.ExecContext(ctx, `
 		INSERT OR IGNORE INTO categories (name)
 		SELECT DISTINCT value FROM airings, json_each(airings.categories)
 		WHERE value IS NOT NULL AND value != ''

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -13,14 +14,14 @@ import (
 
 // ExecRaw executes a raw SQL statement against the database.
 // Exposed for testing (e.g. verifying FTS5 availability).
-func (d *DB) ExecRaw(query string) (sql.Result, error) {
-	return d.db.Exec(query)
+func (d *DB) ExecRaw(ctx context.Context, query string) (sql.Result, error) {
+	return d.db.ExecContext(ctx, query)
 }
 
 // SearchSimple performs an FTS5 search on the title column only.
 // Returns future airings ordered by relevance then start time.
 // If includeRepeats is false, repeats are excluded.
-func (d *DB) SearchSimple(query string, includeRepeats bool, today bool) ([]model.SearchResult, error) {
+func (d *DB) SearchSimple(ctx context.Context, query string, includeRepeats bool, today bool) ([]model.SearchResult, error) {
 	now := d.clock.Now().UTC().Format(time.RFC3339)
 	q := `
 		SELECT
@@ -50,14 +51,14 @@ func (d *DB) SearchSimple(query string, includeRepeats bool, today bool) ([]mode
 	}
 	q += ` ORDER BY f.rank, a.start_time`
 
-	return d.scanSearchResults(q, args...)
+	return d.scanSearchResults(ctx, q, args...)
 }
 
 // SearchAdvanced performs an FTS5 search on title, sub_title, and description.
 // If categories is non-empty, only airings with at least one matching category are returned.
 // If includePast is false, only future airings are returned.
 // If includeRepeats is false, repeats are excluded.
-func (d *DB) SearchAdvanced(query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error) {
+func (d *DB) SearchAdvanced(ctx context.Context, query string, categories []string, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error) {
 	q := `
 		SELECT
 			a.channel_id, a.start_time, a.stop_time,
@@ -98,13 +99,13 @@ func (d *DB) SearchAdvanced(query string, categories []string, includePast bool,
 	}
 	q += ` ORDER BY f.rank, a.start_time`
 
-	return d.scanSearchResults(q, args...)
+	return d.scanSearchResults(ctx, q, args...)
 }
 
 // SearchBrowse queries the airings table directly (bypassing FTS) using plain SQL filters.
 // Used when q is empty and browse filters (isPremiere, categories) are provided.
 // Results are sorted by start_time ASC; Rank is set to 0 for all results.
-func (d *DB) SearchBrowse(categories []string, isPremiere bool, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error) {
+func (d *DB) SearchBrowse(ctx context.Context, categories []string, isPremiere bool, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error) {
 	q := `
 		SELECT
 			a.channel_id, a.start_time, a.stop_time,
@@ -147,7 +148,7 @@ func (d *DB) SearchBrowse(categories []string, isPremiere bool, includePast bool
 	}
 	q += ` ORDER BY a.start_time`
 
-	return d.scanSearchResults(q, args...)
+	return d.scanSearchResults(ctx, q, args...)
 }
 
 // endOfToday returns midnight tonight in the server's local timezone, formatted as RFC3339 in UTC.
@@ -157,8 +158,8 @@ func (d *DB) endOfToday() string {
 }
 
 // GetCategories returns all distinct categories sorted alphabetically.
-func (d *DB) GetCategories() ([]string, error) {
-	rows, err := d.db.Query(`SELECT name FROM categories ORDER BY name`)
+func (d *DB) GetCategories(ctx context.Context) ([]string, error) {
+	rows, err := d.db.QueryContext(ctx, `SELECT name FROM categories ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("querying categories: %w", err)
 	}
@@ -181,8 +182,8 @@ func (d *DB) GetCategories() ([]string, error) {
 
 // scanSearchResults executes a query and scans results into SearchResult slices.
 // The query must select the standard airing columns plus display_name and rank.
-func (d *DB) scanSearchResults(query string, args ...any) ([]model.SearchResult, error) {
-	rows, err := d.db.Query(query, args...)
+func (d *DB) scanSearchResults(ctx context.Context, query string, args ...any) ([]model.SearchResult, error) {
+	rows, err := d.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying search results: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func runInitialRefresh(db *database.DB, client *http.Client, xmltvURL string, po
 	// Perform initial data fetch only when explicitly requested or when the
 	// database is empty (fresh install). Otherwise schedule the first refresh
 	// at the normal poll interval so restarts don't hammer the XMLTV source.
-	if refreshOnStart || !db.HasData() {
+	if refreshOnStart || !db.HasData(context.Background()) {
 		if err := refresh(db, client, xmltvURL, pollInterval); err != nil {
 			log.Printf("warning: initial fetch failed: %v", err)
 		}


### PR DESCRIPTION
## Summary

- All database SQL methods now accept `context.Context` as first parameter and use `*Context` SQL variants (`QueryContext`, `ExecContext`, `BeginTx`, `PrepareContext`, etc.)
- API handlers pass `r.Context()` to all database calls; startup code (`Open`, `applyMigrations`) uses `context.Background()`
- Test helpers `httpGet`/`httpPost` added to replace bare `http.Get`/`http.Post` calls that also triggered `noctx`
- TDD approach followed: failing tests written first (`TestGetChannels_AcceptsContext`, `TestGetAirings_AcceptsContext`, etc.), then implementation

Closes #163

## Test plan

- [x] All existing tests pass (`make test`)
- [x] Zero `noctx` linter violations remain (`make lint` shows no `noctx` findings)
- [x] New context-acceptance tests added for all public DB methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)