### PR TITLE
Suppress false-positive gosec G304 (file inclusion) in channels.go

### DIFF
--- a/internal/api/channels.go
+++ b/internal/api/channels.go
@@ -29,7 +29,9 @@ func (h *Handler) serveChannelIcon(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := os.ReadFile(localPath)
+	// localPath is retrieved from the database, not constructed from user input,
+	// so this is not a path traversal risk.
+	data, err := os.ReadFile(localPath) //nolint:gosec // G304: path comes from DB, not user input
 	if err != nil {
 		http.Error(w, "failed to read icon", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary

- Adds `//nolint:gosec // G304: path comes from DB, not user input` to the `os.ReadFile(localPath)` call in `serveChannelIcon`
- Adds an explanatory comment above clarifying that `localPath` is retrieved from the database (written by the application itself during XMLTV refresh), not constructed from user-supplied URL input

Closes #167

## Test plan
- [ ] All existing tests pass (`go test ./...`)
- [ ] `golangci-lint run ./internal/api/...` no longer reports G304 on this line

🤖 Generated with [Claude Code](https://claude.com/claude-code)