### PR TITLE
refactor: reduce renderFavouriteResults cognitive complexity in favourites.js

### DIFF
--- a/e2e/tests/favourites.spec.ts
+++ b/e2e/tests/favourites.spec.ts
@@ -66,6 +66,21 @@ test.describe('Favourites tab — Single saved search', () => {
     await expect(fav.noResultsMessageInGroup('Evening News')).toContainText('No upcoming airings');
   });
 
+  test('shows error message when search API fails', async ({ page, seedLocalStorage }) => {
+    await seedLocalStorage('tvguide-favourites', SIMPLE_FAV_SEED);
+
+    await page.route('/api/search**', (route) => {
+      route.fulfill({ status: 500, body: 'Internal Server Error' });
+    });
+
+    const fav = new FavouritesPage(page);
+    await fav.goto();
+    await fav.waitForSearchesComplete();
+
+    await expect(fav.noResultsMessageInGroup('Evening News')).toBeVisible();
+    await expect(fav.noResultsMessageInGroup('Evening News')).toContainText('Search failed:');
+  });
+
   test('airing row shows channel name and time', async ({ page, seedLocalStorage }) => {
     await seedLocalStorage('tvguide-favourites', SIMPLE_FAV_SEED);
 

--- a/web/js/pages/favourites.js
+++ b/web/js/pages/favourites.js
@@ -70,6 +70,111 @@ async function executeFavouriteSearches() {
     renderFavouriteResults();
 }
 
+function buildFavGroupHeader(fav) {
+    const header = document.createElement('div');
+    header.className = 'fav-group-header';
+
+    const star = document.createElement('span');
+    star.className = 'fav-group-star';
+    star.textContent = '\u2605'; // ★
+    header.appendChild(star);
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'fav-group-name';
+    nameEl.textContent = '"' + fav.name + '"';
+    header.appendChild(nameEl);
+
+    const actions = document.createElement('div');
+    actions.className = 'fav-group-actions';
+
+    const editBtn = document.createElement('button');
+    editBtn.className = 'fav-action-btn';
+    editBtn.textContent = 'Edit';
+    editBtn.title = 'Edit this search';
+    editBtn.addEventListener('click', () => editFavouriteSearch(fav.id));
+    actions.appendChild(editBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'fav-action-btn fav-delete-btn';
+    deleteBtn.textContent = '\u2715'; // ✕
+    deleteBtn.title = 'Remove favourite';
+    deleteBtn.addEventListener('click', () => {
+        if (confirm('Remove "' + fav.name + '" from favourites?')) {
+            removeFavouriteSearch(fav.id);
+            renderFavouritesPage();
+        }
+    });
+    actions.appendChild(deleteBtn);
+
+    header.appendChild(actions);
+    return header;
+}
+
+function buildAiringRow(airing, title) {
+    const airingEl = document.createElement('div');
+    airingEl.className = 'fav-airing';
+    airingEl.addEventListener('click', () => openSearchAiringModal(airing, title));
+
+    const channelEl = document.createElement('span');
+    channelEl.className = 'fav-airing-channel';
+    channelEl.textContent = airing.channelName || airing.channelId;
+    airingEl.appendChild(channelEl);
+
+    const timeEl = document.createElement('span');
+    timeEl.className = 'fav-airing-time';
+    timeEl.textContent = formatSearchDate(new Date(airing.startTime));
+    airingEl.appendChild(timeEl);
+
+    return airingEl;
+}
+
+function buildFavGroupResults(fav) {
+    const results = state.favouriteResults[fav.id];
+
+    if (results === undefined) {
+        const loadingEl = document.createElement('div');
+        loadingEl.className = 'fav-loading';
+        loadingEl.innerHTML = '<div class="loading-spinner fav-spinner"></div>';
+        return loadingEl;
+    }
+
+    if (results && results.error) {
+        const errorEl = document.createElement('div');
+        errorEl.className = 'fav-no-results';
+        errorEl.textContent = `Search failed: ${results.error}`;
+        return errorEl;
+    }
+
+    const filtered = results
+        .map(group => ({ title: group.title, airings: group.airings.filter(a => !isHidden(a.channelId)) }))
+        .filter(group => group.airings.length > 0);
+
+    if (filtered.length === 0) {
+        const noResults = document.createElement('div');
+        noResults.className = 'fav-no-results';
+        noResults.textContent = 'No upcoming airings';
+        return noResults;
+    }
+
+    const fragment = document.createDocumentFragment();
+    for (const titleGroup of filtered) {
+        const titleEl = document.createElement('div');
+        titleEl.className = 'fav-title-group';
+
+        const titleHeader = document.createElement('div');
+        titleHeader.className = 'fav-title-name';
+        titleHeader.textContent = titleGroup.title;
+        titleEl.appendChild(titleHeader);
+
+        for (const airing of titleGroup.airings) {
+            titleEl.appendChild(buildAiringRow(airing, titleGroup.title));
+        }
+
+        fragment.appendChild(titleEl);
+    }
+    return fragment;
+}
+
 function renderFavouriteResults() {
     const list = document.getElementById('favouritesList');
     list.innerHTML = '';
@@ -77,108 +182,8 @@ function renderFavouriteResults() {
     for (const fav of state.favouriteSearches) {
         const groupEl = document.createElement('div');
         groupEl.className = 'fav-group';
-
-        // Header: star + name + edit + delete
-        const header = document.createElement('div');
-        header.className = 'fav-group-header';
-
-        const star = document.createElement('span');
-        star.className = 'fav-group-star';
-        star.textContent = '\u2605'; // ★
-        header.appendChild(star);
-
-        const nameEl = document.createElement('span');
-        nameEl.className = 'fav-group-name';
-        nameEl.textContent = '"' + fav.name + '"';
-        header.appendChild(nameEl);
-
-        const actions = document.createElement('div');
-        actions.className = 'fav-group-actions';
-
-        const editBtn = document.createElement('button');
-        editBtn.className = 'fav-action-btn';
-        editBtn.textContent = 'Edit';
-        editBtn.title = 'Edit this search';
-        editBtn.addEventListener('click', () => editFavouriteSearch(fav.id));
-        actions.appendChild(editBtn);
-
-        const deleteBtn = document.createElement('button');
-        deleteBtn.className = 'fav-action-btn fav-delete-btn';
-        deleteBtn.textContent = '\u2715'; // ✕
-        deleteBtn.title = 'Remove favourite';
-        deleteBtn.addEventListener('click', () => {
-            if (confirm('Remove "' + fav.name + '" from favourites?')) {
-                removeFavouriteSearch(fav.id);
-                renderFavouritesPage();
-            }
-        });
-        actions.appendChild(deleteBtn);
-
-        header.appendChild(actions);
-        groupEl.appendChild(header);
-
-        // Results
-        const results = state.favouriteResults[fav.id];
-        if (results === undefined) {
-            // Still loading
-            const loadingEl = document.createElement('div');
-            loadingEl.className = 'fav-loading';
-            loadingEl.innerHTML = '<div class="loading-spinner fav-spinner"></div>';
-            groupEl.appendChild(loadingEl);
-        } else if (results && results.error) {
-            // Failed
-            const errorEl = document.createElement('div');
-            errorEl.className = 'fav-no-results';
-            errorEl.textContent = `Search failed: ${results.error}`;
-            groupEl.appendChild(errorEl);
-        } else {
-            // Filter hidden channels
-            const filtered = [];
-            for (const group of results) {
-                const visibleAirings = group.airings.filter(a => !isHidden(a.channelId));
-                if (visibleAirings.length > 0) {
-                    filtered.push({ title: group.title, airings: visibleAirings });
-                }
-            }
-
-            if (filtered.length === 0) {
-                const noResults = document.createElement('div');
-                noResults.className = 'fav-no-results';
-                noResults.textContent = 'No upcoming airings';
-                groupEl.appendChild(noResults);
-            } else {
-                for (const titleGroup of filtered) {
-                    const titleEl = document.createElement('div');
-                    titleEl.className = 'fav-title-group';
-
-                    const titleHeader = document.createElement('div');
-                    titleHeader.className = 'fav-title-name';
-                    titleHeader.textContent = titleGroup.title;
-                    titleEl.appendChild(titleHeader);
-
-                    for (const airing of titleGroup.airings) {
-                        const airingEl = document.createElement('div');
-                        airingEl.className = 'fav-airing';
-                        airingEl.addEventListener('click', () => openSearchAiringModal(airing, titleGroup.title));
-
-                        const channelEl = document.createElement('span');
-                        channelEl.className = 'fav-airing-channel';
-                        channelEl.textContent = airing.channelName || airing.channelId;
-                        airingEl.appendChild(channelEl);
-
-                        const timeEl = document.createElement('span');
-                        timeEl.className = 'fav-airing-time';
-                        timeEl.textContent = formatSearchDate(new Date(airing.startTime));
-                        airingEl.appendChild(timeEl);
-
-                        titleEl.appendChild(airingEl);
-                    }
-
-                    groupEl.appendChild(titleEl);
-                }
-            }
-        }
-
+        groupEl.appendChild(buildFavGroupHeader(fav));
+        groupEl.appendChild(buildFavGroupResults(fav));
         list.appendChild(groupEl);
     }
 }


### PR DESCRIPTION
## Summary
- Extracted `buildFavGroupHeader`, `buildAiringRow`, and `buildFavGroupResults` helpers from `renderFavouriteResults` to reduce cognitive complexity from 26 to below 20
- Added missing UI test for the error state (API returns 500 → "Search failed:" message shown)

## Test plan
- [ ] All 136 UI tests pass (`make test-ui`)
- [ ] `npx eslint web/js/pages/favourites.js` reports no warnings
- [ ] Favourites page renders correctly for loading, error, empty, and results states
- [ ] Edit and delete buttons function correctly
- [ ] Airing rows open the detail modal on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)