### PR TITLE
refactor: have newIntegrationServer delegate to populateDB

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -101,14 +101,7 @@ func newIntegrationServer(t *testing.T, xmltvURL string) *httptest.Server {
 		t.Fatalf("Open: %v", err)
 	}
 
-	tv, err := xmltv.Fetch(context.Background(), &http.Client{}, xmltvURL+"/xmltv")
-	if err != nil {
-		t.Fatalf("Fetch: %v", err)
-	}
-
-	if err := db.Refresh(context.Background(), tv, time.Now().Add(time.Hour)); err != nil {
-		t.Fatalf("Refresh: %v", err)
-	}
+	populateDB(t, db, &http.Client{}, xmltvURL+"/xmltv")
 
 	mux := http.NewServeMux()
 	handler := api.New(db, 0)


### PR DESCRIPTION
## Summary
- Replaces duplicate inline `xmltv.Fetch` + `db.Refresh` logic in `newIntegrationServer` with a call to the existing `populateDB` helper
- Resolves golangci-lint `dupl` warning flagged in #226

## Test plan
- [ ] All existing integration tests pass (`go test ./...`)

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)