### PR TITLE
Suppress false-positive cyclop warning in airingFromXMLTV

### DIFF
--- a/internal/database/airings.go
+++ b/internal/database/airings.go
@@ -77,7 +77,10 @@ func (d *DB) GetAirings(ctx context.Context, date time.Time) ([]model.Airing, er
 	return airings, rows.Err()
 }
 
-// airingFromXMLTV maps an xmltv.Programme to an Airing.
+// airingFromXMLTV maps an xmltv.Programme to a model.Airing.
+// Complexity comes from the number of optional XMLTV fields — not reducible without obfuscating the mapping.
+//
+//nolint:cyclop
 func airingFromXMLTV(p xmltv.Programme) model.Airing {
 	a := model.Airing{
 		ChannelID:  p.Channel,


### PR DESCRIPTION
## Summary

- Adds `//nolint:cyclop` to `airingFromXMLTV` in `internal/database/airings.go`
- The function's cyclomatic complexity (17) exceeds the linter threshold (15) but is inherent to field-by-field XMLTV struct mapping — not reducible without obfuscating the code

Closes #171

## Test plan

- [x] All existing Go tests pass (`go test ./...`)
- [x] No functional changes — linter suppression only

🤖 Generated with [Claude Code](https://claude.com/claude-code)