### PR TITLE
Add Status info + Reset preferences to Settings → Advanced #258

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ The app uses a bottom navigation bar (iOS-style) with four tabs:
 | Guide | `/` or `/guide` | The main TV guide grid (default) |
 | Search | `/search` | Search for programmes by title or with advanced filters |
 | Favourites | `/favourites` | Saved search favourites — shows upcoming airings for all saved searches |
-| Settings | `/settings` | Channels section (visibility/favourite toggles) and an Advanced section (collapsible) containing the Refresh guide action |
+| Settings | `/settings` | Channels section (visibility/favourite toggles) and an Advanced section (collapsible) containing Refresh guide, Status info (last/next refresh + source URL from `/api/status`, fetched lazily on first expand), and Reset preferences (clears `tvguide-prefs` and `tvguide-favourites` from `localStorage` after a `window.confirm`, then reloads the page) |
 | Explore | `/explore` | Browse TV by mode: Now/Next (default), Categories, Premieres, Time Slot |
 
 Navigation uses the **History API** (`pushState`/`popstate`) for client-side routing without full page reloads. The top bar (date display + prev/next day buttons) is only visible on the Guide tab. The Guide tab preserves its `?date=YYYY-MM-DD` query parameter behaviour.

--- a/e2e/fixtures/api/status.json
+++ b/e2e/fixtures/api/status.json
@@ -1,0 +1,5 @@
+{
+  "lastRefresh": "2025-06-10T13:00:00.000Z",
+  "nextRefresh": "2025-06-11T01:00:00.000Z",
+  "sourceUrl": "https://example.com/xmltv.xml"
+}

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -4,6 +4,7 @@ import guideTodayFixture from './api/guide-today.json';
 import categoriesFixture from './api/categories.json';
 import searchResultsFixture from './api/search-results.json';
 import exploreNowNextFixture from './api/explore-now-next.json';
+import statusFixture from './api/status.json';
 
 export const FIXED_NOW = new Date('2025-06-10T14:00:00.000Z').getTime();
 
@@ -21,6 +22,7 @@ export async function setupApiRoutes(
     '/api/categories': categoriesFixture,
     '/api/search**': searchResultsFixture,
     '/api/explore/now-next': exploreNowNextFixture,
+    '/api/status': statusFixture,
   };
 
   for (const [pattern, body] of Object.entries(defaultRoutes)) {

--- a/e2e/pages/SettingsPage.ts
+++ b/e2e/pages/SettingsPage.ts
@@ -55,6 +55,34 @@ export class SettingsPage extends AppPage {
     await this.refreshButton().click();
   }
 
+  // Status block
+  statusBlock(): Locator {
+    return this.page.locator('.settings-status-block');
+  }
+
+  statusRow(label: string): Locator {
+    return this.page.locator('.settings-status-row').filter({
+      has: this.page.locator('.settings-status-label', { hasText: label }),
+    });
+  }
+
+  statusValue(label: string): Locator {
+    return this.statusRow(label).locator('.settings-status-value');
+  }
+
+  statusUnavailable(): Locator {
+    return this.page.locator('.settings-status-unavailable');
+  }
+
+  // Reset preferences action
+  resetButton(): Locator {
+    return this.page.locator('.settings-action-reset');
+  }
+
+  async clickReset(): Promise<void> {
+    await this.resetButton().click();
+  }
+
   // Channel rows
   channelItems(): Locator {
     return this.page.locator('.settings-item');

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../fixtures/index';
 import { SettingsPage } from '../pages/SettingsPage';
 import { GuidePage } from '../pages/GuidePage';
 import channelsFixture from '../fixtures/api/channels.json';
+import statusFixture from '../fixtures/api/status.json';
 
 // FIXED_NOW = 2025-06-10T14:00:00.000Z (Tuesday, 14:00 UTC)
 
@@ -82,6 +83,149 @@ test.describe('Settings tab — Advanced accordion', () => {
     const refresh = settings.refreshButton();
     await expect(refresh).toBeVisible();
     await expect(refresh).toContainText(/refresh guide/i);
+  });
+});
+
+test.describe('Settings tab — Status block', () => {
+  test('displays last refresh, next refresh, and source URL when Advanced is expanded', async ({
+    page,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await expect(settings.statusBlock()).toBeVisible();
+    await expect(settings.statusRow('Last refresh')).toBeVisible();
+    await expect(settings.statusRow('Next refresh')).toBeVisible();
+    await expect(settings.statusRow('Source')).toBeVisible();
+
+    // Source value should match the fixture URL exactly.
+    await expect(settings.statusValue('Source')).toHaveText(statusFixture.sourceUrl);
+
+    // Refresh times render as some non-empty string (formatting is locale-dependent;
+    // we only assert it's populated and not the raw ISO string).
+    const lastText = (await settings.statusValue('Last refresh').textContent()) ?? '';
+    expect(lastText.trim().length).toBeGreaterThan(0);
+    expect(lastText).not.toContain('T');
+
+    const nextText = (await settings.statusValue('Next refresh').textContent()) ?? '';
+    expect(nextText.trim().length).toBeGreaterThan(0);
+    expect(nextText).not.toContain('T');
+  });
+
+  test('Source URL has a title attribute showing the full value', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await expect(settings.statusValue('Source')).toHaveAttribute(
+      'title',
+      statusFixture.sourceUrl
+    );
+  });
+
+  test('shows "Status unavailable" when /api/status returns 500 without breaking the rest of the Advanced section', async ({
+    page,
+    setupApiRoutes,
+  }) => {
+    await setupApiRoutes({ '/api/status': null });
+    await page.route('/api/status', (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'boom' }),
+      })
+    );
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await expect(settings.statusUnavailable()).toBeVisible();
+    await expect(settings.statusUnavailable()).toContainText(/status unavailable/i);
+
+    // Other actions still render
+    await expect(settings.refreshButton()).toBeVisible();
+    await expect(settings.resetButton()).toBeVisible();
+  });
+});
+
+test.describe('Settings tab — Reset preferences action', () => {
+  test('Reset preferences button is rendered inside the Advanced section', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    const btn = settings.resetButton();
+    await expect(btn).toBeVisible();
+    await expect(btn).toContainText(/reset preferences/i);
+  });
+
+  test('confirming the prompt clears both localStorage keys and reloads the page', async ({
+    page,
+  }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    // Seed AFTER navigation so a page reload doesn't restore the values.
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'tvguide-prefs',
+        JSON.stringify({ hidden: { ch2: true }, favourites: { ch1: true } })
+      );
+      localStorage.setItem(
+        'tvguide-favourites',
+        JSON.stringify([{ id: 'uuid-1', name: 'Test', query: 'Test', mode: 'simple' }])
+      );
+    });
+
+    // Pre-condition: keys exist
+    const before = await page.evaluate(() => ({
+      prefs: localStorage.getItem('tvguide-prefs'),
+      favs: localStorage.getItem('tvguide-favourites'),
+    }));
+    expect(before.prefs).not.toBeNull();
+    expect(before.favs).not.toBeNull();
+
+    page.on('dialog', (dialog) => dialog.accept());
+
+    await Promise.all([page.waitForEvent('load'), settings.clickReset()]);
+
+    const after = await page.evaluate(() => ({
+      prefs: localStorage.getItem('tvguide-prefs'),
+      favs: localStorage.getItem('tvguide-favourites'),
+    }));
+    expect(after.prefs).toBeNull();
+    expect(after.favs).toBeNull();
+  });
+
+  test('cancelling the prompt leaves localStorage untouched', async ({
+    page,
+    seedLocalStorage,
+  }) => {
+    await seedLocalStorage('tvguide-prefs', { hidden: { ch2: true }, favourites: { ch1: true } });
+    await seedLocalStorage('tvguide-favourites', [
+      { id: 'uuid-1', name: 'Test', query: 'Test', mode: 'simple' },
+    ]);
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    page.on('dialog', (dialog) => dialog.dismiss());
+
+    await settings.clickReset();
+
+    // No reload triggered — give it a tick to be sure no async clear runs
+    await page.waitForTimeout(100);
+
+    const after = await page.evaluate(() => ({
+      prefs: localStorage.getItem('tvguide-prefs'),
+      favs: localStorage.getItem('tvguide-favourites'),
+    }));
+    expect(after.prefs).not.toBeNull();
+    expect(after.favs).not.toBeNull();
   });
 });
 

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -36,6 +36,12 @@ export async function fetchCategories() {
     return state.categories;
 }
 
+export async function fetchStatus() {
+    const res = await fetch('/api/status', { redirect: 'manual' }).then(handleRedirect);
+    if (!res.ok) throw new Error(`/api/status returned ${res.status}`);
+    return res.json();
+}
+
 export async function refreshGuide() {
     const res = await fetch('/api/guide/refresh?sync=true', {
         method: 'POST',

--- a/web/js/pages/settings.js
+++ b/web/js/pages/settings.js
@@ -1,7 +1,8 @@
 import { state } from '../state.js';
 import { isHidden, isFavourite, toggleHidden, toggleFavourite } from '../store/preferences.js';
-import { fetchChannels, fetchGuide, refreshGuide } from '../api.js';
+import { fetchChannels, fetchGuide, fetchStatus, refreshGuide } from '../api.js';
 import { renderGuide, hasAiringsStartingOn } from './guide.js';
+import { formatAbsoluteDateTime } from '../utils/date.js';
 
 export function renderSettingsPanel() {
     const panel = document.getElementById('settingsPanel');
@@ -84,10 +85,18 @@ function buildAdvancedSection() {
     const body = document.createElement('div');
     body.className = 'settings-accordion-body';
     body.appendChild(buildRefreshAction());
+    const statusBlock = buildStatusBlock();
+    body.appendChild(statusBlock);
+    body.appendChild(buildResetAction());
 
+    let statusLoaded = false;
     header.addEventListener('click', () => {
         const expanded = section.classList.toggle('is-expanded');
         header.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        if (expanded && !statusLoaded) {
+            statusLoaded = true;
+            loadStatus(statusBlock);
+        }
     });
 
     section.appendChild(header);
@@ -157,6 +166,99 @@ function buildRefreshAction() {
     row.appendChild(spinner);
     row.appendChild(status);
 
+    wrap.appendChild(description);
+    wrap.appendChild(row);
+    return wrap;
+}
+
+function buildStatusBlock() {
+    const wrap = document.createElement('div');
+    wrap.className = 'settings-status-block';
+    wrap.setAttribute('aria-busy', 'true');
+
+    const loading = document.createElement('div');
+    loading.className   = 'settings-status-loading';
+    loading.textContent = 'Loading status…';
+    wrap.appendChild(loading);
+
+    return wrap;
+}
+
+async function loadStatus(block) {
+    try {
+        const status = await fetchStatus();
+        renderStatus(block, status);
+    } catch {
+        renderStatusUnavailable(block);
+    } finally {
+        block.removeAttribute('aria-busy');
+    }
+}
+
+function renderStatus(block, status) {
+    block.innerHTML = '';
+    block.appendChild(buildStatusRow('Last refresh', formatStatusTime(status.lastRefresh)));
+    block.appendChild(buildStatusRow('Next refresh', formatStatusTime(status.nextRefresh)));
+    block.appendChild(buildStatusRow('Source', status.sourceUrl || '—', { url: true, title: status.sourceUrl }));
+}
+
+function buildStatusRow(label, value, opts = {}) {
+    const row = document.createElement('div');
+    row.className = 'settings-status-row';
+
+    const l = document.createElement('span');
+    l.className   = 'settings-status-label';
+    l.textContent = label;
+
+    const v = document.createElement('span');
+    v.className   = 'settings-status-value' + (opts.url ? ' settings-status-value-url' : '');
+    v.textContent = value;
+    if (opts.title) v.title = opts.title;
+
+    row.appendChild(l);
+    row.appendChild(v);
+    return row;
+}
+
+function formatStatusTime(value) {
+    if (!value) return '—';
+    const d = new Date(value);
+    if (isNaN(d.getTime())) return '—';
+    return formatAbsoluteDateTime(d);
+}
+
+function renderStatusUnavailable(block) {
+    block.innerHTML = '';
+    const msg = document.createElement('div');
+    msg.className   = 'settings-status-unavailable';
+    msg.textContent = 'Status unavailable';
+    block.appendChild(msg);
+}
+
+function buildResetAction() {
+    const wrap = document.createElement('div');
+    wrap.className = 'settings-action settings-action-reset-wrap';
+
+    const description = document.createElement('p');
+    description.className   = 'settings-action-desc';
+    description.textContent = 'Clears hidden channels, channel favourites, and saved searches stored on this device.';
+
+    const row = document.createElement('div');
+    row.className = 'settings-action-row';
+
+    const btn = document.createElement('button');
+    btn.type        = 'button';
+    btn.className   = 'settings-action-btn settings-action-reset';
+    btn.textContent = 'Reset preferences';
+
+    btn.addEventListener('click', () => {
+        if (!window.confirm('Reset all preferences? This cannot be undone.')) return;
+        localStorage.removeItem('tvguide-prefs');
+        localStorage.removeItem('tvguide-favourites');
+        window.location.reload();
+    });
+
+    row.appendChild(btn);
     wrap.appendChild(description);
     wrap.appendChild(row);
     return wrap;

--- a/web/js/utils/date.js
+++ b/web/js/utils/date.js
@@ -43,6 +43,14 @@ export function addDays(dateStr, days) {
     ].join('-');
 }
 
+// Formats a Date as an absolute local date+time, e.g. "10 Jun 2025, 23:00".
+export function formatAbsoluteDateTime(date) {
+    return date.toLocaleString([], {
+        day: 'numeric', month: 'short', year: 'numeric',
+        hour: '2-digit', minute: '2-digit', hour12: false,
+    });
+}
+
 export function formatSearchDate(date) {
     const now = new Date();
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());

--- a/web/style/settings.css
+++ b/web/style/settings.css
@@ -163,3 +163,46 @@
 .settings-status.is-error {
     color: var(--accent-now);
 }
+
+/* ── Status block ─────────────────────────────────────────────── */
+
+.settings-status-block {
+    margin-bottom: 12px;
+    padding: 8px 0;
+    border-top: 1px solid var(--border);
+}
+
+.settings-status-loading,
+.settings-status-unavailable {
+    color: var(--text-muted);
+    font-size: 13px;
+    font-style: italic;
+}
+
+.settings-status-row {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 4px 0;
+    font-size: 13px;
+}
+
+.settings-status-label {
+    flex: 0 0 auto;
+    color: var(--text-secondary);
+    min-width: 100px;
+}
+
+.settings-status-value {
+    flex: 1 1 auto;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+
+.settings-status-value-url {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- Adds a **Status** block to the Advanced section that lazily fetches `/api/status` on first expand and shows last refresh, next refresh, and the XMLTV source URL (monospace, ellipsis-truncated, full value on hover). Falls back to a muted "Status unavailable" line on error without breaking other actions.
- Adds a **Reset preferences** action that prompts via `window.confirm`, then clears `tvguide-prefs` and `tvguide-favourites` from `localStorage` and reloads the page.
- Updates `CLAUDE.md` Frontend navigation row to reflect the new Advanced contents.

Closes #258 (Phase 2 of #256).

## Test plan
- [x] New Playwright tests cover: status rows populated from mocked `/api/status`, `Source` `title=` tooltip, 500 fallback message + other actions remain visible, Reset button rendering, confirm-clears-and-reloads, cancel-leaves-storage-intact
- [x] Full Playwright suite green (155 passed, 1 pre-existing skip)
- [x] Go tests green (`make test`)
- [ ] Built via `docker compose up --build` and exercised manually in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)