### PR TITLE
diagnostic: log temp dir, DB connections, and FTS rows before rebuild (#241)

### DIFF
--- a/internal/database/refresh.go
+++ b/internal/database/refresh.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -320,9 +321,52 @@ func (d *DB) upsertAirings(ctx context.Context, tx *sql.Tx, airings []xmltv.Prog
 	return nil
 }
 
+// probeTempDir creates and immediately removes a temporary file to verify that
+// the OS temp directory is accessible and writable. SQLite FTS5 segment
+// operations require a writable temp directory even when PRAGMA
+// temp_store=MEMORY is set; this probe surfaces permission or missing-dir
+// problems before the FTS rebuild so they appear in the logs.
+func probeTempDir() (string, error) {
+	dir := os.TempDir()
+	f, err := os.CreateTemp(dir, "tvguide-probe-*")
+	if err != nil {
+		return dir, err
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return dir, nil
+}
+
 // rebuildFTS clears and repopulates the airings_fts full-text search index
 // from the current contents of the airings table.
 func (d *DB) rebuildFTS(ctx context.Context, tx *sql.Tx) error {
+	// Probe temp directory — SQLITE_IOERR_GETTEMPPATH (6410) means SQLite
+	// couldn't find a writable temp dir. Log the result every time so that
+	// if the DELETE fails we have a record of the temp dir state immediately
+	// before the failure.
+	if dir, err := probeTempDir(); err != nil {
+		log.Printf("diagnostic: temp dir probe FAILED (FTS rebuild may fail with disk I/O error): dir=%s err=%v", dir, err)
+	} else {
+		log.Printf("diagnostic: temp dir OK: %s", dir)
+	}
+
+	// Log DB connection stats to help detect concurrency issues — multiple
+	// open connections to the same SQLite WAL database can cause FTS5
+	// segment operations to fail.
+	stats := d.db.Stats()
+	log.Printf("diagnostic: DB connections before FTS rebuild: open=%d in-use=%d idle=%d wait=%d",
+		stats.OpenConnections, stats.InUse, stats.Idle, stats.WaitCount)
+
+	// Count FTS rows before DELETE so we can confirm the table had data if
+	// the operation fails.
+	var ftsCount int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM airings_fts`).Scan(&ftsCount); err != nil {
+		log.Printf("diagnostic: could not count FTS rows: %v", err)
+	} else {
+		log.Printf("diagnostic: FTS rows before rebuild: %d", ftsCount)
+	}
+
 	if _, err := tx.ExecContext(ctx, `DELETE FROM airings_fts`); err != nil {
 		return fmt.Errorf("clearing FTS index: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Adds three diagnostic log lines to `rebuildFTS` before every FTS rebuild
- Probes `/tmp` writability using `os.CreateTemp` — surfaces the `SQLITE_IOERR_GETTEMPPATH` cause before it happens
- Logs `db.Stats()` open/in-use/idle connections — surfaces concurrent-connection issues
- Counts FTS rows inside the transaction — confirms the table had data when the failure occurred

## Why not a fix yet

The root cause of issue #241 is still unconfirmed. Two prior fixes (#87, #231) addressed `/tmp` availability and permissions; the failure persists. The three hypotheses are:

1. `/tmp` is still inaccessible during scheduled (but not startup) refreshes
2. FTS5 segment operations only trigger temp-file usage when the table has data, meaning fix #87 never covered this path
3. Concurrent connections from the running HTTP server conflict with the FTS5 write

The new log output immediately before the next failure will confirm which hypothesis is correct.

## Test plan

- [ ] Deploy and let the scheduled refresh run once
- [ ] Confirm three `diagnostic:` lines appear in the log before each FTS rebuild
- [ ] If the failure recurs, check whether `temp dir probe FAILED`, `open=N` with N > 1, or `FTS rows = 0` gives the answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)