### PR TITLE
Add 'Run system check' button to Settings → Advanced (#266)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ The app uses a bottom navigation bar (iOS-style) with four tabs:
 | Guide | `/` or `/guide` | The main TV guide grid (default) |
 | Search | `/search` | Search for programmes by title or with advanced filters |
 | Favourites | `/favourites` | Saved search favourites — shows upcoming airings for all saved searches |
-| Settings | `/settings` | Channels section (visibility/favourite toggles) and an Advanced section (collapsible) containing Refresh guide, Status info (last/next refresh + source URL from `/api/status`, fetched lazily on first expand), and Reset preferences (clears `tvguide-prefs` and `tvguide-favourites` from `localStorage` after a `window.confirm`, then reloads the page) |
+| Settings | `/settings` | Channels section (visibility/favourite toggles) and an Advanced section (collapsible) containing Refresh guide, Status info (last/next refresh + source URL from `/api/status`, fetched lazily on first expand), Run system check (calls `/api/deepcheck` and renders per-check results inline; the panel is cleared when the accordion collapses), and Reset preferences (clears `tvguide-prefs` and `tvguide-favourites` from `localStorage` after a `window.confirm`, then reloads the page) |
 | Explore | `/explore` | Browse TV by mode: Now/Next (default), Categories, Premieres, Time Slot |
 
 Navigation uses the **History API** (`pushState`/`popstate`) for client-side routing without full page reloads. The top bar (date display + prev/next day buttons) is only visible on the Guide tab. The Guide tab preserves its `?date=YYYY-MM-DD` query parameter behaviour.

--- a/e2e/pages/SettingsPage.ts
+++ b/e2e/pages/SettingsPage.ts
@@ -44,7 +44,7 @@ export class SettingsPage extends AppPage {
   }
 
   refreshSpinner(): Locator {
-    return this.page.locator('.settings-action-row .loading-spinner');
+    return this.page.locator('.settings-action-refresh-wrap .loading-spinner');
   }
 
   refreshStatus(): Locator {
@@ -81,6 +81,38 @@ export class SettingsPage extends AppPage {
 
   async clickReset(): Promise<void> {
     await this.resetButton().click();
+  }
+
+  // Deep / system check action
+  deepCheckButton(): Locator {
+    return this.page.locator('.settings-action-deepcheck');
+  }
+
+  deepCheckSpinner(): Locator {
+    return this.page
+      .locator('.settings-action-deepcheck-wrap .loading-spinner');
+  }
+
+  deepCheckResults(): Locator {
+    return this.page.locator('.settings-deepcheck-results');
+  }
+
+  deepCheckSummary(): Locator {
+    return this.page.locator('.settings-deepcheck-summary');
+  }
+
+  deepCheckRows(): Locator {
+    return this.page.locator('.settings-deepcheck-row');
+  }
+
+  deepCheckRowByName(name: string): Locator {
+    return this.page.locator('.settings-deepcheck-row').filter({
+      has: this.page.locator('.settings-deepcheck-name', { hasText: name }),
+    });
+  }
+
+  async clickDeepCheck(): Promise<void> {
+    await this.deepCheckButton().click();
   }
 
   // Channel rows

--- a/e2e/tests/deepcheck.spec.ts
+++ b/e2e/tests/deepcheck.spec.ts
@@ -1,0 +1,233 @@
+import { test, expect } from '../fixtures/index';
+import { SettingsPage } from '../pages/SettingsPage';
+
+// FIXED_NOW = 2025-06-10T14:00:00.000Z
+
+const SUCCESS_REPORT = {
+  status: 'SUCCESS',
+  checks: [
+    { name: 'database', status: 'SUCCESS' },
+    { name: 'database_writable', status: 'SUCCESS' },
+    { name: 'fts', status: 'SUCCESS' },
+    { name: 'data_presence', status: 'SUCCESS', info: 'channels=5 airings=120' },
+    { name: 'data_freshness', status: 'SUCCESS', info: 'last_refresh=2025-06-10T13:00:00Z' },
+    { name: 'xmltv_url', status: 'SUCCESS', info: 'status=200' },
+    { name: 'disk_data', status: 'SUCCESS', info: 'mode=0755' },
+    { name: 'disk_tmp', status: 'SUCCESS', info: 'mode=0755' },
+    { name: 'image_cache', status: 'SUCCESS', info: 'mode=0755' },
+  ],
+};
+
+const FAILURE_REPORT = {
+  status: 'FAILURE',
+  checks: [
+    { name: 'database', status: 'SUCCESS' },
+    { name: 'database_writable', status: 'SUCCESS' },
+    { name: 'fts', status: 'SUCCESS' },
+    { name: 'data_presence', status: 'SUCCESS', info: 'channels=5 airings=120' },
+    { name: 'data_freshness', status: 'SUCCESS', info: 'last_refresh=2025-06-10T13:00:00Z' },
+    {
+      name: 'xmltv_url',
+      status: 'FAILURE',
+      error: 'HEAD https://example/xmltv: connection refused',
+    },
+    { name: 'disk_data', status: 'SUCCESS', info: 'mode=0755' },
+    { name: 'disk_tmp', status: 'SUCCESS', info: 'mode=0755' },
+    { name: 'image_cache', status: 'SUCCESS', info: 'mode=0755' },
+  ],
+};
+
+test.describe('Settings tab — Run system check action', () => {
+  test('button is rendered inside the Advanced section', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    const btn = settings.deepCheckButton();
+    await expect(btn).toBeVisible();
+    await expect(btn).toContainText(/run system check/i);
+  });
+
+  test('results panel is hidden until the first run', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await expect(settings.deepCheckResults()).toBeHidden();
+  });
+
+  test('all checks pass: shows summary and nine ✓ rows', async ({ page }) => {
+    await page.route('/api/deepcheck', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SUCCESS_REPORT),
+      })
+    );
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await settings.clickDeepCheck();
+
+    const summary = settings.deepCheckSummary();
+    await expect(summary).toBeVisible();
+    await expect(summary).toHaveText(/all checks passed/i);
+    await expect(summary).toHaveClass(/is-success/);
+
+    await expect(settings.deepCheckRows()).toHaveCount(9);
+
+    // Every row should have a ✓ icon
+    const icons = settings.deepCheckRows().locator('.settings-deepcheck-icon');
+    const iconCount = await icons.count();
+    for (let i = 0; i < iconCount; i++) {
+      const text = (await icons.nth(i).textContent()) ?? '';
+      expect(text.trim()).toBe('✓');
+      await expect(icons.nth(i)).toHaveClass(/is-success/);
+    }
+
+    // The XMLTV row uses the humanised label "XMLTV source"
+    await expect(settings.deepCheckRowByName('XMLTV source')).toBeVisible();
+    // And it should include its info text
+    await expect(
+      settings.deepCheckRowByName('XMLTV source').locator('.settings-deepcheck-info')
+    ).toContainText('status=200');
+
+    // No error blocks should be present
+    await expect(page.locator('.settings-deepcheck-error')).toHaveCount(0);
+
+    // Button is re-enabled after success
+    await expect(settings.deepCheckButton()).toBeEnabled();
+  });
+
+  test('one check fails: summary in error colour and ✗ row with error text', async ({ page }) => {
+    await page.route('/api/deepcheck', (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: 'application/json',
+        body: JSON.stringify(FAILURE_REPORT),
+      })
+    );
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await settings.clickDeepCheck();
+
+    const summary = settings.deepCheckSummary();
+    await expect(summary).toBeVisible();
+    await expect(summary).toHaveText(/1 of 9 checks failed/);
+    await expect(summary).toHaveClass(/is-error/);
+
+    const failingRow = settings.deepCheckRowByName('XMLTV source');
+    await expect(failingRow).toBeVisible();
+    const icon = failingRow.locator('.settings-deepcheck-icon');
+    await expect(icon).toHaveText('✗');
+    await expect(icon).toHaveClass(/is-error/);
+
+    const errorEl = failingRow.locator('.settings-deepcheck-error');
+    await expect(errorEl).toBeVisible();
+    await expect(errorEl).toContainText('HEAD https://example/xmltv: connection refused');
+  });
+
+  test('network failure shows a single graceful error row', async ({ page }) => {
+    await page.route('/api/deepcheck', (route) => route.abort('failed'));
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await settings.clickDeepCheck();
+
+    const results = settings.deepCheckResults();
+    await expect(results).toBeVisible();
+    await expect(results).toContainText(/system check could not be run/i);
+
+    // No summary line because we never got a report
+    await expect(settings.deepCheckSummary()).toHaveCount(0);
+
+    // Button is re-enabled even on failure
+    await expect(settings.deepCheckButton()).toBeEnabled();
+  });
+
+  test('button is disabled and spinner is visible while the request is in flight', async ({
+    page,
+  }) => {
+    await page.route('/api/deepcheck', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SUCCESS_REPORT),
+      });
+    });
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    // Don't await — let the click resolve in the background
+    const clickPromise = settings.clickDeepCheck();
+
+    await expect(settings.deepCheckButton()).toBeDisabled();
+    await expect(settings.deepCheckSpinner()).toBeVisible();
+
+    await clickPromise;
+
+    await expect(settings.deepCheckButton()).toBeEnabled();
+  });
+
+  test('re-running replaces previous results', async ({ page }) => {
+    let callCount = 0;
+    await page.route('/api/deepcheck', (route) => {
+      callCount += 1;
+      const body = callCount === 1 ? SUCCESS_REPORT : FAILURE_REPORT;
+      const status = callCount === 1 ? 200 : 503;
+      route.fulfill({
+        status,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      });
+    });
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await settings.clickDeepCheck();
+    await expect(settings.deepCheckSummary()).toHaveText(/all checks passed/i);
+
+    await settings.clickDeepCheck();
+    await expect(settings.deepCheckSummary()).toHaveText(/1 of 9 checks failed/);
+
+    // Still exactly nine rows after the rerun, not eighteen
+    await expect(settings.deepCheckRows()).toHaveCount(9);
+  });
+
+  test('results are cleared when the Advanced accordion is collapsed', async ({ page }) => {
+    await page.route('/api/deepcheck', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SUCCESS_REPORT),
+      })
+    );
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.toggleAdvanced();
+
+    await settings.clickDeepCheck();
+    await expect(settings.deepCheckSummary()).toBeVisible();
+
+    // Collapse the accordion
+    await settings.toggleAdvanced();
+    expect(await settings.isAdvancedExpanded()).toBe(false);
+
+    // Re-expand — the panel should be hidden again (cleared)
+    await settings.toggleAdvanced();
+    await expect(settings.deepCheckResults()).toBeHidden();
+  });
+});

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -58,6 +58,19 @@ export async function refreshGuide() {
     return res.json();
 }
 
+export async function runDeepCheck() {
+    const res = await fetch('/api/deepcheck', { redirect: 'manual' }).then(handleRedirect);
+    // /api/deepcheck returns JSON for both 200 and 503 — both are valid "got a report" cases.
+    // Throw only when there is no parseable JSON body (network error, opaque response, etc.).
+    let body;
+    try {
+        body = await res.json();
+    } catch {
+        throw new Error(`Deep check failed (${res.status})`);
+    }
+    return body;
+}
+
 export function logError({ type, message, source, lineno, colno, stack, url }) {
     fetch('/api/debug/log', {
         method: 'POST',

--- a/web/js/pages/settings.js
+++ b/web/js/pages/settings.js
@@ -1,6 +1,6 @@
 import { state } from '../state.js';
 import { isHidden, isFavourite, toggleHidden, toggleFavourite } from '../store/preferences.js';
-import { fetchChannels, fetchGuide, fetchStatus, refreshGuide } from '../api.js';
+import { fetchChannels, fetchGuide, fetchStatus, refreshGuide, runDeepCheck } from '../api.js';
 import { renderGuide, hasAiringsStartingOn } from './guide.js';
 import { formatAbsoluteDateTime } from '../utils/date.js';
 
@@ -87,6 +87,8 @@ function buildAdvancedSection() {
     body.appendChild(buildRefreshAction());
     const statusBlock = buildStatusBlock();
     body.appendChild(statusBlock);
+    const deepCheck = buildDeepCheckAction();
+    body.appendChild(deepCheck.wrap);
     body.appendChild(buildResetAction());
 
     let statusLoaded = false;
@@ -96,6 +98,9 @@ function buildAdvancedSection() {
         if (expanded && !statusLoaded) {
             statusLoaded = true;
             loadStatus(statusBlock);
+        }
+        if (!expanded) {
+            deepCheck.clear();
         }
     });
 
@@ -169,6 +174,172 @@ function buildRefreshAction() {
     wrap.appendChild(description);
     wrap.appendChild(row);
     return wrap;
+}
+
+const DEEPCHECK_LABELS = {
+    database:          'Database',
+    database_writable: 'Database writable',
+    fts:               'FTS index',
+    data_presence:     'Data presence',
+    data_freshness:    'Data freshness',
+    xmltv_url:         'XMLTV source',
+    disk_data:         'Disk: /data',
+    disk_tmp:          'Disk: /tmp',
+    image_cache:       'Image cache',
+};
+
+function humaniseDeepCheckName(name) {
+    return DEEPCHECK_LABELS[name] || name;
+}
+
+function buildDeepCheckAction() {
+    const wrap = document.createElement('div');
+    wrap.className = 'settings-action settings-action-deepcheck-wrap';
+
+    const description = document.createElement('p');
+    description.className   = 'settings-action-desc';
+    description.textContent = 'Runs a deeper health check across database, storage, network, and data freshness.';
+
+    const row = document.createElement('div');
+    row.className = 'settings-action-row';
+
+    const btn = document.createElement('button');
+    btn.type        = 'button';
+    btn.className   = 'settings-action-btn settings-action-deepcheck';
+    btn.textContent = 'Run system check';
+
+    const spinner = document.createElement('div');
+    spinner.className = 'loading-spinner';
+    spinner.style.display = 'none';
+
+    row.appendChild(btn);
+    row.appendChild(spinner);
+
+    const results = document.createElement('div');
+    results.className = 'settings-deepcheck-results';
+    results.style.display = 'none';
+    results.setAttribute('role', 'status');
+
+    const clear = () => {
+        results.innerHTML = '';
+        results.style.display = 'none';
+    };
+
+    btn.addEventListener('click', async () => {
+        btn.disabled = true;
+        spinner.style.display = '';
+        clear();
+
+        let report;
+        try {
+            report = await runDeepCheck();
+        } catch (err) {
+            renderDeepCheckNetworkError(results, err);
+            btn.disabled = false;
+            spinner.style.display = 'none';
+            return;
+        }
+
+        renderDeepCheckReport(results, report);
+        btn.disabled = false;
+        spinner.style.display = 'none';
+    });
+
+    wrap.appendChild(description);
+    wrap.appendChild(row);
+    wrap.appendChild(results);
+
+    return { wrap, clear };
+}
+
+function renderDeepCheckReport(results, report) {
+    results.innerHTML = '';
+    results.style.display = '';
+
+    const checks = Array.isArray(report.checks) ? report.checks : [];
+    const failed = checks.filter((c) => c.status !== 'SUCCESS').length;
+    const total  = checks.length;
+
+    const summary = document.createElement('div');
+    summary.className = 'settings-deepcheck-summary';
+    if (report.status === 'SUCCESS' && failed === 0) {
+        summary.classList.add('is-success');
+        summary.textContent = 'All checks passed';
+    } else {
+        summary.classList.add('is-error');
+        summary.textContent = `${failed} of ${total} checks failed`;
+    }
+    results.appendChild(summary);
+
+    for (const check of checks) {
+        results.appendChild(buildDeepCheckRow(check));
+    }
+}
+
+function buildDeepCheckRow(check) {
+    const row = document.createElement('div');
+    row.className = 'settings-deepcheck-row';
+
+    const head = document.createElement('div');
+    head.className = 'settings-deepcheck-head';
+
+    const success = check.status === 'SUCCESS';
+
+    const icon = document.createElement('span');
+    icon.className = 'settings-deepcheck-icon ' + (success ? 'is-success' : 'is-error');
+    icon.textContent = success ? '✓' : '✗'; // ✓ / ✗
+    icon.setAttribute('aria-hidden', 'true');
+
+    const name = document.createElement('span');
+    name.className   = 'settings-deepcheck-name';
+    name.textContent = humaniseDeepCheckName(check.name);
+
+    head.appendChild(icon);
+    head.appendChild(name);
+
+    if (check.info) {
+        const info = document.createElement('span');
+        info.className   = 'settings-deepcheck-info';
+        info.textContent = check.info;
+        head.appendChild(info);
+    }
+
+    row.appendChild(head);
+
+    if (check.error) {
+        const err = document.createElement('div');
+        err.className   = 'settings-deepcheck-error';
+        err.textContent = check.error;
+        row.appendChild(err);
+    }
+
+    return row;
+}
+
+function renderDeepCheckNetworkError(results, err) {
+    results.innerHTML = '';
+    results.style.display = '';
+
+    const row = document.createElement('div');
+    row.className = 'settings-deepcheck-row';
+
+    const head = document.createElement('div');
+    head.className = 'settings-deepcheck-head';
+
+    const icon = document.createElement('span');
+    icon.className = 'settings-deepcheck-icon is-error';
+    icon.textContent = '✗';
+    icon.setAttribute('aria-hidden', 'true');
+
+    const name = document.createElement('span');
+    name.className   = 'settings-deepcheck-name';
+    name.textContent = `System check could not be run: ${err.message || 'request failed'}`;
+
+    head.appendChild(icon);
+    head.appendChild(name);
+    row.appendChild(head);
+
+    results.appendChild(row);
 }
 
 function buildStatusBlock() {

--- a/web/style/settings.css
+++ b/web/style/settings.css
@@ -206,3 +206,70 @@
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 12px;
 }
+
+/* ── Deep / system check results ──────────────────────────────── */
+
+.settings-deepcheck-results {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.settings-deepcheck-summary {
+    font-weight: 600;
+    font-size: 13px;
+    margin-bottom: 4px;
+}
+
+.settings-deepcheck-summary.is-success {
+    color: #3fb950;
+}
+
+.settings-deepcheck-summary.is-error {
+    color: var(--accent-now);
+}
+
+.settings-deepcheck-row {
+    padding: 2px 0;
+    font-size: 13px;
+}
+
+.settings-deepcheck-head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+
+.settings-deepcheck-icon {
+    flex: 0 0 14px;
+    width: 14px;
+    font-weight: 700;
+    text-align: center;
+    line-height: 1;
+}
+
+.settings-deepcheck-icon.is-success {
+    color: #3fb950;
+}
+
+.settings-deepcheck-icon.is-error {
+    color: var(--accent-now);
+}
+
+.settings-deepcheck-name {
+    color: var(--text-primary);
+}
+
+.settings-deepcheck-info {
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.settings-deepcheck-error {
+    margin: 2px 0 0 22px;
+    color: var(--accent-now);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    word-break: break-word;
+}


### PR DESCRIPTION
## Summary
- Adds `runDeepCheck()` API helper and a new "Run system check" action in Settings → Advanced that calls `/api/deepcheck` and renders the per-check report inline (summary line + ✓/✗ rows, with info and error text where present).
- Results panel is hidden until the first run and cleared when the Advanced accordion is collapsed so it never pops into view on the next expand.
- Network failures render a single graceful error row instead of throwing.

Closes #266. Closes #264.

## Test plan
- [x] New Playwright spec `e2e/tests/deepcheck.spec.ts` covers: button rendering, hidden-until-first-run, all-pass (✓ × 9), one-fail (✗ + error text + error summary), network failure, in-flight disabled state + spinner, re-run replacing results, accordion-collapse clearing results.
- [x] `make test-ui` — 163 passed, 1 pre-existing skip.
- [x] `go test ./...` — all packages OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)