### PR TITLE
Fix PWA serving stale assets after updates #271

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,18 @@ The now-line timer only runs when the Guide tab is active.
 4. The frontend fetches `/api/channels` and `/api/guide?date=...` in parallel on page load.
 5. Airings are rendered as absolutely-positioned cells within a CSS-grid layout.
 
+## PWA caching
+
+The service worker (`web/sw.js`) is cache-first for static assets and network-first for the API. Cache invalidation across deploys depends on **two cooperating mechanisms**:
+
+1. **Service-worker cache versioning.** The cache name is `tvguide-__CACHE_VERSION__`; the Dockerfile replaces the placeholder with the build `VERSION` arg (`github.sha` in CI). A new build → new cache name → on the next SW update check, the new SW installs, `cache.addAll()` populates the new cache, the old one is deleted, `controllerchange` fires, and the page reloads. The SW's install step uses `new Request(url, { cache: 'reload' })` so `cache.addAll()` bypasses the browser's HTTP cache (without this, iOS Safari's heuristic caching can pull stale assets into the new SW cache — issue #271).
+
+2. **Per-file ETag + `Cache-Control: no-cache` on static asset responses.** `spaHandler` walks the embedded `web/` filesystem at startup, computes a SHA-256 hash per file, and serves it as the response ETag. The browser revalidates on every request; Go's `serveContent` returns `304 Not Modified` automatically when `If-None-Match` matches. This is defence-in-depth for the first install and for navigation requests (which bypass the SW so Traefik/Authelia can intercept).
+
+`/sw.js` is the deliberate exception: it has `Cache-Control: no-cache, no-store, must-revalidate` and no ETag, so the browser never caches it — required for the SW update-check mechanism.
+
+When adding a new static asset under `web/`, also add it to the `STATIC` list in `web/sw.js` so it is pre-cached for offline use.
+
 ## XMLTV notes
 
 - Time format: `YYYYMMDDHHmmss ±HHMM` — the parser handles both `+1100` and `+11:00` offset styles.

--- a/integration_test.go
+++ b/integration_test.go
@@ -111,7 +111,11 @@ func newIntegrationServer(t *testing.T, xmltvURL string) *httptest.Server {
 	if err != nil {
 		t.Fatalf("fs.Sub: %v", err)
 	}
-	mux.Handle("/", spaHandler(http.FS(webSub)))
+	staticHandler, err := spaHandler(webSub)
+	if err != nil {
+		t.Fatalf("spaHandler: %v", err)
+	}
+	mux.Handle("/", staticHandler)
 
 	srv := httptest.NewServer(mux)
 	t.Cleanup(func() {
@@ -1358,6 +1362,183 @@ func TestIntegration_AuthRedirectHandling(t *testing.T) {
 		// error must propagate so the page can trigger re-authentication.
 		if strings.Contains(body, "fetch(event.request).catch(() => caches.match(event.request))") {
 			t.Error("sw.js must not fall back to stale cache on API fetch failure — re-throw so the page can handle auth redirects")
+		}
+	})
+}
+
+// TestIntegration_PWACacheInvalidation_ServiceWorker verifies the service
+// worker's pre-cache step bypasses the browser's HTTP cache. Without this,
+// cache.addAll() can store stale assets fetched from the browser's heuristic
+// HTTP cache, defeating the version-based cache invalidation scheme. See #271.
+func TestIntegration_PWACacheInvalidation_ServiceWorker(t *testing.T) {
+	srv := newSampleIntegrationServer(t)
+	swJS := fetchBody(t, srv, "/sw.js")
+
+	t.Run("addAll_uses_reload_cache_mode", func(t *testing.T) {
+		// The SW install handler must construct Request objects with
+		// { cache: 'reload' } so cache.addAll() bypasses the HTTP cache.
+		if !strings.Contains(swJS, "cache: 'reload'") {
+			t.Error("sw.js install handler must use { cache: 'reload' } when pre-caching to bypass the browser HTTP cache (see #271)")
+		}
+	})
+
+	t.Run("static_includes_explore_assets", func(t *testing.T) {
+		// /style/explore.css and /js/pages/explore.js are loaded by the
+		// Explore page; both must be pre-cached so the PWA works offline.
+		for _, path := range []string{"/style/explore.css", "/js/pages/explore.js"} {
+			if !strings.Contains(swJS, path) {
+				t.Errorf("sw.js STATIC list should include %s", path)
+			}
+		}
+	})
+
+	t.Run("clients_claim_inside_waitUntil", func(t *testing.T) {
+		// clients.claim() should be inside event.waitUntil() so the activate
+		// event isn't considered complete until claim resolves — some browsers
+		// (iOS Safari historically) are flaky if it runs outside.
+		activateIdx := strings.Index(swJS, "addEventListener('activate'")
+		if activateIdx < 0 {
+			t.Fatal("sw.js missing activate handler")
+		}
+		// Find the waitUntil( call within the activate handler and walk the
+		// parentheses to find its matching close. clients.claim() must appear
+		// between them.
+		bodyStart := activateIdx
+		waitRel := strings.Index(swJS[bodyStart:], "waitUntil(")
+		if waitRel < 0 {
+			t.Fatal("sw.js activate handler must use event.waitUntil()")
+		}
+		waitOpen := bodyStart + waitRel + len("waitUntil(") - 1 // position of '('
+		depth := 0
+		waitClose := -1
+		for i := waitOpen; i < len(swJS); i++ {
+			switch swJS[i] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					waitClose = i
+				}
+			}
+			if waitClose >= 0 {
+				break
+			}
+		}
+		if waitClose < 0 {
+			t.Fatal("sw.js activate handler: could not find closing ) for waitUntil(")
+		}
+		waitUntilBody := swJS[waitOpen+1 : waitClose]
+		if !strings.Contains(waitUntilBody, "clients.claim()") {
+			t.Error("sw.js activate handler must call clients.claim() inside event.waitUntil(), not after it")
+		}
+	})
+}
+
+// TestIntegration_PWACacheInvalidation_StaticAssetHeaders verifies the
+// server sets Cache-Control and ETag on static assets so the browser's HTTP
+// cache revalidates on every request. This is defense-in-depth alongside the
+// SW's { cache: 'reload' } change. See #271.
+func TestIntegration_PWACacheInvalidation_StaticAssetHeaders(t *testing.T) {
+	srv := newSampleIntegrationServer(t)
+
+	staticPaths := []string{
+		"/index.html",
+		"/js/main.js",
+		"/style/base.css",
+		"/manifest.json",
+	}
+
+	t.Run("static_assets_have_cache_control_no_cache", func(t *testing.T) {
+		for _, path := range staticPaths {
+			resp, err := httpGet(t, srv.URL+path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			_ = resp.Body.Close()
+			cc := resp.Header.Get("Cache-Control")
+			if !strings.Contains(cc, "no-cache") {
+				t.Errorf("GET %s: Cache-Control = %q; want it to contain 'no-cache' so the browser revalidates", path, cc)
+			}
+		}
+	})
+
+	t.Run("static_assets_have_etag", func(t *testing.T) {
+		for _, path := range staticPaths {
+			resp, err := httpGet(t, srv.URL+path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			_ = resp.Body.Close()
+			if resp.Header.Get("ETag") == "" {
+				t.Errorf("GET %s: ETag header missing; needed for 304 revalidation", path)
+			}
+		}
+	})
+
+	t.Run("sw_js_keeps_no_store", func(t *testing.T) {
+		// /sw.js must remain uncached entirely (no-store) so the browser
+		// always fetches fresh on update checks. This pre-dates #271 — guard
+		// against the new middleware overriding it.
+		resp, err := httpGet(t, srv.URL+"/sw.js")
+		if err != nil {
+			t.Fatalf("GET /sw.js: %v", err)
+		}
+		_ = resp.Body.Close()
+		cc := resp.Header.Get("Cache-Control")
+		if !strings.Contains(cc, "no-store") {
+			t.Errorf("GET /sw.js: Cache-Control = %q; must contain 'no-store'", cc)
+		}
+	})
+
+	t.Run("matching_if_none_match_returns_304", func(t *testing.T) {
+		// First request: capture the ETag.
+		resp, err := httpGet(t, srv.URL+"/js/main.js")
+		if err != nil {
+			t.Fatalf("GET /js/main.js: %v", err)
+		}
+		_ = resp.Body.Close()
+		etag := resp.Header.Get("ETag")
+		if etag == "" {
+			t.Fatal("first GET /js/main.js did not return an ETag")
+		}
+
+		// Second request with If-None-Match: must return 304.
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/js/main.js", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("If-None-Match", etag)
+		resp2, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("conditional GET: %v", err)
+		}
+		_ = resp2.Body.Close()
+		if resp2.StatusCode != http.StatusNotModified {
+			t.Errorf("conditional GET with If-None-Match: got %d, want 304", resp2.StatusCode)
+		}
+	})
+
+	t.Run("different_assets_have_different_etags", func(t *testing.T) {
+		// Per-file ETags (not a single global version stamp) — otherwise an
+		// unchanged file can't return 304 after redeploy.
+		resp1, err := httpGet(t, srv.URL+"/js/main.js")
+		if err != nil {
+			t.Fatalf("GET /js/main.js: %v", err)
+		}
+		_ = resp1.Body.Close()
+		resp2, err := httpGet(t, srv.URL+"/style/base.css")
+		if err != nil {
+			t.Fatalf("GET /style/base.css: %v", err)
+		}
+		_ = resp2.Body.Close()
+		e1 := resp1.Header.Get("ETag")
+		e2 := resp2.Header.Get("ETag")
+		if e1 == "" || e2 == "" {
+			t.Fatalf("missing ETag: main.js=%q, base.css=%q", e1, e2)
+		}
+		if e1 == e2 {
+			t.Errorf("different assets should have different ETags; both = %q", e1)
 		}
 	})
 }

--- a/main.go
+++ b/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"log"
@@ -155,7 +157,11 @@ func run(cfg config) error {
 	if err != nil {
 		return fmt.Errorf("embedding web files: %w", err)
 	}
-	mux.Handle("/", spaHandler(http.FS(webContent)))
+	staticHandler, err := spaHandler(webContent)
+	if err != nil {
+		return fmt.Errorf("building static handler: %w", err)
+	}
+	mux.Handle("/", staticHandler)
 
 	srv := &http.Server{
 		Addr:              ":" + cfg.port,
@@ -250,10 +256,25 @@ func runInitialRefresh(db *database.DB, client *http.Client, xmltvURL string, po
 // spaHandler returns an http.Handler that serves static files from fsys,
 // falling back to index.html for any path that doesn't match a real file.
 // This enables client-side (History API) routing in the SPA.
-func spaHandler(fsys http.FileSystem) http.Handler {
-	fileServer := http.FileServer(fsys)
+//
+// All static responses are tagged with a per-file content-hash ETag and
+// Cache-Control: no-cache. The browser revalidates each request and the Go
+// stdlib's serveContent returns 304 when the client's If-None-Match matches.
+// Embedded files have zero mtime so Last-Modified would be absent; ETags give
+// us proper revalidation regardless. Without this, browsers (notably iOS
+// Safari in standalone PWA mode) apply heuristic caching and can serve stale
+// assets into the service worker's pre-cache — see issue #271.
+//
+// /sw.js is the one exception: it keeps no-store so the browser never caches
+// it at all, which is required for the SW update-check mechanism to work.
+func spaHandler(fsys fs.FS) (http.Handler, error) {
+	etags, err := computeStaticETags(fsys)
+	if err != nil {
+		return nil, fmt.Errorf("computing static asset ETags: %w", err)
+	}
+	httpFS := http.FS(fsys)
+	fileServer := http.FileServer(httpFS)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Try to open the requested file. If it exists, serve it normally.
 		path := r.URL.Path
 
 		// Prevent the browser from caching the service worker script itself.
@@ -261,22 +282,64 @@ func spaHandler(fsys http.FileSystem) http.Handler {
 		// stale HTTP caching of sw.js defeats the entire versioning scheme.
 		if path == "/sw.js" {
 			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+			fileServer.ServeHTTP(w, r)
+			return
 		}
 
-		if path == "/" {
-			fileServer.ServeHTTP(w, r)
-			return
+		// Resolve which file will actually be served: the requested path if it
+		// exists, otherwise / (SPA fallback to index.html).
+		servedPath := path
+		if path != "/" {
+			f, err := httpFS.Open(path)
+			if err == nil {
+				_ = f.Close()
+			} else {
+				servedPath = "/"
+				r.URL.Path = "/"
+			}
 		}
-		f, err := fsys.Open(path)
-		if err == nil {
-			_ = f.Close()
-			fileServer.ServeHTTP(w, r)
-			return
+
+		if tag, ok := etags[servedPath]; ok {
+			w.Header().Set("ETag", tag)
+			w.Header().Set("Cache-Control", "no-cache")
 		}
-		// File not found — serve index.html for SPA client-side routing.
-		r.URL.Path = "/"
 		fileServer.ServeHTTP(w, r)
+	}), nil
+}
+
+// computeStaticETags walks the embedded web filesystem at startup and
+// computes a content-hash ETag for every file. The map is keyed by the URL
+// path (with leading slash); "/" maps to the same tag as "/index.html" so
+// SPA-fallback navigations serve a consistent ETag.
+func computeStaticETags(fsys fs.FS) (map[string]string, error) {
+	etags := make(map[string]string)
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Skip sw.js — it intentionally has no-store and no ETag.
+		if p == "sw.js" {
+			return nil
+		}
+		data, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			return err
+		}
+		sum := sha256.Sum256(data)
+		tag := `"` + hex.EncodeToString(sum[:8]) + `"`
+		etags["/"+p] = tag
+		if p == "index.html" {
+			etags["/"] = tag
+		}
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+	return etags, nil
 }
 
 // parseStripWords splits the CHANNEL_NAME_STRIP value on commas and trims whitespace.

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,20 +1,25 @@
 const CACHE = 'tvguide-__CACHE_VERSION__';
-const STATIC = ['/', '/index.html', '/style/base.css', '/style/layout.css', '/style/guide.css', '/style/modal.css', '/style/search.css', '/style/favourites.css', '/style/settings.css', '/js/main.js', '/js/router.js', '/js/state.js', '/js/api.js', '/js/config.js', '/js/utils/date.js', '/js/store/preferences.js', '/js/store/favourites.js', '/js/components/modal.js', '/js/pages/guide.js', '/js/pages/search.js', '/js/pages/favourites.js', '/js/pages/settings.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
+const STATIC = ['/', '/index.html', '/style/base.css', '/style/layout.css', '/style/guide.css', '/style/modal.css', '/style/search.css', '/style/favourites.css', '/style/settings.css', '/style/explore.css', '/js/main.js', '/js/router.js', '/js/state.js', '/js/api.js', '/js/config.js', '/js/utils/date.js', '/js/store/preferences.js', '/js/store/favourites.js', '/js/components/modal.js', '/js/pages/guide.js', '/js/pages/search.js', '/js/pages/favourites.js', '/js/pages/settings.js', '/js/pages/explore.js', '/manifest.json', '/icon.svg', '/apple-touch-icon.png', '/icon-192.png', '/icon-512.png'];
 
 self.addEventListener('install', event => {
+    // Use { cache: 'reload' } so cache.addAll() bypasses the browser's HTTP cache.
+    // Without this, a stale heuristic-cached asset can be pulled from the browser
+    // cache into our SW cache during an update, defeating the version-based cache
+    // invalidation scheme — see issue #271.
     event.waitUntil(
-        caches.open(CACHE).then(cache => cache.addAll(STATIC))
+        caches.open(CACHE).then(cache =>
+            cache.addAll(STATIC.map(url => new Request(url, { cache: 'reload' })))
+        )
     );
     self.skipWaiting();
 });
 
 self.addEventListener('activate', event => {
-    event.waitUntil(
-        caches.keys().then(keys =>
-            Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
-        )
-    );
-    self.clients.claim();
+    event.waitUntil((async () => {
+        const keys = await caches.keys();
+        await Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)));
+        await self.clients.claim();
+    })());
 });
 
 self.addEventListener('fetch', event => {


### PR DESCRIPTION
## Summary

Fixes #271 — the PWA was unreliable about picking up new deployments on iOS, with users still seeing old code (e.g. the "Run system check" button missing) even after a force reload.

**Root cause:** `cache.addAll()` in the service worker's install handler fetches assets through the browser's HTTP cache. Since our static assets are served with no `Cache-Control`/`ETag`/`Last-Modified` (embed.FS files have a zero mtime), iOS Safari applies heuristic caching. When a new SW version installs, its pre-cache step pulls stale assets from the browser's HTTP cache into the new SW cache — defeating the entire version-based invalidation scheme.

## Changes

**Primary fix** — force fresh network fetches when the SW pre-caches:
```js
cache.addAll(STATIC.map(url => new Request(url, { cache: 'reload' })))
```

**Defence-in-depth** — proper HTTP cache headers on every static response:
- `spaHandler` now walks the embedded `web/` filesystem at startup and computes a SHA-256 ETag per file.
- Each response gets `ETag: "<hash>"` + `Cache-Control: no-cache`.
- Go's `serveContent` handles `If-None-Match` → 304 automatically.
- `/sw.js` keeps its `no-store` headers (browser must never cache the SW itself).

**Smaller fixes also rolled in:**
- Added missing `/style/explore.css` and `/js/pages/explore.js` to the SW `STATIC` pre-cache list — both were referenced by `index.html`/`router.js` but excluded from offline pre-caching.
- Moved `clients.claim()` inside `event.waitUntil()` (it was running unawaited, which has historically been flaky on iOS Safari).

## Test plan

- [x] 8 new integration test cases covering both fixes (`TestIntegration_PWACacheInvalidation_ServiceWorker` and `TestIntegration_PWACacheInvalidation_StaticAssetHeaders`)
- [x] Full Go test suite passes (`make test`)
- [x] ESLint clean (`make lint-js`)
- [x] Binary builds
- [ ] After merge: confirm on iOS PWA that a new deployment is picked up within the 60s SW update check, without needing to delete/reinstall the PWA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)