### PR TITLE
fix: correct nosemgrep comment format in rss.go and channels.go

### DIFF
--- a/internal/api/channels.go
+++ b/internal/api/channels.go
@@ -42,5 +42,6 @@ func (h *Handler) serveChannelIcon(w http.ResponseWriter, r *http.Request) {
 		contentType = http.DetectContentType(data)
 	}
 	w.Header().Set("Content-Type", contentType)
-	w.Write(data) //nolint:errcheck,gosec // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
+	// nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
+	w.Write(data) //nolint:errcheck,gosec
 }

--- a/internal/api/rss.go
+++ b/internal/api/rss.go
@@ -96,7 +96,8 @@ func (h *Handler) writeSearchRSS(w http.ResponseWriter, r *http.Request, query, 
 	}
 
 	w.Header().Set("Content-Type", "application/rss+xml; charset=utf-8")
-	w.Write([]byte(xml.Header)) //nolint:errcheck,gosec // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
+	// nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
+	w.Write([]byte(xml.Header)) //nolint:errcheck,gosec
 	if err := xml.NewEncoder(w).Encode(rss); err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}


### PR DESCRIPTION
## Summary

- Moves `nosemgrep` directives from being embedded inside `//nolint:...` comments to standalone comments on the preceding line
- Affects `w.Write([]byte(xml.Header))` in `rss.go` and `w.Write(data)` in `channels.go`

## Background

After commit 4f90cdb extended `//nolint:errcheck` to `//nolint:errcheck,gosec`, two semgrep findings reappeared for the `no-direct-write-to-responsewriter` rule. Both are false positives — the writes involve a constant XML header string and binary image data from the local database, not user-controlled input.

The root cause is that in Go there is only one `//` comment per line. `//nolint:errcheck,gosec // nosemgrep: rule-id` is a single comment whose text begins with `nolint:`, not `nosemgrep`. Semgrep requires the directive to begin the comment, so the suppression was not being recognised.

## Fix

Semgrep explicitly supports `nosemgrep` on the **preceding line**; golangci-lint requires `nolint` on the **same line** as the code. Splitting them onto separate lines satisfies both tools cleanly.

## Test plan

- [ ] Verify semgrep CI job passes with no findings for `rss.go` and `channels.go`
- [ ] Verify golangci-lint CI job still passes (no new errcheck/gosec violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)