### PR TITLE
fix: service worker no longer intercepts navigation, fixing Authelia re-auth

### DIFF
--- a/e2e/tests/error-handling.spec.ts
+++ b/e2e/tests/error-handling.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { installClock } from '../fixtures/index';
+
+// Tests for API error handling on initial load.
+// Note: the service worker is blocked in all Playwright tests (playwright.config.ts:
+// serviceWorkers: 'block'), so opaqueredirect behaviour (Authelia auth expiry) cannot
+// be simulated here. These tests cover non-redirect API failures.
+
+test.describe('Error handling — initial load', () => {
+  test('shows error message when channels API returns server error', async ({ page }) => {
+    await installClock(page);
+    await page.route('/api/channels', route =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{"error":"internal server error"}' })
+    );
+    await page.route('/api/guide**', route =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{"error":"internal server error"}' })
+    );
+    await page.route('/api/debug/log', route => route.fulfill({ status: 204 }));
+
+    await page.goto('/');
+
+    // Loading screen must stay visible — app cannot proceed without data
+    await expect(page.locator('#loadingScreen')).toBeVisible();
+
+    // Error message must replace "Loading TV guide..."
+    await expect(page.locator('#loadingText')).toContainText('Failed to load guide data', { timeout: 5000 });
+    await expect(page.locator('#loadingText')).not.toContainText('Loading TV guide...');
+  });
+
+  test('shows error message when channels API request fails with network error', async ({ page }) => {
+    await installClock(page);
+    await page.route('/api/channels', route => route.abort('failed'));
+    await page.route('/api/guide**', route => route.abort('failed'));
+    await page.route('/api/debug/log', route => route.fulfill({ status: 204 }));
+
+    await page.goto('/');
+
+    await expect(page.locator('#loadingScreen')).toBeVisible();
+    await expect(page.locator('#loadingText')).toContainText('Failed to load guide data', { timeout: 5000 });
+    await expect(page.locator('#loadingText')).not.toContainText('Loading TV guide...');
+  });
+});

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -8,6 +8,8 @@ import { state } from './state.js';
 // which lets the browser follow the redirect chain to the login page and back.
 function handleRedirect(res) {
     if (res.type === 'opaqueredirect') {
+        const el = document.getElementById('loadingText');
+        if (el) el.textContent = 'Redirecting to authentication...';
         window.location.replace(window.location.href);
         return new Promise(() => {}); // never resolves — navigation is in progress
     }

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,9 +1,6 @@
 const CACHE = 'tvguide-__CACHE_VERSION__';
 const STATIC = ['/', '/index.html', '/style/base.css', '/style/layout.css', '/style/guide.css', '/style/modal.css', '/style/search.css', '/style/favourites.css', '/style/settings.css', '/js/main.js', '/js/router.js', '/js/state.js', '/js/api.js', '/js/config.js', '/js/utils/date.js', '/js/store/preferences.js', '/js/store/favourites.js', '/js/components/modal.js', '/js/pages/guide.js', '/js/pages/search.js', '/js/pages/favourites.js', '/js/pages/settings.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
 
-// SPA routes that should be served from the cached index.html
-const SPA_ROUTES = ['/guide', '/search', '/favourites', '/settings'];
-
 self.addEventListener('install', event => {
     event.waitUntil(
         caches.open(CACHE).then(cache => cache.addAll(STATIC))
@@ -21,6 +18,13 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+    // Do not intercept navigation requests. Letting the browser handle them
+    // directly allows Traefik/Authelia to intercept the request and redirect
+    // to the login page when authentication has expired. The backend's SPA
+    // fallback (spaHandler in main.go) serves index.html for all unmatched
+    // paths, so client-side routing still works for direct URL navigation.
+    if (event.request.mode === 'navigate') return;
+
     const url = new URL(event.request.url);
 
     if (url.pathname.startsWith('/api/')) {
@@ -29,11 +33,6 @@ self.addEventListener('fetch', event => {
         // (e.g. due to a Traefik/Authelia auth redirect), the error must
         // propagate so the page can detect the opaqueredirect and re-authenticate.
         event.respondWith(fetch(event.request));
-    } else if (SPA_ROUTES.includes(url.pathname)) {
-        // SPA routes: serve cached index.html (the SPA shell)
-        event.respondWith(
-            caches.match('/index.html').then(cached => cached || fetch('/'))
-        );
     } else {
         // Cache-first for static assets.
         event.respondWith(


### PR DESCRIPTION
## Summary

Fixes #250

### Root cause

When authentication expires behind Traefik/Authelia, the app's existing `handleRedirect` function in `api.js` correctly detects the `opaqueredirect` response and calls `window.location.replace()` to trigger a full-page navigation — but the **service worker was intercepting that navigation request** and serving cached `index.html` before it ever reached the server. Authelia never saw the request, so the login redirect never happened. The app appeared to hang on "Loading TV guide..." with no user feedback.

### Changes

- **`web/sw.js`**: Skip navigation requests (`event.request.mode === 'navigate'`) so the browser sends them directly to the server. The backend's `spaHandler` already serves `index.html` for all SPA routes, so direct-URL navigation and browser refreshes continue to work. The `SPA_ROUTES` array (which served cached `index.html` for in-SW routing) is removed since it's now redundant.

- **`web/js/api.js`**: When an `opaqueredirect` is detected, update the loading screen to show "Redirecting to authentication..." so the user has feedback while the navigation is in progress.

- **`e2e/tests/error-handling.spec.ts`**: Regression tests confirming the error message is shown when the API returns a server error or fails with a network error. (The service worker bypass itself cannot be tested in the Playwright suite because service workers are blocked there via `serviceWorkers: 'block'`.)

## Test plan

- [x] All 143 UI tests pass
- [ ] Manually verify auth redirect by letting the Authelia session expire — app should redirect to the login page instead of hanging
- [ ] Manually verify that navigating directly to `/guide`, `/search`, etc. still serves the SPA shell correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)