### PR TITLE
Restructure Settings page; add Refresh guide action (#257)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ The app uses a bottom navigation bar (iOS-style) with four tabs:
 | Guide | `/` or `/guide` | The main TV guide grid (default) |
 | Search | `/search` | Search for programmes by title or with advanced filters |
 | Favourites | `/favourites` | Saved search favourites — shows upcoming airings for all saved searches |
-| Settings | `/settings` | Channel visibility and favourite toggles |
+| Settings | `/settings` | Channels section (visibility/favourite toggles) and an Advanced section (collapsible) containing the Refresh guide action |
 | Explore | `/explore` | Browse TV by mode: Now/Next (default), Categories, Premieres, Time Slot |
 
 Navigation uses the **History API** (`pushState`/`popstate`) for client-side routing without full page reloads. The top bar (date display + prev/next day buttons) is only visible on the Guide tab. The Guide tab preserves its `?date=YYYY-MM-DD` query parameter behaviour.

--- a/e2e/pages/SettingsPage.ts
+++ b/e2e/pages/SettingsPage.ts
@@ -11,6 +11,50 @@ export class SettingsPage extends AppPage {
     await this.waitForAppReady();
   }
 
+  // Section containers
+  channelsSection(): Locator {
+    return this.page.locator('.settings-section.channels-section');
+  }
+
+  advancedSection(): Locator {
+    return this.page.locator('.settings-accordion.advanced-section');
+  }
+
+  advancedHeader(): Locator {
+    return this.advancedSection().locator('.settings-accordion-header');
+  }
+
+  advancedBody(): Locator {
+    return this.advancedSection().locator('.settings-accordion-body');
+  }
+
+  async isAdvancedExpanded(): Promise<boolean> {
+    return this.advancedSection().evaluate((el) =>
+      el.classList.contains('is-expanded')
+    );
+  }
+
+  async toggleAdvanced(): Promise<void> {
+    await this.advancedHeader().click();
+  }
+
+  // Refresh-guide action
+  refreshButton(): Locator {
+    return this.page.locator('.settings-action-refresh');
+  }
+
+  refreshSpinner(): Locator {
+    return this.page.locator('.settings-action-row .loading-spinner');
+  }
+
+  refreshStatus(): Locator {
+    return this.page.locator('.settings-status');
+  }
+
+  async clickRefresh(): Promise<void> {
+    await this.refreshButton().click();
+  }
+
   // Channel rows
   channelItems(): Locator {
     return this.page.locator('.settings-item');

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -39,6 +39,155 @@ test.describe('Settings tab — Rendering', () => {
       await expect(item.locator('.hide-btn')).toBeVisible();
     }
   });
+
+  test('renders Channels section containing the channel list', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    await expect(settings.channelsSection()).toBeVisible();
+    await expect(settings.channelsSection().locator('.settings-item')).toHaveCount(5);
+  });
+
+  test('renders Advanced section collapsed by default', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    await expect(settings.advancedSection()).toBeVisible();
+    await expect(settings.advancedHeader()).toBeVisible();
+    await expect(settings.advancedHeader()).toContainText('Advanced');
+    expect(await settings.isAdvancedExpanded()).toBe(false);
+  });
+});
+
+test.describe('Settings tab — Advanced accordion', () => {
+  test('clicking the header expands and a second click collapses', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    expect(await settings.isAdvancedExpanded()).toBe(false);
+
+    await settings.toggleAdvanced();
+    expect(await settings.isAdvancedExpanded()).toBe(true);
+
+    await settings.toggleAdvanced();
+    expect(await settings.isAdvancedExpanded()).toBe(false);
+  });
+
+  test('Refresh guide button is rendered inside the Advanced section', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+
+    await settings.toggleAdvanced();
+
+    const refresh = settings.refreshButton();
+    await expect(refresh).toBeVisible();
+    await expect(refresh).toContainText(/refresh guide/i);
+  });
+});
+
+test.describe('Settings tab — Refresh guide action', () => {
+  test('successful refresh shows success message and re-fetches channels + guide', async ({
+    page,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    let channelsRefetched = 0;
+    let guideRefetched = 0;
+    await page.route('/api/channels', (route) => {
+      channelsRefetched += 1;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(channelsFixture),
+      });
+    });
+    await page.route('/api/guide**', (route) => {
+      guideRefetched += 1;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    let refreshCalled = false;
+    await page.route('**/api/guide/refresh**', (route) => {
+      refreshCalled = true;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    await settings.clickRefresh();
+
+    const status = settings.refreshStatus();
+    await expect(status).toBeVisible();
+    await expect(status).toHaveClass(/is-success/);
+    await expect(status).toContainText(/refreshed/i);
+
+    expect(refreshCalled).toBe(true);
+    expect(channelsRefetched).toBeGreaterThanOrEqual(1);
+    expect(guideRefetched).toBeGreaterThanOrEqual(1);
+
+    // Button is re-enabled after success
+    await expect(settings.refreshButton()).toBeEnabled();
+  });
+
+  test('failure response shows the error message and re-enables the button', async ({
+    page,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await page.route('**/api/guide/refresh**', (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'upstream timeout' }),
+      })
+    );
+
+    await settings.clickRefresh();
+
+    const status = settings.refreshStatus();
+    await expect(status).toBeVisible();
+    await expect(status).toHaveClass(/is-error/);
+    await expect(status).toContainText('upstream timeout');
+
+    await expect(settings.refreshButton()).toBeEnabled();
+  });
+
+  test('button is disabled while the refresh request is in flight', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await page.route('**/api/guide/refresh**', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    // Don't await — let the click resolve in the background
+    const clickPromise = settings.clickRefresh();
+
+    // While the request is in flight, the button is disabled
+    await expect(settings.refreshButton()).toBeDisabled();
+    await expect(settings.refreshSpinner()).toBeVisible();
+
+    await clickPromise;
+
+    // After completion, the button is re-enabled
+    await expect(settings.refreshButton()).toBeEnabled();
+  });
 });
 
 test.describe('Settings tab — Initial state from localStorage', () => {

--- a/web/index.html
+++ b/web/index.html
@@ -116,10 +116,7 @@
 
     <!-- Page: Settings -->
     <div class="page" id="page-settings" style="display:none">
-        <div class="page-content">
-            <h1>Channels</h1>
-            <div class="settings-list" id="settingsList"></div>
-        </div>
+        <div class="page-content" id="settingsPanel"></div>
     </div>
 
     <!-- Bottom navigation bar -->

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -36,6 +36,22 @@ export async function fetchCategories() {
     return state.categories;
 }
 
+export async function refreshGuide() {
+    const res = await fetch('/api/guide/refresh?sync=true', {
+        method: 'POST',
+        redirect: 'manual',
+    }).then(handleRedirect);
+    if (!res.ok) {
+        let msg = `Refresh failed (${res.status})`;
+        try {
+            const body = await res.json();
+            if (body && body.error) msg = body.error;
+        } catch { /* response had no JSON body */ }
+        throw new Error(msg);
+    }
+    return res.json();
+}
+
 export function logError({ type, message, source, lineno, colno, stack, url }) {
     fetch('/api/debug/log', {
         method: 'POST',

--- a/web/js/pages/settings.js
+++ b/web/js/pages/settings.js
@@ -1,11 +1,36 @@
 import { state } from '../state.js';
 import { isHidden, isFavourite, toggleHidden, toggleFavourite } from '../store/preferences.js';
-import { renderGuide } from './guide.js';
+import { fetchChannels, fetchGuide, refreshGuide } from '../api.js';
+import { renderGuide, hasAiringsStartingOn } from './guide.js';
 
 export function renderSettingsPanel() {
-    const list = document.getElementById('settingsList');
-    list.innerHTML = '';
+    const panel = document.getElementById('settingsPanel');
+    panel.innerHTML = '';
 
+    panel.appendChild(buildChannelsSection());
+    panel.appendChild(buildAdvancedSection());
+}
+
+function buildChannelsSection() {
+    const section = document.createElement('section');
+    section.className = 'settings-section channels-section';
+
+    const heading = document.createElement('h1');
+    heading.className   = 'settings-section-heading';
+    heading.textContent = 'Channels';
+    section.appendChild(heading);
+
+    const list = document.createElement('div');
+    list.className = 'settings-list';
+    list.id        = 'settingsList';
+    populateChannelsList(list);
+
+    section.appendChild(list);
+    return section;
+}
+
+function populateChannelsList(list) {
+    list.innerHTML = '';
     for (const ch of state.channels) {
         const hidden = isHidden(ch.id);
         const fav    = isFavourite(ch.id);
@@ -13,23 +38,20 @@ export function renderSettingsPanel() {
         const item = document.createElement('div');
         item.className = 'settings-item' + (hidden ? ' is-hidden' : '');
 
-        // Favourite toggle
         const favBtn = document.createElement('button');
         favBtn.className = 'settings-icon-btn fav-btn' + (fav ? ' active' : '');
-        favBtn.textContent = '\u2605'; // ★
+        favBtn.textContent = '★'; // ★
         favBtn.title = fav ? 'Remove from favourites' : 'Add to favourites';
         favBtn.addEventListener('click', () => {
             toggleFavourite(ch.id);
             renderGuide();
-            renderSettingsPanel();
+            populateChannelsList(list);
         });
 
-        // Channel name
         const name = document.createElement('span');
         name.className   = 'settings-name';
         name.textContent = ch.displayName;
 
-        // Hide/show toggle
         const hideBtn = document.createElement('button');
         hideBtn.className = 'settings-icon-btn hide-btn' + (hidden ? ' active' : '');
         hideBtn.textContent = hidden ? '\u{1F648}' : '\u{1F441}'; // 🙈 / 👁
@@ -37,7 +59,7 @@ export function renderSettingsPanel() {
         hideBtn.addEventListener('click', () => {
             toggleHidden(ch.id);
             renderGuide();
-            renderSettingsPanel();
+            populateChannelsList(list);
         });
 
         item.appendChild(favBtn);
@@ -45,4 +67,109 @@ export function renderSettingsPanel() {
         item.appendChild(hideBtn);
         list.appendChild(item);
     }
+}
+
+function buildAdvancedSection() {
+    const section = document.createElement('section');
+    section.className = 'settings-accordion advanced-section';
+
+    const header = document.createElement('button');
+    header.type      = 'button';
+    header.className = 'settings-accordion-header';
+    header.setAttribute('aria-expanded', 'false');
+    header.innerHTML =
+        '<span class="settings-accordion-title">Advanced</span>' +
+        '<span class="settings-accordion-chevron" aria-hidden="true">▾</span>';
+
+    const body = document.createElement('div');
+    body.className = 'settings-accordion-body';
+    body.appendChild(buildRefreshAction());
+
+    header.addEventListener('click', () => {
+        const expanded = section.classList.toggle('is-expanded');
+        header.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    });
+
+    section.appendChild(header);
+    section.appendChild(body);
+    return section;
+}
+
+function buildRefreshAction() {
+    const wrap = document.createElement('div');
+    wrap.className = 'settings-action settings-action-refresh-wrap';
+
+    const description = document.createElement('p');
+    description.className   = 'settings-action-desc';
+    description.textContent = 'Re-fetches the XMLTV source now.';
+
+    const row = document.createElement('div');
+    row.className = 'settings-action-row';
+
+    const btn = document.createElement('button');
+    btn.type        = 'button';
+    btn.className   = 'settings-action-btn settings-action-refresh';
+    btn.textContent = 'Refresh guide';
+
+    const spinner = document.createElement('div');
+    spinner.className = 'loading-spinner';
+    spinner.style.display = 'none';
+
+    const status = document.createElement('div');
+    status.className = 'settings-status';
+    status.style.display = 'none';
+    status.setAttribute('role', 'status');
+
+    btn.addEventListener('click', async () => {
+        btn.disabled = true;
+        spinner.style.display = '';
+        hideStatus(status);
+
+        try {
+            await refreshGuide();
+            const [channels, programmes] = await Promise.all([
+                fetchChannels(),
+                fetchGuide(state.currentDate),
+            ]);
+            state.channels   = channels;
+            state.programmes = programmes;
+
+            const hasData = hasAiringsStartingOn(state.programmes, state.currentDate);
+            const empty = document.getElementById('guideEmpty');
+            const container = document.querySelector('.guide-container');
+            if (empty)     empty.classList.toggle('visible', !hasData);
+            if (container) container.classList.toggle('no-data', !hasData);
+            renderGuide();
+
+            const list = document.getElementById('settingsList');
+            if (list) populateChannelsList(list);
+
+            showStatus(status, 'Guide refreshed', 'is-success');
+        } catch (err) {
+            showStatus(status, err.message || 'Refresh failed', 'is-error');
+        } finally {
+            btn.disabled = false;
+            spinner.style.display = 'none';
+        }
+    });
+
+    row.appendChild(btn);
+    row.appendChild(spinner);
+    row.appendChild(status);
+
+    wrap.appendChild(description);
+    wrap.appendChild(row);
+    return wrap;
+}
+
+function showStatus(el, text, cls) {
+    el.textContent = text;
+    el.className = `settings-status ${cls}`;
+    el.style.display = '';
+}
+
+function hideStatus(el) {
+    el.style.display = 'none';
+    el.className = 'settings-status';
+    el.textContent = '';
 }

--- a/web/style/settings.css
+++ b/web/style/settings.css
@@ -1,8 +1,18 @@
-/* ── Settings page (channel list) ─────────────────────────────── */
+/* ── Settings page ────────────────────────────────────────────── */
+
+.settings-section {
+    margin-bottom: 18px;
+}
+
+.settings-section-heading {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+}
 
 .settings-list {
     overflow-y: auto;
-    flex: 1;
 }
 
 .settings-item {
@@ -50,4 +60,106 @@
 .settings-icon-btn.hide-btn.active {
     color: var(--text-muted);
     opacity: 0.45;
+}
+
+/* ── Advanced accordion ───────────────────────────────────────── */
+
+.settings-accordion {
+    border-top: 1px solid var(--border);
+    margin-top: 8px;
+}
+
+.settings-accordion-header {
+    width: 100%;
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: 16px;
+    font-weight: 600;
+    text-align: left;
+    padding: 12px 0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.settings-accordion-header:hover {
+    color: var(--text-primary);
+}
+
+.settings-accordion-chevron {
+    font-size: 14px;
+    color: var(--text-secondary);
+    transition: transform 0.15s ease;
+}
+
+.settings-accordion.is-expanded .settings-accordion-chevron {
+    transform: rotate(180deg);
+}
+
+.settings-accordion-body {
+    display: none;
+    padding: 4px 0 12px;
+}
+
+.settings-accordion.is-expanded .settings-accordion-body {
+    display: block;
+}
+
+/* ── Action button + inline status ────────────────────────────── */
+
+.settings-action {
+    margin-bottom: 12px;
+}
+
+.settings-action-desc {
+    color: var(--text-secondary);
+    font-size: 13px;
+    margin-bottom: 8px;
+}
+
+.settings-action-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.settings-action-btn {
+    background: var(--bg-programme);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 14px;
+    font-size: 14px;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.settings-action-btn:hover:not(:disabled) {
+    background: var(--bg-prog-hover);
+}
+
+.settings-action-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.settings-action-row .loading-spinner {
+    width: 18px;
+    height: 18px;
+    border-width: 2px;
+}
+
+.settings-status {
+    font-size: 13px;
+}
+
+.settings-status.is-success {
+    color: #3fb950;
+}
+
+.settings-status.is-error {
+    color: var(--accent-now);
 }


### PR DESCRIPTION
## Summary

- Settings page now renders a **Channels** section (heading + existing list, unchanged behaviour) and a collapsed-by-default **Advanced** accordion.
- The Advanced section contains a **Refresh guide** action that calls `POST /api/guide/refresh?sync=true`, disables the button + shows a spinner while in flight, and surfaces inline success/error feedback.
- On success, channels and the current-day guide are re-fetched so fresh data appears immediately; the channel list re-renders in place without collapsing the accordion.

Phase 1 of #256. Closes #257.

## Test plan

- [x] All 21 Playwright settings tests pass (7 new + 14 existing)
- [x] All 149 UI tests pass
- [x] All Go tests pass
- [x] ESLint clean on changed JS files
- [ ] Manual smoke test: open Settings → expand Advanced → Refresh guide → success message + fresh data
- [ ] Manual smoke test: simulate failure (e.g. stop WireMock) → red error message, button re-enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)