### PR TITLE
Fix /data permissions for fresh volumes on non-root runtime #259

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o tvguide .
 # with SQLITE_IOERR_WRITE (6410). See GitHub issue #87.
 RUN mkdir /scratch_tmp && chmod 1777 /scratch_tmp
 
+# Create an empty /data directory to carry into the scratch image.
+# When Docker mounts an empty named volume on top of a directory that exists
+# in the image, the volume inherits the image directory's ownership and mode.
+# Without this, a fresh volume is created root-owned and the non-root runtime
+# user (UID 65534) cannot write the SQLite DB or image cache. See issue #259.
+RUN mkdir /scratch_data && chown 65534:65534 /scratch_data
+
 # ── Runtime stage ─────────────────────────────────────────────────
 # scratch: zero OS overhead (~0 MB vs ~8 MB for alpine).
 # Timezone data is embedded in the binary via `import _ "time/tzdata"`,
@@ -36,6 +43,7 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/tvguide /tvguide
 COPY --from=builder --chmod=1777 /scratch_tmp /tmp
+COPY --from=builder --chown=65534:65534 --chmod=1777 /scratch_data /data
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o tvguide .
 # SQLite FTS5 segment operations require a writable temp directory even when
 # PRAGMA temp_store=MEMORY is set; without /tmp the second+ refresh fails
 # with SQLITE_IOERR_WRITE (6410). See GitHub issue #87.
-RUN mkdir /scratch_tmp && chmod 1777 /scratch_tmp
+RUN mkdir /scratch_tmp && chown 65534:65534 /scratch_tmp
 
 # Create an empty /data directory to carry into the scratch image.
 # When Docker mounts an empty named volume on top of a directory that exists
@@ -42,7 +42,7 @@ FROM scratch
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/tvguide /tvguide
-COPY --from=builder --chmod=1777 /scratch_tmp /tmp
+COPY --from=builder --chown=65534:65534 --chmod=1777 /scratch_tmp /tmp
 COPY --from=builder --chown=65534:65534 --chmod=1777 /scratch_data /data
 
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- Pre-create `/data` in the builder stage owned by UID 65534, then `COPY --chown=65534:65534 --chmod=1777` it into the scratch image.
- Docker propagates the image directory's ownership to empty named volumes on first mount, so fresh deployments no longer fail with `permission denied` (image cache) or `attempt to write a readonly database` (SQLite) when the non-root runtime user (UID 65534, set in #241) tries to write.
- Existing volumes are unaffected — Docker only inherits image dir metadata when the volume is empty on first mount.

Fixes #259.

## Test plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v` then `up --build` — container starts healthy on fresh volume, loads programmes, no restart loop
- [x] Mount fresh empty volume on rebuilt image — `stat` confirms volume inherits `Uid: 65534 / Gid: 65534`
- [x] `/tvguide --healthcheck` returns cleanly against the running container
- [ ] Reviewer to confirm existing prod volume continues to work after deploy (no migration expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)