### PR TITLE
fix: make /tmp world-writable so nobody user can write SQLite temp files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o tvguide .
 # SQLite FTS5 segment operations require a writable temp directory even when
 # PRAGMA temp_store=MEMORY is set; without /tmp the second+ refresh fails
 # with SQLITE_IOERR_WRITE (6410). See GitHub issue #87.
-RUN mkdir /scratch_tmp
+RUN mkdir /scratch_tmp && chmod 1777 /scratch_tmp
 
 # ── Runtime stage ─────────────────────────────────────────────────
 # scratch: zero OS overhead (~0 MB vs ~8 MB for alpine).


### PR DESCRIPTION
## Summary
- The scratch image's `/tmp` was created with default root permissions (`755`), preventing the `nobody` user (UID 65534) from writing temp files
- SQLite FTS5 requires a writable temp directory for segment merge operations during the 2nd+ refresh, even with `PRAGMA temp_store=MEMORY`
- Fix: add `chmod 1777` to the `mkdir` so `/tmp` has standard world-writable permissions

Fixes #231

## Test plan
- [ ] Build and run the Docker container
- [ ] Verify the initial refresh succeeds
- [ ] Wait for (or trigger) a scheduled refresh and confirm it succeeds without the `disk I/O error (6410)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)