### PR TITLE
Fix /tmp permissions: switch runtime image to distroless #263

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # ── Build stage ──────────────────────────────────────────────────
 FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 
-# ca-certificates is needed at runtime for HTTPS; install here so we can
-# copy just the cert bundle into the scratch image.
-RUN apk --no-cache add ca-certificates
-
 WORKDIR /app
 
 # Copy module manifests first so this layer is cached until dependencies change.
@@ -21,37 +17,40 @@ RUN sed -i "s/__CACHE_VERSION__/${VERSION}/" web/sw.js
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o tvguide .
 
-# Create an empty /tmp directory to carry into the scratch image.
-# SQLite FTS5 segment operations require a writable temp directory even when
-# PRAGMA temp_store=MEMORY is set; without /tmp the second+ refresh fails
-# with SQLITE_IOERR_WRITE (6410). See GitHub issue #87.
-RUN mkdir /scratch_tmp && chown 65534:65534 /scratch_tmp
-
-# Create an empty /data directory to carry into the scratch image.
+# Create an empty /data directory to carry into the runtime image.
 # When Docker mounts an empty named volume on top of a directory that exists
 # in the image, the volume inherits the image directory's ownership and mode.
 # Without this, a fresh volume is created root-owned and the non-root runtime
-# user (UID 65534) cannot write the SQLite DB or image cache. See issue #259.
-RUN mkdir /scratch_data && chown 65534:65534 /scratch_data
+# user (UID 65532) cannot write the SQLite DB or image cache. See issue #259.
+RUN mkdir /scratch_data && chown 65532:65532 /scratch_data
 
 # ── Runtime stage ─────────────────────────────────────────────────
-# scratch: zero OS overhead (~0 MB vs ~8 MB for alpine).
-# Timezone data is embedded in the binary via `import _ "time/tzdata"`,
-# so only the CA certificate bundle needs to be copied in.
-FROM scratch
+# distroless static-debian12:nonroot — minimal (~2 MB) image that ships:
+#   - /tmp as drwxrwxrwt (mode 1777) — writable by any UID, which fixes
+#     issue #263 (Docker BuildKit's COPY --chmod does NOT apply to the
+#     destination directory itself, only files inside, so the previous
+#     scratch-based approach left /tmp at 0755 and broke for any user
+#     not matching its owner UID)
+#   - /etc/ssl/certs/ca-certificates.crt (no manual copy needed)
+#   - /etc/passwd containing the `nonroot` user (UID/GID 65532)
+# Timezone data is embedded in the binary via `import _ "time/tzdata"`.
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/tvguide /tvguide
-COPY --from=builder --chown=65534:65534 --chmod=1777 /scratch_tmp /tmp
-COPY --from=builder --chown=65534:65534 --chmod=1777 /scratch_data /data
+# --chown is required on the COPY because Docker's COPY does not preserve the
+# source directory's ownership for the destination directory itself (only for
+# its contents). Without this, a fresh /data volume inherits root:0755 and
+# the non-root runtime user cannot write the SQLite DB. See issue #259.
+COPY --from=builder --chown=65532:65532 /scratch_data /data
 
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD ["/tvguide", "--healthcheck"]
 
-# Run as non-root (numeric UID required for scratch images which have no /etc/passwd).
-# UID 65534 is the conventional "nobody" user on Linux.
-USER 65534:65534
+# Run as non-root. UID 65532 is the conventional "nonroot" user shipped by
+# distroless. /tmp is mode 1777 in the base image so users overriding this
+# via `docker run --user` or compose `user:` can still write temp files.
+USER 65532:65532
 
 ENTRYPOINT ["/tvguide"]

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -407,11 +407,10 @@ func TestRefresh_IconRedownloadsIfURLChanged(t *testing.T) {
 
 // TestRefresh_FTSRebuildSucceedsOnSubsequentRefresh verifies that a second
 // Refresh correctly clears and rebuilds the FTS index when it already contains
-// data. Regression test for GitHub issues #87 and #231: FTS5 segment operations
-// require a writable temp directory (SQLITE_IOERR_GETTEMPPATH, error 6410). In
-// the scratch Docker image /tmp must exist AND be world-writable (1777); the
-// original #87 fix added /tmp but left it root:0755, which fails for the
-// non-root container user (UID 65534).
+// data. Regression test for GitHub issues #87, #231, and #263: FTS5 segment
+// operations require a writable temp directory (SQLITE_IOERR_GETTEMPPATH,
+// error 6410). The runtime image must ship /tmp world-writable so any
+// container UID (including one overridden via compose `user:`) can write it.
 func TestRefresh_FTSRebuildSucceedsOnSubsequentRefresh(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Switch runtime base from `FROM scratch` to `gcr.io/distroless/static-debian12:nonroot` so `/tmp` ships as `drwxrwxrwt` (1777) and is writable for any container UID.
- Drop the manual ca-certificates COPY (distroless includes it) and the `/scratch_tmp` setup.
- Move runtime UID from 65534 (nobody) to 65532 (nonroot), the distroless convention; update `/data` chown to match.
- Add `--chown=65532:65532` to the `/data` COPY (unlike `--chmod`, `--chown` *does* apply to the destination directory itself, which is the fix path for #259-style fresh-volume ownership).

## Root cause

Docker BuildKit's `COPY --chmod=1777` flag is silently ignored for the destination directory itself when copying a directory — only files inside the directory get the new mode. The previous Dockerfile ended up with `/tmp` at mode 0755 owned by UID 65534, which matches the `mode=0755 uid=65534` reported by `/api/deepcheck` in the issue. When the container is started with `user: 9001:9001` in docker-compose, UID 9001 hits a 0755-mode directory owned by a different UID → permission denied on every `/tmp` write → SQLite FTS5 segment operations fail intermittently (succeeds when ops fit in memory, fails when spill-to-disk is needed).

Verified by building the previous Dockerfile and inspecting tar layers; the same is true with `--chmod=0777` and with `COPY --link`, so this is not a sticky-bit issue. The only fix paths are (a) use a base image that already ships `/tmp` correctly, or (b) avoid `/tmp` entirely. (a) is simpler and is what this PR does.

## Test plan

- [x] Build the new image and inspect tar layers — `/tmp` is `drwxrwxrwt` (1777).
- [x] Run the container with `--user 9001:9001` (a UID neither owning `/tmp` nor matching the image USER) and confirm a write probe to `/tmp` succeeds.
- [x] Run `/api/deepcheck` against the running container: `disk_tmp: SUCCESS`.
- [x] `go test ./...` passes.
- [ ] Deploy to home-lab home environment and confirm scheduled refreshes no longer log the "temp dir probe FAILED" diagnostic and the FTS rebuild succeeds across multiple poll intervals.

Fixes #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)