### PR TITLE
fix: resolve gosec G104 (errors unhandled) lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,18 @@ linters:
           - errcheck
         text: "Error return value of `(.*\\.Close|fmt\\.Fprint|fmt\\.Fprintf|.*\\.Write)` is not checked"
 
+      # Suppress G104 (gosec "errors unhandled") in test files for the same
+      # idiomatic patterns already excluded for errcheck:
+      # - .Close() in test teardown
+      # - w.Write() in fake test HTTP handlers
+      # - io.Copy() / resp.Body.Close() when reading test responses
+      # G104 messages do not include the function name, so a path filter is
+      # the correct scope here.
+      - path: "_test\\.go"
+        linters:
+          - gosec
+        text: "G104"
+
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/internal/api/channels.go
+++ b/internal/api/channels.go
@@ -42,5 +42,5 @@ func (h *Handler) serveChannelIcon(w http.ResponseWriter, r *http.Request) {
 		contentType = http.DetectContentType(data)
 	}
 	w.Header().Set("Content-Type", contentType)
-	w.Write(data) //nolint:errcheck // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
+	w.Write(data) //nolint:errcheck,gosec // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
 }

--- a/internal/api/rss.go
+++ b/internal/api/rss.go
@@ -96,7 +96,7 @@ func (h *Handler) writeSearchRSS(w http.ResponseWriter, r *http.Request, query, 
 	}
 
 	w.Header().Set("Content-Type", "application/rss+xml; charset=utf-8")
-	w.Write([]byte(xml.Header)) //nolint:errcheck // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
+	w.Write([]byte(xml.Header)) //nolint:errcheck,gosec // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
 	if err := xml.NewEncoder(w).Encode(rss); err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}

--- a/internal/database/airings.go
+++ b/internal/database/airings.go
@@ -68,7 +68,7 @@ func (d *DB) GetAirings(ctx context.Context, date time.Time) ([]model.Airing, er
 
 		a.Start, _ = time.Parse(time.RFC3339, startStr)
 		a.Stop, _ = time.Parse(time.RFC3339, stopStr)
-		json.Unmarshal([]byte(catsJSON), &a.Categories) //nolint:errcheck // malformed JSON yields nil slice, which is acceptable
+		json.Unmarshal([]byte(catsJSON), &a.Categories) //nolint:errcheck,gosec // malformed JSON yields nil slice, which is acceptable
 		a.IsRepeat = isRepeat == 1
 		a.IsPremiere = isPremiere == 1
 

--- a/internal/database/nownext.go
+++ b/internal/database/nownext.go
@@ -128,7 +128,7 @@ func scanAiring(rows *sql.Rows) (*model.Airing, error) {
 
 	a.Start, _ = time.Parse(time.RFC3339, startStr)
 	a.Stop, _ = time.Parse(time.RFC3339, stopStr)
-	json.Unmarshal([]byte(catsJSON), &a.Categories) //nolint:errcheck
+	json.Unmarshal([]byte(catsJSON), &a.Categories) //nolint:errcheck,gosec
 	a.IsRepeat = isRepeat == 1
 	a.IsPremiere = isPremiere == 1
 	return &a, nil


### PR DESCRIPTION
## Summary
- Extends existing `//nolint:errcheck` directives to `//nolint:errcheck,gosec` on 4 production lines where G104 fires alongside already-suppressed errcheck violations
- Adds a scoped G104 exclusion rule for `_test.go` files in `.golangci.yml`, covering the same idiomatic test patterns (`.Close()` teardown, `w.Write()` in fake handlers, `io.Copy()` response reading) already excluded for `errcheck`

Closes #206

## Test plan
- [x] `golangci-lint run` reports zero G104 errors
- [x] No broad/blanket gosec exclusions added — Group 1 fixes are line-level; Group 2 exclusion is scoped to `_test.go` files only
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)