### PR TITLE
feat: add GET /api/health endpoint and Docker HEALTHCHECK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ tvguide/
 │       ├── categories.go        # GET /api/categories
 │       ├── explore.go           # GET /api/explore/now-next
 │       ├── rss.go               # RSS feed formatting
+│       ├── health.go            # GET /api/health
 │       └── debug.go             # Debug/status endpoints
 ├── web/                         # Frontend — embedded into binary via go:embed
 │   ├── index.html               # App shell (no JS framework)
@@ -76,6 +77,7 @@ tvguide/
 | `GET /images/channel/{channel-id}` | Cached channel logo. Re-downloads from upstream if the local file is missing. Returns 404 if the channel has no icon. |
 | `GET /api/explore/now-next` | For every channel, returns the currently-airing show (`current`) and the next upcoming show (`next`). Either field may be `null`. Ordered by channel sort order (lcn, then source order). |
 | `POST /api/guide/refresh` | Triggers a refresh of TV guide data. `sync=true`: waits for completion and returns `200 {"ok":true}` or `500 {"error":"..."}`. Default (async): returns `202 Accepted` immediately. |
+| `GET /api/health` | Healthcheck endpoint. Probes SQLite connectivity and FTS availability. Returns `200 {"status":"ok"}` when healthy or `500 {"error":"..."}` when unhealthy. Used by the Docker `HEALTHCHECK` instruction via the `--healthcheck` binary flag. |
 | `GET /` | Serves the embedded frontend (SPA shell) |
 | `GET /{any}` | SPA fallback — serves `index.html` for any path not matching API, images, or static files. Enables client-side routing via History API. |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ COPY --from=builder /scratch_tmp /tmp
 
 EXPOSE 8080
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["/tvguide", "--healthcheck"]
+
 # Run as non-root (numeric UID required for scratch images which have no /etc/passwd).
 # UID 65534 is the conventional "nobody" user on Linux.
 USER 65534:65534

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -20,6 +20,7 @@ type store interface {
 	SearchBrowse(ctx context.Context, categories []string, isPremiere bool, includePast bool, includeRepeats bool, today bool) ([]model.SearchResult, error)
 	GetCategories(ctx context.Context) ([]string, error)
 	GetNowNext(ctx context.Context) ([]model.NowNextEntry, error)
+	Ping(ctx context.Context) error
 }
 
 // Handler holds the HTTP handler dependencies.
@@ -48,6 +49,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /images/channel/{id}", h.serveChannelIcon)
 	mux.HandleFunc("POST /api/debug/log", h.postDebugLog)
 	mux.HandleFunc("POST /api/guide/refresh", h.postGuideRefresh)
+	mux.HandleFunc("GET /api/health", h.getHealth)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"net/http"
+)
+
+func (h *Handler) getHealth(w http.ResponseWriter, r *http.Request) {
+	if err := h.db.Ping(r.Context()); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, map[string]string{"status": "ok"})
+}

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -1,0 +1,31 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestGetHealth(t *testing.T) {
+	srv := newSeededServer(t)
+
+	t.Run("returns 200 with ok status", func(t *testing.T) {
+		resp, err := httpGet(t, srv.URL+"/api/health")
+		if err != nil {
+			t.Fatalf("GET /api/health: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("status = %d, want 200", resp.StatusCode)
+		}
+
+		var body map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["status"] != "ok" {
+			t.Errorf("status = %q, want %q", body["status"], "ok")
+		}
+	})
+}

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -283,6 +283,12 @@ func (d *DB) SetNextRefresh(t time.Time) {
 	d.mu.Unlock()
 }
 
+// Ping checks database connectivity and FTS availability by running a lightweight probe query.
+func (d *DB) Ping(ctx context.Context) error {
+	_, err := d.db.ExecContext(ctx, `SELECT 1 FROM airings_fts LIMIT 1`)
+	return err
+}
+
 // Close closes the underlying database connection.
 func (d *DB) Close() error {
 	return d.db.Close()

--- a/main.go
+++ b/main.go
@@ -183,6 +183,14 @@ func run(cfg config) error {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--healthcheck" {
+		if err := healthcheck(); err != nil {
+			log.Printf("healthcheck failed: %v", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	cfg, err := parseConfig()
 	if err != nil {
 		log.Fatal(err)
@@ -190,6 +198,30 @@ func main() {
 	if err := run(cfg); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// healthcheck performs an HTTP GET to /api/health and returns nil on success.
+func healthcheck() error {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	url := "http://localhost:" + port + "/api/health"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 func runInitialRefresh(db *database.DB, client *http.Client, xmltvURL string, pollInterval time.Duration, refreshOnStart bool) {

--- a/main.go
+++ b/main.go
@@ -206,18 +206,21 @@ func healthcheck() error {
 	if port == "" {
 		port = "8080"
 	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return fmt.Errorf("invalid PORT %q: must be a number", port)
+	}
 	url := "http://localhost:" + port + "/api/health"
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) //nolint:gosec // G704: host is hardcoded to localhost; port is validated as numeric above
 	if err != nil {
 		return err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: see above
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}


### PR DESCRIPTION
## Summary
- Adds `GET /api/health` endpoint that probes SQLite connectivity and FTS availability (`SELECT 1 FROM airings_fts LIMIT 1`), returning `200 {"status":"ok"}` or `500 {"error":"..."}`
- Adds `--healthcheck` subcommand to the binary so the scratch-based Docker image can run health checks without curl/wget
- Updates `Dockerfile` with `HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD ["/tvguide", "--healthcheck"]`

Closes #243

## Test plan
- [ ] `GET /api/health` returns `200 {"status":"ok"}` on a healthy instance
- [ ] All existing tests pass (`go test ./...`)
- [ ] Docker build succeeds and container reports healthy status

🤖 Generated with [Claude Code](https://claude.com/claude-code)