### PR TITLE
fix: enforce whole-word matching in CHANNEL_NAME_STRIP

### DIFF
--- a/internal/database/channel_name_strip_test.go
+++ b/internal/database/channel_name_strip_test.go
@@ -44,6 +44,10 @@ func stripSampleTV() *xmltv.TV {
 				ID:           "ch3",
 				DisplayNames: []xmltv.Name{{Value: "Seven"}},
 			},
+			{
+				ID:           "ch4",
+				DisplayNames: []xmltv.Name{{Value: "Viceland"}},
+			},
 		},
 		Programmes: []xmltv.Programme{
 			{
@@ -122,6 +126,28 @@ func TestRefresh_ChannelNameStrip_TrimSpace(t *testing.T) {
 		if ch.ID == "ch2" {
 			if ch.DisplayName != "Nine" {
 				t.Errorf("expected trimmed name %q, got %q", "Nine", ch.DisplayName)
+			}
+		}
+	}
+}
+
+// TestRefresh_ChannelNameStrip_WholeWord verifies that strip words match whole words only, not substrings.
+func TestRefresh_ChannelNameStrip_WholeWord(t *testing.T) {
+	db := openTestDBWithStripWords(t, []string{"Vic"})
+	tv := stripSampleTV()
+	if err := db.Refresh(context.Background(), tv, testBaseDate()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	channels, err := db.GetChannels(context.Background())
+	if err != nil {
+		t.Fatalf("GetChannels: %v", err)
+	}
+
+	for _, ch := range channels {
+		if ch.ID == "ch4" {
+			if ch.DisplayName != "Viceland" {
+				t.Errorf("expected name %q (should not strip partial word), got %q", "Viceland", ch.DisplayName)
 			}
 		}
 	}

--- a/internal/database/refresh.go
+++ b/internal/database/refresh.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -351,26 +352,13 @@ func (d *DB) rebuildCategories(ctx context.Context, tx *sql.Tx) error {
 	return nil
 }
 
-// stripWordCaseInsensitive removes all occurrences of word from s, case-insensitively.
-// Both s and word are lowercased for comparison; the original casing of non-matched
-// characters in s is preserved. The word must be non-empty.
+// stripWordCaseInsensitive removes all whole-word occurrences of word from s,
+// case-insensitively. Word boundaries are enforced so partial matches within
+// longer words (e.g. "Vic" inside "Viceland") are not removed.
 func stripWordCaseInsensitive(s, word string) string {
 	if word == "" {
 		return s
 	}
-	sLower := strings.ToLower(s)
-	wLower := strings.ToLower(word)
-	wLen := len(wLower)
-	var result strings.Builder
-	for {
-		idx := strings.Index(sLower, wLower)
-		if idx < 0 {
-			result.WriteString(s)
-			break
-		}
-		result.WriteString(s[:idx])
-		s = s[idx+wLen:]
-		sLower = sLower[idx+wLen:]
-	}
-	return result.String()
+	re := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(word) + `\b`)
+	return re.ReplaceAllString(s, "")
 }


### PR DESCRIPTION
## Summary

- `CHANNEL_NAME_STRIP` was using a plain substring match, so a strip word like `Vic` would corrupt `Viceland` into `eland`
- Replaced the manual substring loop in `stripWordCaseInsensitive` with a case-insensitive regex using `\b` word boundaries
- Added a regression test (`TestRefresh_ChannelNameStrip_WholeWord`) with a `Viceland` channel to prevent recurrence

Fixes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)