### PR TITLE
fix: resolve ESLint eqeqeq and no-for-loop errors in guide.js

### DIFF
--- a/web/js/pages/guide.js
+++ b/web/js/pages/guide.js
@@ -38,9 +38,9 @@ function orderedVisibleChannels() {
     const favs    = visible.filter(ch =>  isFavourite(ch.id));
     const rest    = visible.filter(ch => !isFavourite(ch.id));
     rest.sort((a, b) => {
-        if (a.lcn != null && b.lcn != null) return a.lcn - b.lcn;
-        if (a.lcn != null) return -1;
-        if (b.lcn != null) return  1;
+        if (a.lcn !== null && b.lcn !== null) return a.lcn - b.lcn;
+        if (a.lcn !== null) return -1;
+        if (b.lcn !== null) return  1;
         return 0; // both absent — preserve source order
     });
     return [...favs, ...rest];
@@ -75,8 +75,7 @@ export function renderGuide() {
     inner.style.width  = CONFIG.TOTAL_WIDTH + 'px';
     inner.style.height = totalHeight + 'px';
 
-    for (let i = 0; i < channels.length; i++) {
-        const ch  = channels[i];
+    for (const [i, ch] of channels.entries()) {
         const top = i * CONFIG.ROW_HEIGHT;
 
         // Channel label
@@ -96,7 +95,7 @@ export function renderGuide() {
             img.onerror   = () => img.remove();
             topRow.appendChild(img);
         }
-        if (ch.lcn != null) {
+        if (ch.lcn !== null) {
             const lcnEl = document.createElement('span');
             lcnEl.className   = 'channel-lcn';
             lcnEl.textContent = ch.lcn;


### PR DESCRIPTION
## Summary
- Replace 5 loose equality `!=` operators with strict `!==` in `lcn` comparisons (eqeqeq rule)
- Replace index-based `for` loop with `for...of` using `.entries()` to retain index for top-position calculation (unicorn/no-for-loop rule)

## Test plan
- [x] `npx eslint web/js/pages/guide.js` reports no errors
- [ ] Guide still renders correctly (channels visible, correctly ordered, positioned)

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)