### PR TITLE
feat: add modal on click in Now/Next explore view

### DIFF
--- a/e2e/tests/explore.spec.ts
+++ b/e2e/tests/explore.spec.ts
@@ -390,6 +390,50 @@ test.describe('Explore tab — Now/Next mode', () => {
 
     await expect(explore.errorMessage).toBeVisible();
   });
+
+  test('clicking a current show opens the programme modal', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    // ch1 current: "News at Noon"
+    const currentDiv = explore.nowNextRow('ch1').locator('.now-next-current');
+    await currentDiv.click();
+
+    await expect(explore.modal).toBeVisible();
+    await expect(explore.modalTitle).toHaveText('News at Noon');
+  });
+
+  test('clicking a next show opens the programme modal', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    // ch1 next: "Afternoon Show"
+    const nextDiv = explore.nowNextRow('ch1').locator('.now-next-next');
+    await nextDiv.click();
+
+    await expect(explore.modal).toBeVisible();
+    await expect(explore.modalTitle).toHaveText('Afternoon Show');
+  });
+
+  test('current show div has pointer cursor', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    const cursor = await explore.nowNextRow('ch1').locator('.now-next-current').evaluate(
+      (el) => (el as HTMLElement).style.cursor
+    );
+    expect(cursor).toBe('pointer');
+  });
+
+  test('next show div has pointer cursor', async ({ page }) => {
+    const explore = new ExplorePage(page);
+    await explore.goto();
+
+    const cursor = await explore.nowNextRow('ch1').locator('.now-next-next').evaluate(
+      (el) => (el as HTMLElement).style.cursor
+    );
+    expect(cursor).toBe('pointer');
+  });
 });
 
 test.describe('Explore tab — Premieres mode', () => {

--- a/web/js/pages/explore.js
+++ b/web/js/pages/explore.js
@@ -1,6 +1,6 @@
 import { formatTime, formatSearchDate, getTodayString } from '../utils/date.js';
 import { fetchCategories, fetchChannels } from '../api.js';
-import { openSearchAiringModal } from '../components/modal.js';
+import { openProgrammeModal, openSearchAiringModal } from '../components/modal.js';
 import { state } from '../state.js';
 
 const CLASS_LOADING = 'explore-loading';
@@ -510,6 +510,9 @@ async function renderNowNextMode(container) {
             remaining.className = 'now-next-remaining';
             remaining.textContent = `ends in ${minsRemaining} min`;
             currentDiv.appendChild(remaining);
+
+            currentDiv.style.cursor = 'pointer';
+            currentDiv.addEventListener('click', () => openProgrammeModal(entry.current));
         } else {
             currentDiv.textContent = 'Nothing airing';
         }
@@ -529,6 +532,9 @@ async function renderNowNextMode(container) {
             nextTime.className = 'now-next-time';
             nextTime.textContent = formatTime(new Date(entry.next.start));
             nextDiv.appendChild(nextTime);
+
+            nextDiv.style.cursor = 'pointer';
+            nextDiv.addEventListener('click', () => openProgrammeModal(entry.next));
 
             row.appendChild(nextDiv);
         }


### PR DESCRIPTION
## Summary
- Clicking a current or next show in the Now/Next explore view now opens the programme detail modal
- Reuses the existing `openProgrammeModal` function — no new modal logic added
- Both current and next show divs get `cursor: pointer` to signal interactivity

Closes #235

## Test plan
- [ ] 4 new Playwright tests added: clicking current/next shows opens modal with correct title, pointer cursor on both divs
- [ ] All 140 UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)