### PR TITLE
Add /api/deepcheck endpoint #265

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ tvguide/
 ├── go.sum                       # Generated on first Docker build (commit after first build)
 ├── internal/
 │   ├── xmltv/parser.go          # Fetch XMLTV from URL and parse into structs
-│   ├── database/db.go           # SQLite store: schema, Refresh, GetChannels, GetAirings
+│   ├── database/db.go           # SQLite store: schema, Refresh, GetChannels, GetAirings, DeepCheck
+│   ├── deepcheck/deepcheck.go   # On-demand deep health probe (DB, disk, XMLTV reachability)
 │   └── api/                     # REST API handlers (one file per resource)
 │       ├── handler.go           # Router setup and shared middleware
 │       ├── guide.go             # GET /api/guide
@@ -31,6 +32,7 @@ tvguide/
 │       ├── explore.go           # GET /api/explore/now-next
 │       ├── rss.go               # RSS feed formatting
 │       ├── health.go            # GET /api/health
+│       ├── deepcheck.go         # GET /api/deepcheck
 │       └── debug.go             # Debug/status endpoints
 ├── web/                         # Frontend — embedded into binary via go:embed
 │   ├── index.html               # App shell (no JS framework)
@@ -77,7 +79,8 @@ tvguide/
 | `GET /images/channel/{channel-id}` | Cached channel logo. Re-downloads from upstream if the local file is missing. Returns 404 if the channel has no icon. |
 | `GET /api/explore/now-next` | For every channel, returns the currently-airing show (`current`) and the next upcoming show (`next`). Either field may be `null`. Ordered by channel sort order (lcn, then source order). |
 | `POST /api/guide/refresh` | Triggers a refresh of TV guide data. `sync=true`: waits for completion and returns `200 {"ok":true}` or `500 {"error":"..."}`. Default (async): returns `202 Accepted` immediately. |
-| `GET /api/health` | Healthcheck endpoint. Probes SQLite connectivity and FTS availability. Returns `200 {"status":"ok"}` when healthy or `500 {"error":"..."}` when unhealthy. Used by the Docker `HEALTHCHECK` instruction via the `--healthcheck` binary flag. |
+| `GET /api/health` | Healthcheck endpoint. Probes SQLite connectivity and FTS availability. Returns `200 {"status":"ok"}` when healthy or `500 {"error":"..."}` when unhealthy. Used by the Docker `HEALTHCHECK` instruction via the `--healthcheck` binary flag — this remains the Docker liveness probe and is unchanged. |
+| `GET /api/deepcheck` | Deep health check across database, FTS, data presence/freshness, XMLTV source reachability, and disk writability for `/data`, `/tmp`, and the image cache. Returns JSON `{status, checks[]}`: each entry is `{name, status, error?, info?}` with `status` one of `SUCCESS`/`FAILURE`. HTTP `200` when global status is `SUCCESS`, `503 Service Unavailable` otherwise. Every check runs independently — one failure does not skip the others. Intended for occasional on-demand diagnostics, not high-frequency probing — use `/api/health` for that. |
 | `GET /` | Serves the embedded frontend (SPA shell) |
 | `GET /{any}` | SPA fallback — serves `index.html` for any path not matching API, images, or static files. Enables client-side routing via History API. |
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -104,7 +104,7 @@ func newIntegrationServer(t *testing.T, xmltvURL string) *httptest.Server {
 	populateDB(t, db, &http.Client{}, xmltvURL+"/xmltv")
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0, nil)
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	webSub, err := fs.Sub(webFS, "web")
@@ -684,7 +684,7 @@ func TestIntegration_ChannelIconProxy(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	api.New(db, 0, nil).RegisterRoutes(mux)
+	api.New(db, 0, nil, api.DeepCheckConfig{}).RegisterRoutes(mux)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 

--- a/internal/api/deepcheck.go
+++ b/internal/api/deepcheck.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/deepcheck"
+)
+
+// deepCheckOverallTimeout caps the total time the deepcheck handler may run,
+// independent of any per-check timeouts.
+const deepCheckOverallTimeout = 15 * time.Second
+
+func (h *Handler) getDeepCheck(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), deepCheckOverallTimeout)
+	defer cancel()
+
+	checker := &deepcheck.Checker{
+		DB:            h.db,
+		HTTPClient:    h.deep.HTTPClient,
+		XMLTVURL:      h.deep.XMLTVURL,
+		PollInterval:  h.deep.PollInterval,
+		DBPath:        h.deep.DBPath,
+		ImageCacheDir: h.deep.ImageCacheDir,
+	}
+	report := checker.Run(ctx)
+	if report.Status != deepcheck.StatusSuccess {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+	writeJSON(w, report)
+}

--- a/internal/api/deepcheck_test.go
+++ b/internal/api/deepcheck_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 // newDeepCheckServer creates a test API server with seeded data and a stub
-// XMLTV upstream. xmltvSrv may be nil to point at an unreachable URL.
-func newDeepCheckServer(t *testing.T, xmltvURL string) (*httptest.Server, *database.DB, string, string) {
+// XMLTV upstream. xmltvURL is the upstream URL the deepcheck probe targets.
+func newDeepCheckServer(t *testing.T, xmltvURL string) *httptest.Server {
 	t.Helper()
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
 	imgDir := filepath.Join(dir, "images")
-	if err := os.MkdirAll(filepath.Join(imgDir, "channels"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(imgDir, "channels"), 0o750); err != nil {
 		t.Fatalf("mkdir channels: %v", err)
 	}
 	db, err := database.Open(dbPath, 7, xmltvURL, images.NewCache(&http.Client{}, imgDir), nil, nil, nil)
@@ -65,7 +65,7 @@ func newDeepCheckServer(t *testing.T, xmltvURL string) (*httptest.Server, *datab
 		srv.Close()
 		db.Close()
 	})
-	return srv, db, dbPath, imgDir
+	return srv
 }
 
 func TestDeepCheck_HappyPath_Returns200AndSuccess(t *testing.T) {
@@ -75,7 +75,7 @@ func TestDeepCheck_HappyPath_Returns200AndSuccess(t *testing.T) {
 	}))
 	t.Cleanup(upstream.Close)
 
-	srv, _, _, _ := newDeepCheckServer(t, upstream.URL)
+	srv := newDeepCheckServer(t, upstream.URL)
 
 	resp, err := httpGet(t, srv.URL+"/api/deepcheck")
 	if err != nil {
@@ -133,7 +133,7 @@ func TestDeepCheck_HappyPath_Returns200AndSuccess(t *testing.T) {
 
 func TestDeepCheck_UnreachableXMLTV_Returns503(t *testing.T) {
 	// Point at an unreachable URL (TCP port 1 is reserved).
-	srv, _, _, _ := newDeepCheckServer(t, "http://127.0.0.1:1/")
+	srv := newDeepCheckServer(t, "http://127.0.0.1:1/")
 
 	resp, err := httpGet(t, srv.URL+"/api/deepcheck")
 	if err != nil {

--- a/internal/api/deepcheck_test.go
+++ b/internal/api/deepcheck_test.go
@@ -1,0 +1,182 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/api"
+	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/images"
+	"github.com/acbgbca/xmltvguide/internal/xmltv"
+)
+
+// newDeepCheckServer creates a test API server with seeded data and a stub
+// XMLTV upstream. xmltvSrv may be nil to point at an unreachable URL.
+func newDeepCheckServer(t *testing.T, xmltvURL string) (*httptest.Server, *database.DB, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	imgDir := filepath.Join(dir, "images")
+	if err := os.MkdirAll(filepath.Join(imgDir, "channels"), 0o755); err != nil {
+		t.Fatalf("mkdir channels: %v", err)
+	}
+	db, err := database.Open(dbPath, 7, xmltvURL, images.NewCache(&http.Client{}, imgDir), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	// Seed some data so data_presence passes.
+	base := time.Now().UTC().Truncate(24 * time.Hour)
+	tv := &xmltv.TV{
+		Channels: []xmltv.Channel{
+			{ID: "ch1", DisplayNames: []xmltv.Name{{Value: "ABC"}}},
+		},
+		Programmes: []xmltv.Programme{
+			{
+				Start:   xmltv.XmltvTime{Time: base.Add(6 * time.Hour)},
+				Stop:    xmltv.XmltvTime{Time: base.Add(7 * time.Hour)},
+				Channel: "ch1",
+				Titles:  []xmltv.Name{{Value: "Morning News"}},
+			},
+		},
+	}
+	if err := db.Refresh(context.Background(), tv, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{
+		HTTPClient:    &http.Client{Timeout: 10 * time.Second},
+		XMLTVURL:      xmltvURL,
+		PollInterval:  12 * time.Hour,
+		DBPath:        dbPath,
+		ImageCacheDir: imgDir,
+	})
+	handler.RegisterRoutes(mux)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		srv.Close()
+		db.Close()
+	})
+	return srv, db, dbPath, imgDir
+}
+
+func TestDeepCheck_HappyPath_Returns200AndSuccess(t *testing.T) {
+	// Spin up a reachable XMLTV source that responds 200 to HEAD.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	srv, _, _, _ := newDeepCheckServer(t, upstream.URL)
+
+	resp, err := httpGet(t, srv.URL+"/api/deepcheck")
+	if err != nil {
+		t.Fatalf("GET /api/deepcheck: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var body struct {
+		Status string `json:"status"`
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Error  string `json:"error,omitempty"`
+			Info   string `json:"info,omitempty"`
+		} `json:"checks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Status != "SUCCESS" {
+		t.Errorf("global status = %q, want SUCCESS; body=%+v", body.Status, body)
+	}
+
+	wantOrder := []string{
+		"database",
+		"database_writable",
+		"fts",
+		"data_presence",
+		"data_freshness",
+		"xmltv_url",
+		"disk_data",
+		"disk_tmp",
+		"image_cache",
+	}
+	if len(body.Checks) != len(wantOrder) {
+		t.Fatalf("got %d checks, want %d (%+v)", len(body.Checks), len(wantOrder), body.Checks)
+	}
+	for i, want := range wantOrder {
+		if body.Checks[i].Name != want {
+			t.Errorf("checks[%d].Name = %q, want %q", i, body.Checks[i].Name, want)
+		}
+		if body.Checks[i].Status != "SUCCESS" {
+			t.Errorf("checks[%d] %s status = %q, want SUCCESS (error=%q)",
+				i, body.Checks[i].Name, body.Checks[i].Status, body.Checks[i].Error)
+		}
+	}
+}
+
+func TestDeepCheck_UnreachableXMLTV_Returns503(t *testing.T) {
+	// Point at an unreachable URL (TCP port 1 is reserved).
+	srv, _, _, _ := newDeepCheckServer(t, "http://127.0.0.1:1/")
+
+	resp, err := httpGet(t, srv.URL+"/api/deepcheck")
+	if err != nil {
+		t.Fatalf("GET /api/deepcheck: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Status string `json:"status"`
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Error  string `json:"error,omitempty"`
+		} `json:"checks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Status != "FAILURE" {
+		t.Errorf("global status = %q, want FAILURE", body.Status)
+	}
+
+	// All checks should be present even when xmltv_url fails.
+	if len(body.Checks) != 9 {
+		t.Errorf("expected 9 checks, got %d", len(body.Checks))
+	}
+	var xmltv *struct {
+		Name, Status, Error string
+	}
+	for _, c := range body.Checks {
+		if c.Name == "xmltv_url" {
+			xmltv = &struct{ Name, Status, Error string }{c.Name, c.Status, c.Error}
+			break
+		}
+	}
+	if xmltv == nil {
+		t.Fatalf("xmltv_url check not found in response")
+	}
+	if xmltv.Status != "FAILURE" {
+		t.Errorf("xmltv_url status = %q, want FAILURE", xmltv.Status)
+	}
+}

--- a/internal/api/guide_refresh_test.go
+++ b/internal/api/guide_refresh_test.go
@@ -24,7 +24,7 @@ func newRefreshServer(t *testing.T, refreshFn func() error) *httptest.Server {
 		t.Fatalf("Open: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
-	h := api.New(db, 0, refreshFn)
+	h := api.New(db, 0, refreshFn, api.DeepCheckConfig{})
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 	srv := httptest.NewServer(mux)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/acbgbca/xmltvguide/internal/deepcheck"
 	"github.com/acbgbca/xmltvguide/internal/model"
 )
 
@@ -21,6 +22,17 @@ type store interface {
 	GetCategories(ctx context.Context) ([]string, error)
 	GetNowNext(ctx context.Context) ([]model.NowNextEntry, error)
 	Ping(ctx context.Context) error
+	DeepCheck(ctx context.Context) deepcheck.DBCheckResults
+}
+
+// DeepCheckConfig bundles the deepcheck-specific dependencies for the Handler
+// constructor so the signature stays manageable.
+type DeepCheckConfig struct {
+	HTTPClient    *http.Client
+	XMLTVURL      string
+	PollInterval  time.Duration
+	DBPath        string
+	ImageCacheDir string
 }
 
 // Handler holds the HTTP handler dependencies.
@@ -28,14 +40,16 @@ type Handler struct {
 	db        store
 	rssTTL    int          // default RSS TTL in minutes; 0 means use hard-coded default (360)
 	refreshFn func() error // optional; nil means refresh endpoint returns 501
+	deep      DeepCheckConfig
 }
 
 // New creates a new Handler backed by db. rssTTL is the server-wide default
 // RSS feed TTL in minutes (from the RSS_TTL env var); pass 0 to use the
 // hard-coded default of 360 minutes. refreshFn is called by POST /api/guide/refresh;
-// pass nil to disable the endpoint.
-func New(db store, rssTTL int, refreshFn func() error) *Handler {
-	return &Handler{db: db, rssTTL: rssTTL, refreshFn: refreshFn}
+// pass nil to disable the endpoint. deepCfg supplies the dependencies needed
+// by the /api/deepcheck endpoint.
+func New(db store, rssTTL int, refreshFn func() error, deepCfg DeepCheckConfig) *Handler {
+	return &Handler{db: db, rssTTL: rssTTL, refreshFn: refreshFn, deep: deepCfg}
 }
 
 // RegisterRoutes adds all API routes to mux.
@@ -50,6 +64,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/debug/log", h.postDebugLog)
 	mux.HandleFunc("POST /api/guide/refresh", h.postGuideRefresh)
 	mux.HandleFunc("GET /api/health", h.getHealth)
+	mux.HandleFunc("GET /api/deepcheck", h.getDeepCheck)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -84,7 +84,7 @@ func newSeededServer(t *testing.T) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0, nil)
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -124,7 +124,7 @@ func newSeededServerWithIcons(t *testing.T, iconSrv *httptest.Server) (*httptest
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0, nil)
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -499,7 +499,7 @@ func newSearchSeededServer(t *testing.T) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0, nil)
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -794,7 +794,7 @@ func TestCategories_EmptyWhenNoData(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0, nil)
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -869,7 +869,7 @@ func TestSearch_AiringsOrderedByStartTime(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0, nil)
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -970,7 +970,7 @@ func TestSearch_TodayFilter_ExcludesTomorrow(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0, nil)
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -1071,7 +1071,7 @@ func TestSearch_TodayFilter_AdvancedMode(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0, nil)
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -1207,7 +1207,7 @@ func newBrowseSeededServer(t *testing.T) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0, nil)
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -1483,7 +1483,7 @@ func newRSSSeededServer(t *testing.T, rssTTL int) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, rssTTL, nil)
+	handler := api.New(db, rssTTL, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)
@@ -2034,7 +2034,7 @@ func newNowNextServer(t *testing.T) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	handler := api.New(db, 0, nil)
+	handler := api.New(db, 0, nil, api.DeepCheckConfig{})
 	handler.RegisterRoutes(mux)
 
 	srv := httptest.NewServer(mux)

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -12,6 +12,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
+	"github.com/acbgbca/xmltvguide/internal/deepcheck"
 	"github.com/acbgbca/xmltvguide/internal/images"
 	"github.com/acbgbca/xmltvguide/internal/model"
 )
@@ -287,6 +288,53 @@ func (d *DB) SetNextRefresh(t time.Time) {
 func (d *DB) Ping(ctx context.Context) error {
 	_, err := d.db.ExecContext(ctx, `SELECT 1 FROM airings_fts LIMIT 1`)
 	return err
+}
+
+// DeepCheck gathers the data the deepcheck package needs to report on the
+// database layer: a write probe, an FTS probe, row counts, and the last
+// refresh timestamp. Per-field errors are stored in the result rather than
+// returned, so the caller can render every check independently.
+func (d *DB) DeepCheck(ctx context.Context) deepcheck.DBCheckResults {
+	var res deepcheck.DBCheckResults
+
+	// Writable probe: create a throwaway table inside a rolled-back transaction.
+	if err := func() error {
+		tx, err := d.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = tx.Rollback() }()
+		if _, err := tx.ExecContext(ctx, `CREATE TABLE _deepcheck_probe(x INTEGER)`); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO _deepcheck_probe(x) VALUES (1)`); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `DROP TABLE _deepcheck_probe`); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		res.WritableErr = err
+	}
+
+	// FTS probe.
+	if _, err := d.db.ExecContext(ctx, `SELECT 1 FROM airings_fts LIMIT 1`); err != nil {
+		res.FTSErr = err
+	}
+
+	// Row counts.
+	if err := d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM channels`).Scan(&res.ChannelCount); err != nil {
+		res.ChannelCountErr = err
+	}
+	if err := d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM airings`).Scan(&res.AiringCount); err != nil {
+		res.AiringCountErr = err
+	}
+
+	// Last refresh — read through the mutex via GetStatus.
+	res.LastRefresh = d.GetStatus().LastRefresh
+
+	return res
 }
 
 // Close closes the underlying database connection.

--- a/internal/deepcheck/deepcheck.go
+++ b/internal/deepcheck/deepcheck.go
@@ -1,0 +1,267 @@
+// Package deepcheck performs an on-demand, comprehensive health probe across
+// the database, storage, XMLTV source reachability, and data freshness.
+package deepcheck
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// CheckStatus is the SUCCESS/FAILURE indicator for a single check or the
+// overall report.
+type CheckStatus string
+
+const (
+	StatusSuccess CheckStatus = "SUCCESS"
+	StatusFailure CheckStatus = "FAILURE"
+)
+
+// xmltvProbeTimeout is the per-request timeout applied to the XMLTV upstream
+// HEAD/GET probe so a slow source cannot stall the whole endpoint.
+const xmltvProbeTimeout = 5 * time.Second
+
+// CheckResult is the outcome of a single named check.
+type CheckResult struct {
+	Name   string      `json:"name"`
+	Status CheckStatus `json:"status"`
+	Error  string      `json:"error,omitempty"`
+	Info   string      `json:"info,omitempty"`
+}
+
+// Report aggregates the results of all checks plus a top-level status.
+type Report struct {
+	Status CheckStatus   `json:"status"`
+	Checks []CheckResult `json:"checks"`
+}
+
+// DBProbe is the narrow interface deepcheck needs from the database layer.
+type DBProbe interface {
+	Ping(ctx context.Context) error
+	DeepCheck(ctx context.Context) DBCheckResults
+}
+
+// DBCheckResults holds the data the DB layer can gather. Per-field errors are
+// stored so the caller can render every check independently — DBCheckResults
+// itself never carries a fatal error.
+type DBCheckResults struct {
+	WritableErr     error
+	FTSErr          error
+	ChannelCount    int
+	AiringCount     int
+	LastRefresh     time.Time
+	ChannelCountErr error
+	AiringCountErr  error
+}
+
+// Checker runs the suite of deep checks.
+type Checker struct {
+	DB            DBProbe
+	HTTPClient    *http.Client
+	XMLTVURL      string
+	PollInterval  time.Duration
+	DBPath        string
+	ImageCacheDir string
+	Now           func() time.Time
+}
+
+// Run executes every check in order and returns the aggregated report. One
+// failing check never stops subsequent checks from running.
+func (c *Checker) Run(ctx context.Context) Report {
+	now := c.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	checks := make([]CheckResult, 0, 9)
+
+	// 1. database — SELECT 1 via Ping.
+	checks = append(checks, runCheck("database", func() (string, error) {
+		return "", c.DB.Ping(ctx)
+	}))
+
+	// Pull the bulk DB results once; they cover the next 4 checks.
+	dbResults := c.DB.DeepCheck(ctx)
+
+	// 2. database_writable
+	checks = append(checks, runCheck("database_writable", func() (string, error) {
+		return "", dbResults.WritableErr
+	}))
+
+	// 3. fts
+	checks = append(checks, runCheck("fts", func() (string, error) {
+		return "", dbResults.FTSErr
+	}))
+
+	// 4. data_presence
+	checks = append(checks, runCheck("data_presence", func() (string, error) {
+		if dbResults.ChannelCountErr != nil {
+			return "", fmt.Errorf("channels: %w", dbResults.ChannelCountErr)
+		}
+		if dbResults.AiringCountErr != nil {
+			return "", fmt.Errorf("airings: %w", dbResults.AiringCountErr)
+		}
+		if dbResults.ChannelCount == 0 {
+			return "", fmt.Errorf("no channels in database")
+		}
+		if dbResults.AiringCount == 0 {
+			return "", fmt.Errorf("no airings in database")
+		}
+		return "", nil
+	}))
+
+	// 5. data_freshness
+	checks = append(checks, runCheck("data_freshness", func() (string, error) {
+		if dbResults.LastRefresh.IsZero() {
+			return "", fmt.Errorf("no refresh has completed yet")
+		}
+		threshold := 2 * c.PollInterval
+		age := now().Sub(dbResults.LastRefresh)
+		if age > threshold {
+			return "", fmt.Errorf("last refresh %s ago exceeds %s", age.Truncate(time.Second), threshold)
+		}
+		return "", nil
+	}))
+
+	// 6. xmltv_url
+	checks = append(checks, c.probeXMLTV(ctx))
+
+	// 7. disk_data — stat parent of DBPath, then write-probe.
+	checks = append(checks, probeDisk("disk_data", filepath.Dir(c.DBPath)))
+
+	// 8. disk_tmp
+	checks = append(checks, probeDisk("disk_tmp", os.TempDir()))
+
+	// 9. image_cache — write-probe in IMAGE_CACHE_DIR/channels.
+	checks = append(checks, writeProbe("image_cache", filepath.Join(c.ImageCacheDir, "channels")))
+
+	overall := StatusSuccess
+	for _, r := range checks {
+		if r.Status != StatusSuccess {
+			overall = StatusFailure
+			break
+		}
+	}
+	return Report{Status: overall, Checks: checks}
+}
+
+// runCheck wraps a probe function and turns the (info, err) result into a
+// CheckResult with the supplied name.
+func runCheck(name string, fn func() (string, error)) CheckResult {
+	info, err := fn()
+	if err != nil {
+		return CheckResult{Name: name, Status: StatusFailure, Error: err.Error(), Info: info}
+	}
+	return CheckResult{Name: name, Status: StatusSuccess, Info: info}
+}
+
+// probeXMLTV issues a HEAD request to c.XMLTVURL with a fresh 5s timeout. On
+// a 405 Method Not Allowed response, it falls back to a single GET with
+// Range: bytes=0-0. Final response status outside 2xx/3xx is a failure.
+func (c *Checker) probeXMLTV(parent context.Context) CheckResult {
+	const name = "xmltv_url"
+	ctx, cancel := context.WithTimeout(parent, xmltvProbeTimeout)
+	defer cancel()
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	wrapErr := func(method string, err error) error {
+		return fmt.Errorf("%s %s: %w", method, c.XMLTVURL, err)
+	}
+	wrapStatus := func(method string, status int) error {
+		return fmt.Errorf("%s %s: unexpected status %d", method, c.XMLTVURL, status)
+	}
+
+	doRequest := func(method string, headers map[string]string) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, method, c.XMLTVURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		return client.Do(req)
+	}
+
+	resp, err := doRequest(http.MethodHead, nil)
+	if err != nil {
+		return CheckResult{Name: name, Status: StatusFailure, Error: wrapErr(http.MethodHead, err).Error()}
+	}
+	// Drain and close to allow connection reuse, then decide.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	method := http.MethodHead
+	status := resp.StatusCode
+
+	if status == http.StatusMethodNotAllowed {
+		// Fallback to GET with Range header to minimise bytes transferred.
+		resp2, err2 := doRequest(http.MethodGet, map[string]string{"Range": "bytes=0-0"})
+		if err2 != nil {
+			return CheckResult{Name: name, Status: StatusFailure, Error: wrapErr(http.MethodGet, err2).Error()}
+		}
+		_, _ = io.Copy(io.Discard, resp2.Body)
+		_ = resp2.Body.Close()
+		method = http.MethodGet
+		status = resp2.StatusCode
+	}
+
+	if status < 200 || status >= 400 {
+		return CheckResult{Name: name, Status: StatusFailure, Error: wrapStatus(method, status).Error()}
+	}
+	return CheckResult{Name: name, Status: StatusSuccess}
+}
+
+// probeDisk stats the directory, reports its mode+uid in Info, then performs
+// a write probe.
+func probeDisk(name, dir string) CheckResult {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return CheckResult{Name: name, Status: StatusFailure, Error: fmt.Sprintf("stat %s: %s", dir, err.Error())}
+	}
+	info := fmt.Sprintf("mode=%04o uid=%s", fi.Mode().Perm()|fi.Mode()&os.ModeSticky, statUID(fi))
+	wp := writeProbe(name, dir)
+	if wp.Status != StatusSuccess {
+		wp.Info = info
+		return wp
+	}
+	wp.Info = info
+	return wp
+}
+
+// writeProbe creates a temp file in dir, writes a byte, then removes it.
+// Always attempts to Remove, even when the write fails.
+func writeProbe(name, dir string) CheckResult {
+	f, err := os.CreateTemp(dir, ".deepcheck-*")
+	if err != nil {
+		return CheckResult{Name: name, Status: StatusFailure, Error: fmt.Sprintf("create %s: %s", dir, err.Error())}
+	}
+	path := f.Name()
+	_, writeErr := f.Write([]byte{0})
+	_ = f.Close()
+	removeErr := os.Remove(path)
+	if writeErr != nil {
+		return CheckResult{Name: name, Status: StatusFailure, Error: fmt.Sprintf("write %s: %s", dir, writeErr.Error())}
+	}
+	if removeErr != nil {
+		return CheckResult{Name: name, Status: StatusFailure, Error: fmt.Sprintf("remove %s: %s", dir, removeErr.Error())}
+	}
+	return CheckResult{Name: name, Status: StatusSuccess}
+}
+
+// statUID returns the numeric owner UID of fi as a string. On platforms that
+// don't expose syscall.Stat_t, returns "?".
+func statUID(fi os.FileInfo) string {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return fmt.Sprintf("%d", st.Uid)
+	}
+	return "?"
+}

--- a/internal/deepcheck/deepcheck_test.go
+++ b/internal/deepcheck/deepcheck_test.go
@@ -52,7 +52,7 @@ func newChecker(t *testing.T, db DBProbe, xmltvURL string, now time.Time) *Check
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "tvguide.db")
 	imgDir := filepath.Join(dir, "images")
-	if err := os.MkdirAll(filepath.Join(imgDir, "channels"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(imgDir, "channels"), 0o750); err != nil {
 		t.Fatalf("mkdir imgDir: %v", err)
 	}
 	return &Checker{

--- a/internal/deepcheck/deepcheck_test.go
+++ b/internal/deepcheck/deepcheck_test.go
@@ -1,0 +1,444 @@
+package deepcheck
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeDB implements DBProbe for tests. Behaviour is configured per-test.
+type fakeDB struct {
+	pingErr     error
+	deepResults DBCheckResults
+}
+
+func (f *fakeDB) Ping(ctx context.Context) error               { return f.pingErr }
+func (f *fakeDB) DeepCheck(ctx context.Context) DBCheckResults { return f.deepResults }
+
+// healthyDB returns a fakeDB with all DB-related checks succeeding.
+func healthyDB(now time.Time) *fakeDB {
+	return &fakeDB{
+		deepResults: DBCheckResults{
+			ChannelCount: 5,
+			AiringCount:  100,
+			LastRefresh:  now.Add(-1 * time.Hour),
+		},
+	}
+}
+
+// successHEADServer returns 200 for HEAD requests.
+func successHEADServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newChecker(t *testing.T, db DBProbe, xmltvURL string, now time.Time) *Checker {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "tvguide.db")
+	imgDir := filepath.Join(dir, "images")
+	if err := os.MkdirAll(filepath.Join(imgDir, "channels"), 0o755); err != nil {
+		t.Fatalf("mkdir imgDir: %v", err)
+	}
+	return &Checker{
+		DB:            db,
+		HTTPClient:    http.DefaultClient,
+		XMLTVURL:      xmltvURL,
+		PollInterval:  12 * time.Hour,
+		DBPath:        dbPath,
+		ImageCacheDir: imgDir,
+		Now:           func() time.Time { return now },
+	}
+}
+
+func findCheck(t *testing.T, r Report, name string) CheckResult {
+	t.Helper()
+	for _, c := range r.Checks {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("check %q not found in report; checks=%+v", name, r.Checks)
+	return CheckResult{}
+}
+
+func TestRun_AllSuccess(t *testing.T) {
+	now := time.Now()
+	srv := successHEADServer(t)
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+
+	rep := c.Run(context.Background())
+
+	if rep.Status != StatusSuccess {
+		t.Errorf("global status = %q, want SUCCESS; report=%+v", rep.Status, rep)
+	}
+	wantOrder := []string{
+		"database",
+		"database_writable",
+		"fts",
+		"data_presence",
+		"data_freshness",
+		"xmltv_url",
+		"disk_data",
+		"disk_tmp",
+		"image_cache",
+	}
+	if len(rep.Checks) != len(wantOrder) {
+		t.Fatalf("got %d checks, want %d (%v)", len(rep.Checks), len(wantOrder), rep.Checks)
+	}
+	for i, want := range wantOrder {
+		if rep.Checks[i].Name != want {
+			t.Errorf("checks[%d].Name = %q, want %q", i, rep.Checks[i].Name, want)
+		}
+		if rep.Checks[i].Status != StatusSuccess {
+			t.Errorf("checks[%d] %s status = %q, want SUCCESS (error=%q)",
+				i, rep.Checks[i].Name, rep.Checks[i].Status, rep.Checks[i].Error)
+		}
+	}
+}
+
+func TestRun_PingFailure_DatabaseFails(t *testing.T) {
+	now := time.Now()
+	db := healthyDB(now)
+	db.pingErr = errors.New("boom")
+	srv := successHEADServer(t)
+	c := newChecker(t, db, srv.URL, now)
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "database")
+	if check.Status != StatusFailure {
+		t.Errorf("database status = %q, want FAILURE", check.Status)
+	}
+	if !strings.Contains(check.Error, "boom") {
+		t.Errorf("database error = %q, want to contain %q", check.Error, "boom")
+	}
+	if rep.Status != StatusFailure {
+		t.Errorf("global status = %q, want FAILURE", rep.Status)
+	}
+}
+
+func TestRun_WritableErr_DatabaseWritableFails(t *testing.T) {
+	now := time.Now()
+	db := healthyDB(now)
+	db.deepResults.WritableErr = errors.New("readonly")
+	srv := successHEADServer(t)
+	c := newChecker(t, db, srv.URL, now)
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "database_writable")
+	if check.Status != StatusFailure {
+		t.Errorf("database_writable status = %q, want FAILURE", check.Status)
+	}
+	if !strings.Contains(check.Error, "readonly") {
+		t.Errorf("database_writable error = %q", check.Error)
+	}
+}
+
+func TestRun_FTSErr_FTSFails(t *testing.T) {
+	now := time.Now()
+	db := healthyDB(now)
+	db.deepResults.FTSErr = errors.New("no fts")
+	srv := successHEADServer(t)
+	c := newChecker(t, db, srv.URL, now)
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "fts")
+	if check.Status != StatusFailure {
+		t.Errorf("fts status = %q, want FAILURE", check.Status)
+	}
+}
+
+func TestRun_DataPresence_FailsOnZeroChannels(t *testing.T) {
+	now := time.Now()
+	db := healthyDB(now)
+	db.deepResults.ChannelCount = 0
+	srv := successHEADServer(t)
+	c := newChecker(t, db, srv.URL, now)
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "data_presence")
+	if check.Status != StatusFailure {
+		t.Errorf("data_presence status = %q, want FAILURE", check.Status)
+	}
+}
+
+func TestRun_DataPresence_FailsOnZeroAirings(t *testing.T) {
+	now := time.Now()
+	db := healthyDB(now)
+	db.deepResults.AiringCount = 0
+	srv := successHEADServer(t)
+	c := newChecker(t, db, srv.URL, now)
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "data_presence")
+	if check.Status != StatusFailure {
+		t.Errorf("data_presence status = %q, want FAILURE", check.Status)
+	}
+}
+
+func TestRun_DataPresence_FailsOnCountError(t *testing.T) {
+	now := time.Now()
+	db := healthyDB(now)
+	db.deepResults.ChannelCountErr = errors.New("query fail")
+	srv := successHEADServer(t)
+	c := newChecker(t, db, srv.URL, now)
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "data_presence")
+	if check.Status != StatusFailure {
+		t.Errorf("data_presence status = %q, want FAILURE", check.Status)
+	}
+}
+
+func TestRun_DataFreshness_FailsOnZeroLastRefresh(t *testing.T) {
+	now := time.Now()
+	db := healthyDB(now)
+	db.deepResults.LastRefresh = time.Time{}
+	srv := successHEADServer(t)
+	c := newChecker(t, db, srv.URL, now)
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "data_freshness")
+	if check.Status != StatusFailure {
+		t.Errorf("data_freshness status = %q, want FAILURE", check.Status)
+	}
+}
+
+func TestRun_DataFreshness_BoundaryAtTwiceInterval(t *testing.T) {
+	now := time.Now()
+	srv := successHEADServer(t)
+
+	// pollInterval = 12h, so threshold is 24h.
+	// just within (23h ago) → SUCCESS
+	db := healthyDB(now)
+	db.deepResults.LastRefresh = now.Add(-23 * time.Hour)
+	c := newChecker(t, db, srv.URL, now)
+	rep := c.Run(context.Background())
+	if findCheck(t, rep, "data_freshness").Status != StatusSuccess {
+		t.Errorf("23h-old refresh: data_freshness should be SUCCESS")
+	}
+
+	// just outside (25h ago) → FAILURE
+	db2 := healthyDB(now)
+	db2.deepResults.LastRefresh = now.Add(-25 * time.Hour)
+	c2 := newChecker(t, db2, srv.URL, now)
+	rep2 := c2.Run(context.Background())
+	if findCheck(t, rep2, "data_freshness").Status != StatusFailure {
+		t.Errorf("25h-old refresh: data_freshness should be FAILURE")
+	}
+}
+
+func TestRun_XMLTVURL_SuccessOnHEAD200(t *testing.T) {
+	now := time.Now()
+	srv := successHEADServer(t)
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "xmltv_url")
+	if check.Status != StatusSuccess {
+		t.Errorf("xmltv_url status = %q, want SUCCESS (err=%q)", check.Status, check.Error)
+	}
+}
+
+func TestRun_XMLTVURL_FallbackToGETOn405(t *testing.T) {
+	now := time.Now()
+	var headCalls, getCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		case http.MethodGet:
+			getCalls.Add(1)
+			// Validate Range header presence.
+			if r.Header.Get("Range") == "" {
+				t.Errorf("GET fallback should set Range header")
+			}
+			w.WriteHeader(http.StatusPartialContent)
+			w.Write([]byte("x"))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "xmltv_url")
+	if check.Status != StatusSuccess {
+		t.Errorf("xmltv_url status = %q, want SUCCESS (err=%q)", check.Status, check.Error)
+	}
+	if headCalls.Load() != 1 {
+		t.Errorf("HEAD called %d times, want 1", headCalls.Load())
+	}
+	if getCalls.Load() != 1 {
+		t.Errorf("GET called %d times, want 1", getCalls.Load())
+	}
+}
+
+func TestRun_XMLTVURL_FailureOn500(t *testing.T) {
+	now := time.Now()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "xmltv_url")
+	if check.Status != StatusFailure {
+		t.Errorf("xmltv_url status = %q, want FAILURE", check.Status)
+	}
+}
+
+func TestRun_XMLTVURL_FailureOnConnRefused(t *testing.T) {
+	now := time.Now()
+	// Use a URL we know cannot connect.
+	c := newChecker(t, healthyDB(now), "http://127.0.0.1:1/", now)
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "xmltv_url")
+	if check.Status != StatusFailure {
+		t.Errorf("xmltv_url status = %q, want FAILURE", check.Status)
+	}
+	if check.Error == "" {
+		t.Errorf("xmltv_url should have an error message on failure")
+	}
+}
+
+func TestRun_DiskData_ReportsModeAndUID(t *testing.T) {
+	now := time.Now()
+	srv := successHEADServer(t)
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "disk_data")
+	if check.Status != StatusSuccess {
+		t.Errorf("disk_data status = %q, want SUCCESS (err=%q)", check.Status, check.Error)
+	}
+	if !strings.Contains(check.Info, "mode=") || !strings.Contains(check.Info, "uid=") {
+		t.Errorf("disk_data info = %q, want mode=... uid=...", check.Info)
+	}
+}
+
+func TestRun_DiskData_FailsWhenParentMissing(t *testing.T) {
+	now := time.Now()
+	srv := successHEADServer(t)
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	// Point DBPath to a non-existent directory.
+	c.DBPath = filepath.Join(t.TempDir(), "does-not-exist", "tvguide.db")
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "disk_data")
+	if check.Status != StatusFailure {
+		t.Errorf("disk_data status = %q, want FAILURE", check.Status)
+	}
+}
+
+func TestRun_ImageCache_FailsWhenDirMissing(t *testing.T) {
+	now := time.Now()
+	srv := successHEADServer(t)
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	c.ImageCacheDir = filepath.Join(t.TempDir(), "no-such-dir")
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "image_cache")
+	if check.Status != StatusFailure {
+		t.Errorf("image_cache status = %q, want FAILURE", check.Status)
+	}
+}
+
+func TestRun_AllChecksRun_EvenWhenOneFails(t *testing.T) {
+	// One failure should not short-circuit subsequent checks.
+	now := time.Now()
+	db := healthyDB(now)
+	db.deepResults.FTSErr = errors.New("no fts")
+	srv := successHEADServer(t)
+	c := newChecker(t, db, srv.URL, now)
+
+	rep := c.Run(context.Background())
+	if len(rep.Checks) != 9 {
+		t.Fatalf("expected 9 checks, got %d (%+v)", len(rep.Checks), rep.Checks)
+	}
+	// All non-fts checks should still be SUCCESS.
+	for _, c := range rep.Checks {
+		if c.Name == "fts" {
+			if c.Status != StatusFailure {
+				t.Errorf("fts should be FAILURE")
+			}
+		} else {
+			if c.Status != StatusSuccess {
+				t.Errorf("%s status = %q, want SUCCESS (err=%q)", c.Name, c.Status, c.Error)
+			}
+		}
+	}
+	if rep.Status != StatusFailure {
+		t.Errorf("global status should be FAILURE when any check fails")
+	}
+}
+
+func TestRun_ErrorMessageContainsURLPrefix(t *testing.T) {
+	// Errors should be wrapped with a useful prefix.
+	now := time.Now()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "xmltv_url")
+	if !strings.Contains(check.Error, srv.URL) {
+		t.Errorf("xmltv_url error %q should reference URL %q", check.Error, srv.URL)
+	}
+}
+
+// TestRun_XMLTVURL_RespectsPerRequestTimeout uses a server that never responds
+// to verify the per-request 5s timeout is honoured (we set Now to make tests
+// run quickly using a Checker-internal short timeout — the implementation uses
+// 5s so we cap our wait at 8s).
+func TestRun_XMLTVURL_RespectsPerRequestTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	now := time.Now()
+	// Use a TCP listener that accepts but never responds.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(20 * time.Second):
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+
+	start := time.Now()
+	rep := c.Run(context.Background())
+	elapsed := time.Since(start)
+
+	check := findCheck(t, rep, "xmltv_url")
+	if check.Status != StatusFailure {
+		t.Errorf("xmltv_url status = %q, want FAILURE (timeout)", check.Status)
+	}
+	if elapsed > 10*time.Second {
+		t.Errorf("xmltv_url took %s, expected ~5s timeout", elapsed)
+	}
+}
+
+// Compile-time guard that fakeDB implements DBProbe.
+var _ DBProbe = (*fakeDB)(nil)

--- a/main.go
+++ b/main.go
@@ -142,6 +142,12 @@ func run(cfg config) error {
 
 	apiHandler := api.New(db, cfg.rssTTL, func() error {
 		return refresh(db, httpClient, cfg.xmltvURL, cfg.pollInterval)
+	}, api.DeepCheckConfig{
+		HTTPClient:    httpClient,
+		XMLTVURL:      cfg.xmltvURL,
+		PollInterval:  cfg.pollInterval,
+		DBPath:        cfg.dbPath,
+		ImageCacheDir: cfg.imageCacheDir,
 	})
 	apiHandler.RegisterRoutes(mux)
 

--- a/wiremock/mappings/xmltv-head.json
+++ b/wiremock/mappings/xmltv-head.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "method": "HEAD",
+    "url": "/guide.xml"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "text/xml; charset=UTF-8"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/deepcheck` — an on-demand deep health probe across the database (ping, writable tx, FTS, data presence, data freshness), XMLTV upstream reachability (HEAD with GET-on-405 fallback, 5 s per-request timeout), and disk writability (`/data` parent, `/tmp`, image cache). Returns 200 on full success, 503 on any failure. Every check always runs so the full report is emitted.
- New `internal/deepcheck` package owns the check logic; new `DeepCheck(ctx)` method on `*database.DB` returns row counts, write/FTS probe errors, and `lastRefresh` (read via the existing mutex). `api.New` gains a `DeepCheckConfig` value struct.
- `/api/health` is unchanged and remains the Docker liveness probe.
- WireMock dev stub: added a HEAD mapping for `/guide.xml` so `make dev` reports `xmltv_url=SUCCESS`.

Closes #265.

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] New unit tests cover each check independently (fake `DBProbe`, `httptest.Server`, `t.TempDir()`) including HEAD→GET fallback on 405, data-freshness boundary at 2×poll, and unreachable XMLTV
- [x] New end-to-end API tests cover happy path (200 + global `SUCCESS`) and unreachable XMLTV (503 + global `FAILURE`, all 9 checks present)
- [ ] Manual smoke: `make dev` → curl `/api/deepcheck` returns `{"status":"SUCCESS", ...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)