### PR TITLE
feat: add POST /api/guide/refresh endpoint for manual data refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ tvguide/
 | `GET /api/categories` | Sorted JSON array of all distinct category strings |
 | `GET /images/channel/{channel-id}` | Cached channel logo. Re-downloads from upstream if the local file is missing. Returns 404 if the channel has no icon. |
 | `GET /api/explore/now-next` | For every channel, returns the currently-airing show (`current`) and the next upcoming show (`next`). Either field may be `null`. Ordered by channel sort order (lcn, then source order). |
+| `POST /api/guide/refresh` | Triggers a refresh of TV guide data. `sync=true`: waits for completion and returns `200 {"ok":true}` or `500 {"error":"..."}`. Default (async): returns `202 Accepted` immediately. |
 | `GET /` | Serves the embedded frontend (SPA shell) |
 | `GET /{any}` | SPA fallback — serves `index.html` for any path not matching API, images, or static files. Enables client-side routing via History API. |
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -104,7 +104,7 @@ func newIntegrationServer(t *testing.T, xmltvURL string) *httptest.Server {
 	populateDB(t, db, &http.Client{}, xmltvURL+"/xmltv")
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0)
+	handler := api.New(db, 0, nil)
 	handler.RegisterRoutes(mux)
 
 	webSub, err := fs.Sub(webFS, "web")
@@ -684,7 +684,7 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	api.New(db, 0).RegisterRoutes(mux)
+	api.New(db, 0, nil).RegisterRoutes(mux)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 

--- a/internal/api/guide.go
+++ b/internal/api/guide.go
@@ -29,3 +29,22 @@ func (h *Handler) getGuide(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) getStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, h.db.GetStatus())
 }
+
+func (h *Handler) postGuideRefresh(w http.ResponseWriter, r *http.Request) {
+	if h.refreshFn == nil {
+		http.Error(w, "refresh not configured", http.StatusNotImplemented)
+		return
+	}
+	if r.URL.Query().Get("sync") == "true" {
+		if err := h.refreshFn(); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			writeJSON(w, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, map[string]bool{"ok": true})
+		return
+	}
+	go h.refreshFn() //nolint:errcheck
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/internal/api/guide_refresh_test.go
+++ b/internal/api/guide_refresh_test.go
@@ -1,0 +1,131 @@
+package api_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/api"
+	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/images"
+)
+
+// newRefreshServer creates a test API server with a controllable refreshFn.
+func newRefreshServer(t *testing.T, refreshFn func() error) *httptest.Server {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	h := api.New(db, 0, refreshFn)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestPostGuideRefresh_Async(t *testing.T) {
+	var called atomic.Bool
+	done := make(chan struct{})
+	srv := newRefreshServer(t, func() error {
+		called.Store(true)
+		close(done)
+		return nil
+	})
+
+	resp, err := httpPost(t, srv.URL+"/api/guide/refresh", nil)
+	if err != nil {
+		t.Fatalf("POST /api/guide/refresh: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("expected 202 Accepted, got %d", resp.StatusCode)
+	}
+
+	// Wait for the async goroutine to run.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("refresh function was not called within timeout")
+	}
+	if !called.Load() {
+		t.Error("expected refreshFn to be called")
+	}
+}
+
+func TestPostGuideRefresh_Sync_Success(t *testing.T) {
+	var called atomic.Bool
+	srv := newRefreshServer(t, func() error {
+		called.Store(true)
+		return nil
+	})
+
+	resp, err := httpPost(t, srv.URL+"/api/guide/refresh?sync=true", nil)
+	if err != nil {
+		t.Fatalf("POST /api/guide/refresh?sync=true: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 OK, got %d", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["ok"] != true {
+		t.Errorf("expected ok=true, got %v", body["ok"])
+	}
+	if !called.Load() {
+		t.Error("expected refreshFn to be called")
+	}
+}
+
+func TestPostGuideRefresh_Sync_Error(t *testing.T) {
+	srv := newRefreshServer(t, func() error {
+		return errors.New("xmltv fetch failed")
+	})
+
+	resp, err := httpPost(t, srv.URL+"/api/guide/refresh?sync=true", nil)
+	if err != nil {
+		t.Fatalf("POST /api/guide/refresh?sync=true: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["error"] != "xmltv fetch failed" {
+		t.Errorf("expected error message, got %v", body["error"])
+	}
+}
+
+func TestPostGuideRefresh_NoRefreshFn(t *testing.T) {
+	// When no refreshFn is configured, endpoint should return 501 Not Implemented.
+	srv := newRefreshServer(t, nil)
+
+	resp, err := httpPost(t, srv.URL+"/api/guide/refresh", nil)
+	if err != nil {
+		t.Fatalf("POST /api/guide/refresh: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Errorf("expected 501 Not Implemented, got %d", resp.StatusCode)
+	}
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -24,15 +24,17 @@ type store interface {
 
 // Handler holds the HTTP handler dependencies.
 type Handler struct {
-	db     store
-	rssTTL int // default RSS TTL in minutes; 0 means use hard-coded default (360)
+	db        store
+	rssTTL    int          // default RSS TTL in minutes; 0 means use hard-coded default (360)
+	refreshFn func() error // optional; nil means refresh endpoint returns 501
 }
 
 // New creates a new Handler backed by db. rssTTL is the server-wide default
 // RSS feed TTL in minutes (from the RSS_TTL env var); pass 0 to use the
-// hard-coded default of 360 minutes.
-func New(db store, rssTTL int) *Handler {
-	return &Handler{db: db, rssTTL: rssTTL}
+// hard-coded default of 360 minutes. refreshFn is called by POST /api/guide/refresh;
+// pass nil to disable the endpoint.
+func New(db store, rssTTL int, refreshFn func() error) *Handler {
+	return &Handler{db: db, rssTTL: rssTTL, refreshFn: refreshFn}
 }
 
 // RegisterRoutes adds all API routes to mux.
@@ -45,6 +47,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/explore/now-next", h.getNowNext)
 	mux.HandleFunc("GET /images/channel/{id}", h.serveChannelIcon)
 	mux.HandleFunc("POST /api/debug/log", h.postDebugLog)
+	mux.HandleFunc("POST /api/guide/refresh", h.postGuideRefresh)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -84,7 +84,7 @@ func newSeededServer(t *testing.T) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0)
+	handler := api.New(db, 0, nil)
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -124,7 +124,7 @@ func newSeededServerWithIcons(t *testing.T, iconSrv *httptest.Server) (*httptest
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0)
+	handler := api.New(db, 0, nil)
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -499,7 +499,7 @@ func newSearchSeededServer(t *testing.T) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0)
+	handler := api.New(db, 0, nil)
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -794,7 +794,7 @@ func TestCategories_EmptyWhenNoData(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0)
+	handler := api.New(db, 0, nil)
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -869,7 +869,7 @@ func TestSearch_AiringsOrderedByStartTime(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0)
+	handler := api.New(db, 0, nil)
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -970,7 +970,7 @@ func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0)
+	handler := api.New(db, 0, nil)
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -1071,7 +1071,7 @@ func TestSearch_TodayFilter_AdvancedMode(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0)
+	handler := api.New(db, 0, nil)
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -1207,7 +1207,7 @@ func newBrowseSeededServer(t *testing.T) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0)
+	handler := api.New(db, 0, nil)
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -1483,7 +1483,7 @@ func newRSSSeededServer(t *testing.T, rssTTL int) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, rssTTL)
+	handler := api.New(db, rssTTL, nil)
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -2034,7 +2034,7 @@ func newNowNextServer(t *testing.T) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0)
+	handler := api.New(db, 0, nil)
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -148,7 +148,6 @@ func (d *DB) SearchBrowse(ctx context.Context, categories []string, isPremiere b
 	return d.scanSearchResults(ctx, q, args...)
 }
 
-
 // GetCategories returns all distinct categories sorted alphabetically.
 func (d *DB) GetCategories(ctx context.Context) ([]string, error) {
 	rows, err := d.db.QueryContext(ctx, `SELECT name FROM categories ORDER BY name`)

--- a/main.go
+++ b/main.go
@@ -140,7 +140,9 @@ func run(cfg config) error {
 
 	mux := http.NewServeMux()
 
-	apiHandler := api.New(db, cfg.rssTTL)
+	apiHandler := api.New(db, cfg.rssTTL, func() error {
+		return refresh(db, httpClient, cfg.xmltvURL, cfg.pollInterval)
+	})
 	apiHandler.RegisterRoutes(mux)
 
 	webContent, err := fs.Sub(webFS, "web")


### PR DESCRIPTION
Closes #242

## Summary
- Adds `POST /api/guide/refresh` endpoint to trigger an XMLTV data refresh on demand
- Async mode (default): fires refresh in a goroutine and returns `202 Accepted` immediately
- Sync mode (`?sync=true`): waits for completion, returns `200 {"ok":true}` or `500 {"error":"..."}`
- `Handler.New()` gains a `refreshFn func() error` parameter; `main.go` passes a closure wrapping the existing `refresh()` function

## Test plan
- [x] `TestPostGuideRefresh_Async` — async mode returns 202 and calls refreshFn
- [x] `TestPostGuideRefresh_Sync_Success` — sync mode returns 200 with `{"ok":true}`
- [x] `TestPostGuideRefresh_Sync_Error` — sync mode returns 500 with error message
- [x] `TestPostGuideRefresh_NoRefreshFn` — nil refreshFn returns 501 Not Implemented
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)