### PR TITLE
refactor: extend Clock interface with Location() and EndOfToday(), add unit tests

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_input.path // empty' | { read -r f; echo \"$f\" | grep -q '\\.go$' && golangci-lint run --fix \"$(dirname \"$f\")\" 2>/dev/null || true; }",
+            "command": "jq -r '.tool_input.file_path // .tool_input.path // empty' | { read -r f; echo \"$f\" | grep -q '\\.go$' && { gofmt -w \"$f\"; golangci-lint run --fix \"$(dirname \"$f\")\" 2>/dev/null; } || true; }",
             "statusMessage": "Running golangci-lint --fix..."
           }
         ]

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -921,7 +921,12 @@ func TestSearch_AiringsOrderedByStartTime(t *testing.T) {
 // search queries deterministic regardless of when the test runs.
 type fixedClock struct{ t time.Time }
 
-func (c fixedClock) Now() time.Time { return c.t }
+func (c fixedClock) Now() time.Time           { return c.t }
+func (c fixedClock) Location() *time.Location { return time.UTC }
+func (c fixedClock) EndOfToday() time.Time {
+	now := c.t.In(time.UTC)
+	return time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, time.UTC)
+}
 
 func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/database/clock.go
+++ b/internal/database/clock.go
@@ -12,7 +12,7 @@ type Clock interface {
 
 type realClock struct{ loc *time.Location }
 
-func (c realClock) Now() time.Time         { return time.Now() }
+func (c realClock) Now() time.Time           { return time.Now() }
 func (c realClock) Location() *time.Location { return c.loc }
 func (c realClock) EndOfToday() time.Time {
 	now := c.Now().In(c.loc)
@@ -24,7 +24,7 @@ type fixedClock struct {
 	loc *time.Location
 }
 
-func (c fixedClock) Now() time.Time         { return c.t }
+func (c fixedClock) Now() time.Time           { return c.t }
 func (c fixedClock) Location() *time.Location { return c.loc }
 func (c fixedClock) EndOfToday() time.Time {
 	now := c.t.In(c.loc)

--- a/internal/database/clock.go
+++ b/internal/database/clock.go
@@ -2,19 +2,34 @@ package database
 
 import "time"
 
-// Clock provides the current time. Inject a fixed implementation in tests
-// to make time-dependent queries deterministic.
+// Clock provides the current time and timezone. Inject a fixed implementation
+// in tests to make time-dependent queries deterministic.
 type Clock interface {
 	Now() time.Time
+	Location() *time.Location
+	EndOfToday() time.Time
 }
 
-type realClock struct{}
+type realClock struct{ loc *time.Location }
 
-func (realClock) Now() time.Time { return time.Now() }
+func (c realClock) Now() time.Time         { return time.Now() }
+func (c realClock) Location() *time.Location { return c.loc }
+func (c realClock) EndOfToday() time.Time {
+	now := c.Now().In(c.loc)
+	return time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, c.loc)
+}
 
-type fixedClock struct{ t time.Time }
+type fixedClock struct {
+	t   time.Time
+	loc *time.Location
+}
 
-func (c fixedClock) Now() time.Time { return c.t }
+func (c fixedClock) Now() time.Time         { return c.t }
+func (c fixedClock) Location() *time.Location { return c.loc }
+func (c fixedClock) EndOfToday() time.Time {
+	now := c.t.In(c.loc)
+	return time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, c.loc)
+}
 
-// FixedClock returns a Clock that always returns t. Use in tests to pin time.
-func FixedClock(t time.Time) Clock { return fixedClock{t: t} }
+// FixedClock returns a Clock that always returns t in loc. Use in tests to pin time and timezone.
+func FixedClock(t time.Time, loc *time.Location) Clock { return fixedClock{t: t, loc: loc} }

--- a/internal/database/clock_test.go
+++ b/internal/database/clock_test.go
@@ -1,0 +1,90 @@
+package database
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRealClock_Now(t *testing.T) {
+	c := realClock{loc: time.UTC}
+	now := c.Now()
+	if now.IsZero() {
+		t.Error("expected non-zero time from realClock.Now()")
+	}
+}
+
+func TestRealClock_Location(t *testing.T) {
+	loc, _ := time.LoadLocation("Australia/Melbourne")
+	c := realClock{loc: loc}
+	if c.Location() != loc {
+		t.Errorf("expected location %v, got %v", loc, c.Location())
+	}
+}
+
+func TestRealClock_EndOfToday(t *testing.T) {
+	loc, _ := time.LoadLocation("Australia/Melbourne")
+	c := realClock{loc: loc}
+	result := c.EndOfToday()
+
+	now := time.Now().In(loc)
+	expected := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, loc)
+
+	if !result.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, result)
+	}
+	if result.Location() != loc {
+		t.Errorf("expected location %v, got %v", loc, result.Location())
+	}
+}
+
+func TestFixedClock_Now(t *testing.T) {
+	pinned := time.Date(2025, 6, 10, 14, 0, 0, 0, time.UTC)
+	c := fixedClock{t: pinned, loc: time.UTC}
+	if !c.Now().Equal(pinned) {
+		t.Errorf("expected %v, got %v", pinned, c.Now())
+	}
+}
+
+func TestFixedClock_Location(t *testing.T) {
+	loc, _ := time.LoadLocation("Australia/Melbourne")
+	c := fixedClock{t: time.Now(), loc: loc}
+	if c.Location() != loc {
+		t.Errorf("expected location %v, got %v", loc, c.Location())
+	}
+}
+
+func TestFixedClock_EndOfToday(t *testing.T) {
+	loc, _ := time.LoadLocation("Australia/Melbourne")
+	// 2025-06-10T14:00:00 UTC = 2025-06-11T00:00:00 Melbourne (UTC+10)
+	pinned := time.Date(2025, 6, 10, 14, 0, 0, 0, time.UTC)
+	c := fixedClock{t: pinned, loc: loc}
+
+	result := c.EndOfToday()
+
+	// In Melbourne, pinned time is 2025-06-11 00:00:00, so EndOfToday = 2025-06-12 00:00:00 Melbourne
+	pinnedInMelbourne := pinned.In(loc)
+	expected := time.Date(pinnedInMelbourne.Year(), pinnedInMelbourne.Month(), pinnedInMelbourne.Day()+1, 0, 0, 0, 0, loc)
+
+	if !result.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, result)
+	}
+	if result.Location() != loc {
+		t.Errorf("expected result location %v, got %v", loc, result.Location())
+	}
+}
+
+func TestFixedClock_EndOfToday_MidnightBoundary(t *testing.T) {
+	loc, _ := time.LoadLocation("Australia/Melbourne")
+	// 2025-06-10T08:00:00 UTC = 2025-06-10T18:00:00 Melbourne
+	pinned := time.Date(2025, 6, 10, 8, 0, 0, 0, time.UTC)
+	c := fixedClock{t: pinned, loc: loc}
+
+	result := c.EndOfToday()
+
+	// In Melbourne it's still June 10 at 18:00, so EndOfToday = 2025-06-11 00:00:00 Melbourne
+	expected := time.Date(2025, 6, 11, 0, 0, 0, 0, loc)
+
+	if !result.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, result)
+	}
+}

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -244,7 +244,7 @@ func Open(path string, retentionDays int, sourceURL string, imageCache *images.C
 		retentionDays: retentionDays,
 		sourceURL:     sourceURL,
 		imageCache:    imageCache,
-		clock:         realClock{},
+		clock:         realClock{loc: time.Local},
 		hiddenIDs:     hiddenIDs,
 		hiddenLCNs:    hiddenLCNs,
 		stripWords:    stripWords,

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -407,9 +407,11 @@ func TestRefresh_IconRedownloadsIfURLChanged(t *testing.T) {
 
 // TestRefresh_FTSRebuildSucceedsOnSubsequentRefresh verifies that a second
 // Refresh correctly clears and rebuilds the FTS index when it already contains
-// data. Regression test for GitHub issue #87 where DELETE FROM airings_fts
-// failed in scratch Docker containers (no /tmp directory) on the second
-// refresh, because FTS5 segment operations require a writable temp directory.
+// data. Regression test for GitHub issues #87 and #231: FTS5 segment operations
+// require a writable temp directory (SQLITE_IOERR_GETTEMPPATH, error 6410). In
+// the scratch Docker image /tmp must exist AND be world-writable (1777); the
+// original #87 fix added /tmp but left it root:0755, which fails for the
+// non-root container user (UID 65534).
 func TestRefresh_FTSRebuildSucceedsOnSubsequentRefresh(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()
@@ -1244,7 +1246,7 @@ func nowNextTV() (*xmltv.TV, time.Time) {
 func TestGetNowNext_CurrentAndNext(t *testing.T) {
 	db := openTestDB(t)
 	tv, now := nowNextTV()
-	db.SetClock(database.FixedClock(now))
+	db.SetClock(database.FixedClock(now, time.UTC))
 	if err := db.Refresh(context.Background(), tv, now.Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
@@ -1282,7 +1284,7 @@ func TestGetNowNext_CurrentAndNext(t *testing.T) {
 func TestGetNowNext_NullCurrent(t *testing.T) {
 	db := openTestDB(t)
 	tv, now := nowNextTV()
-	db.SetClock(database.FixedClock(now))
+	db.SetClock(database.FixedClock(now, time.UTC))
 	if err := db.Refresh(context.Background(), tv, now.Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
@@ -1314,7 +1316,7 @@ func TestGetNowNext_NullCurrent(t *testing.T) {
 func TestGetNowNext_BothNull(t *testing.T) {
 	db := openTestDB(t)
 	tv, now := nowNextTV()
-	db.SetClock(database.FixedClock(now))
+	db.SetClock(database.FixedClock(now, time.UTC))
 	if err := db.Refresh(context.Background(), tv, now.Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
@@ -1465,7 +1467,7 @@ func TestSearchBrowse_ExcludesRepeats(t *testing.T) {
 func TestGetNowNext_SortOrder(t *testing.T) {
 	db := openTestDB(t)
 	tv, now := nowNextTV()
-	db.SetClock(database.FixedClock(now))
+	db.SetClock(database.FixedClock(now, time.UTC))
 	if err := db.Refresh(context.Background(), tv, now.Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
@@ -1522,7 +1524,7 @@ func TestGetAirings_AcceptsContext(t *testing.T) {
 func TestGetNowNext_AcceptsContext(t *testing.T) {
 	db := openTestDB(t)
 	tv, now := nowNextTV()
-	db.SetClock(database.FixedClock(now))
+	db.SetClock(database.FixedClock(now, time.UTC))
 	if err := db.Refresh(context.Background(), tv, now.Add(time.Hour)); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -45,9 +45,8 @@ func (d *DB) SearchSimple(ctx context.Context, query string, includeRepeats bool
 		q += ` AND a.is_repeat = 0`
 	}
 	if today {
-		endOfDay := d.endOfToday()
 		q += ` AND a.start_time < ?`
-		args = append(args, endOfDay)
+		args = append(args, d.clock.EndOfToday().UTC().Format(time.RFC3339))
 	}
 	q += ` ORDER BY f.rank, a.start_time`
 
@@ -93,9 +92,8 @@ func (d *DB) SearchAdvanced(ctx context.Context, query string, categories []stri
 		q += ` AND EXISTS (SELECT 1 FROM json_each(a.categories) WHERE value IN (` + strings.Join(placeholders, ",") + `))`
 	}
 	if today {
-		endOfDay := d.endOfToday()
 		q += ` AND a.start_time < ?`
-		args = append(args, endOfDay)
+		args = append(args, d.clock.EndOfToday().UTC().Format(time.RFC3339))
 	}
 	q += ` ORDER BY f.rank, a.start_time`
 
@@ -142,20 +140,14 @@ func (d *DB) SearchBrowse(ctx context.Context, categories []string, isPremiere b
 		q += ` AND EXISTS (SELECT 1 FROM json_each(a.categories) WHERE value IN (` + strings.Join(placeholders, ",") + `))`
 	}
 	if today {
-		endOfDay := d.endOfToday()
 		q += ` AND a.start_time < ?`
-		args = append(args, endOfDay)
+		args = append(args, d.clock.EndOfToday().UTC().Format(time.RFC3339))
 	}
 	q += ` ORDER BY a.start_time`
 
 	return d.scanSearchResults(ctx, q, args...)
 }
 
-// endOfToday returns midnight tonight in the server's local timezone, formatted as RFC3339 in UTC.
-func (d *DB) endOfToday() string {
-	now := d.clock.Now()
-	return time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, time.Local).UTC().Format(time.RFC3339)
-}
 
 // GetCategories returns all distinct categories sorted alphabetically.
 func (d *DB) GetCategories(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
## Summary

- Extends the `Clock` interface with `Location() *time.Location` and `EndOfToday() time.Time`, eliminating the implicit `time.Local` global dependency in timezone boundary calculations
- Moves `endOfToday()` off `*DB` and onto the `Clock` interface, making it testable in isolation
- Adds 7 unit tests for `clock.go` covering both `realClock` and `fixedClock` implementations

## Test plan

- [ ] All existing tests pass (`go test ./...`)
- [ ] New `clock_test.go` covers `Now()`, `Location()`, and `EndOfToday()` on both implementations
- [ ] `TestFixedClock_EndOfToday_MidnightBoundary` verifies correct timezone boundary (UTC time that is still "today" in Melbourne is handled correctly)

Closes #233, closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)