### PR TITLE
fix: resolve 6 open code-scanning alerts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,6 +82,21 @@ linters:
           - gosec
         text: "G104"
 
+      # Suppress G306 (gosec "file permissions too permissive") in test files.
+      # Test fixtures written with os.WriteFile(..., 0644) have no security
+      # implications — the files are temporary and scoped to t.TempDir().
+      - path: "_test\\.go"
+        linters:
+          - gosec
+        text: "G306"
+
+      # Allow high cognitive complexity in test functions. Tests legitimately
+      # accumulate complexity through subtests, assertion sequences, and
+      # error-check branches — the metric does not meaningfully apply here.
+      - path: "_test\\.go"
+        linters:
+          - gocognit
+
       # Suppress gosec findings on w.Write() calls to http.ResponseWriter in
       # production API handlers. G104 (errors unhandled) and G705 (XSS taint)
       # are both false positives: the data is either a constant or loaded from

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
 )
 
+// nowNextFixedNow is the anchor time used by newNowNextServer and its tests.
+var nowNextFixedNow = time.Date(2025, 6, 10, 14, 0, 0, 0, time.UTC)
+
 func TestMain(m *testing.M) {
 	time.Local = time.UTC
 	os.Exit(m.Run())
@@ -1979,9 +1982,9 @@ func TestSearchRSS_LastBuildDate(t *testing.T) {
 //   - ch1 (lcn=1): Show A airing now (13:30–14:30), Show B coming next (14:30–15:00)
 //   - ch2 (lcn=2): no current airing, Show C next (15:00–16:00)
 //   - ch3 (no lcn): no airings at all
-func newNowNextServer(t *testing.T) (*httptest.Server, time.Time) {
+func newNowNextServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	fixedNow := time.Date(2025, 6, 10, 14, 0, 0, 0, time.UTC)
+	fixedNow := nowNextFixedNow
 
 	dir := t.TempDir()
 	db, err := database.Open(
@@ -2034,11 +2037,11 @@ func newNowNextServer(t *testing.T) (*httptest.Server, time.Time) {
 		srv.Close()
 		db.Close()
 	})
-	return srv, fixedNow
+	return srv
 }
 
 func TestGetNowNext_API_StatusOK(t *testing.T) {
-	srv, _ := newNowNextServer(t)
+	srv := newNowNextServer(t)
 	resp, err := httpGet(t, srv.URL+"/api/explore/now-next")
 	if err != nil {
 		t.Fatalf("GET /api/explore/now-next: %v", err)
@@ -2050,7 +2053,8 @@ func TestGetNowNext_API_StatusOK(t *testing.T) {
 }
 
 func TestGetNowNext_API_ResponseShape(t *testing.T) {
-	srv, fixedNow := newNowNextServer(t)
+	srv := newNowNextServer(t)
+	fixedNow := nowNextFixedNow
 	resp, err := httpGet(t, srv.URL+"/api/explore/now-next")
 	if err != nil {
 		t.Fatalf("GET /api/explore/now-next: %v", err)

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -30,7 +30,7 @@ type searchResultGroup struct {
 	Airings []searchResultAiring `json:"airings"`
 }
 
-func (h *Handler) getSearch(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) getSearch(w http.ResponseWriter, r *http.Request) { //nolint:cyclop
 	q := strings.TrimSpace(r.URL.Query().Get("q"))
 	isPremiere := r.URL.Query().Get("is_premiere") == "true"
 


### PR DESCRIPTION
## Summary

- **#520, #225, #223 (`gocognit` in tests)**: Added `.golangci.yml` exclusion for `gocognit` in `_test.go` files — false positives; test functions legitimately accumulate complexity through subtests and assertion sequences (mirrors the existing `cyclop` test exclusion)
- **#262 (`gosec G306` in test)**: Added `.golangci.yml` exclusion for `G306` in `_test.go` files — `os.WriteFile(..., 0644)` on `t.TempDir()` fixtures has no security implications
- **#439 (`cyclop` on `getSearch`)**: Added `//nolint:cyclop` — function is only 1 over the limit and is already well-structured; complexity is inherent to multi-modal query-param routing
- **#427 (`unparam` on `newNowNextServer`)**: Extracted `nowNextFixedNow` as a package-level var and removed the redundant `time.Time` return value (was always the same constant); updated both callers

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] No regressions in `internal/api`, `internal/database`, `internal/images`, `internal/xmltv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)