### PR TITLE
Fix XMLTV source check in Deepcheck #270

### DIFF
--- a/internal/deepcheck/deepcheck.go
+++ b/internal/deepcheck/deepcheck.go
@@ -160,8 +160,11 @@ func runCheck(name string, fn func() (string, error)) CheckResult {
 	return CheckResult{Name: name, Status: StatusSuccess, Info: info}
 }
 
-// probeXMLTV issues a HEAD request to c.XMLTVURL with a fresh 5s timeout. On
-// a 405 Method Not Allowed response, it falls back to a single GET with
+// probeXMLTV issues a HEAD request to c.XMLTVURL with a fresh 5s timeout. The
+// HEAD and GET fallback requests both carry the same Accept and User-Agent
+// headers the real XMLTV fetcher uses (see internal/xmltv/parser.go) so hosts
+// that key on those don't reject the probe with 406. If HEAD returns anything
+// outside the 2xx/3xx success range it falls back to a single GET with
 // Range: bytes=0-0. Final response status outside 2xx/3xx is a failure.
 func (c *Checker) probeXMLTV(parent context.Context) CheckResult {
 	const name = "xmltv_url"
@@ -180,12 +183,20 @@ func (c *Checker) probeXMLTV(parent context.Context) CheckResult {
 		return fmt.Errorf("%s %s: unexpected status %d", method, c.XMLTVURL, status)
 	}
 
-	doRequest := func(method string, headers map[string]string) (*http.Response, error) {
+	baseHeaders := map[string]string{
+		"Accept":     "text/xml, application/xml, */*",
+		"User-Agent": "xmltvguide/1.0",
+	}
+
+	doRequest := func(method string, extraHeaders map[string]string) (*http.Response, error) {
 		req, err := http.NewRequestWithContext(ctx, method, c.XMLTVURL, nil)
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range headers {
+		for k, v := range baseHeaders {
+			req.Header.Set(k, v)
+		}
+		for k, v := range extraHeaders {
 			req.Header.Set(k, v)
 		}
 		return client.Do(req)
@@ -202,8 +213,10 @@ func (c *Checker) probeXMLTV(parent context.Context) CheckResult {
 	method := http.MethodHead
 	status := resp.StatusCode
 
-	if status == http.StatusMethodNotAllowed {
-		// Fallback to GET with Range header to minimise bytes transferred.
+	if status < 200 || status >= 400 {
+		// HEAD failed — some servers reject HEAD with 400, 403, 405, 406, 501,
+		// etc. Fall back to a single GET with Range: bytes=0-0 to keep the
+		// probe cheap.
 		resp2, err2 := doRequest(http.MethodGet, map[string]string{"Range": "bytes=0-0"})
 		if err2 != nil {
 			return CheckResult{Name: name, Status: StatusFailure, Error: wrapErr(http.MethodGet, err2).Error()}

--- a/internal/deepcheck/deepcheck_test.go
+++ b/internal/deepcheck/deepcheck_test.go
@@ -291,6 +291,92 @@ func TestRun_XMLTVURL_FallbackToGETOn405(t *testing.T) {
 	}
 }
 
+func TestRun_XMLTVURL_FallbackToGETOn406(t *testing.T) {
+	now := time.Now()
+	var headCalls, getCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			w.WriteHeader(http.StatusNotAcceptable)
+		case http.MethodGet:
+			getCalls.Add(1)
+			if r.Header.Get("Range") == "" {
+				t.Errorf("GET fallback should set Range header")
+			}
+			w.WriteHeader(http.StatusPartialContent)
+			w.Write([]byte("x"))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "xmltv_url")
+	if check.Status != StatusSuccess {
+		t.Errorf("xmltv_url status = %q, want SUCCESS (err=%q)", check.Status, check.Error)
+	}
+	if headCalls.Load() != 1 {
+		t.Errorf("HEAD called %d times, want 1", headCalls.Load())
+	}
+	if getCalls.Load() != 1 {
+		t.Errorf("GET called %d times, want 1", getCalls.Load())
+	}
+}
+
+func TestRun_XMLTVURL_SendsExpectedHeaders(t *testing.T) {
+	// Both HEAD and the GET fallback must send the same Accept and User-Agent
+	// headers as the real XMLTV fetcher (internal/xmltv/parser.go), otherwise
+	// upstream servers may reject the request with 406 Not Acceptable.
+	now := time.Now()
+	wantAccept := "text/xml, application/xml, */*"
+	wantUA := "xmltvguide/1.0"
+
+	type seen struct {
+		accept    string
+		userAgent string
+	}
+	var headSeen, getSeen seen
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headSeen = seen{accept: r.Header.Get("Accept"), userAgent: r.Header.Get("User-Agent")}
+			// Force the GET fallback so we can inspect both requests.
+			w.WriteHeader(http.StatusNotAcceptable)
+		case http.MethodGet:
+			getSeen = seen{accept: r.Header.Get("Accept"), userAgent: r.Header.Get("User-Agent")}
+			w.WriteHeader(http.StatusPartialContent)
+			w.Write([]byte("x"))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "xmltv_url")
+	if check.Status != StatusSuccess {
+		t.Fatalf("xmltv_url status = %q, want SUCCESS (err=%q)", check.Status, check.Error)
+	}
+
+	if headSeen.accept != wantAccept {
+		t.Errorf("HEAD Accept = %q, want %q", headSeen.accept, wantAccept)
+	}
+	if headSeen.userAgent != wantUA {
+		t.Errorf("HEAD User-Agent = %q, want %q", headSeen.userAgent, wantUA)
+	}
+	if getSeen.accept != wantAccept {
+		t.Errorf("GET Accept = %q, want %q", getSeen.accept, wantAccept)
+	}
+	if getSeen.userAgent != wantUA {
+		t.Errorf("GET User-Agent = %q, want %q", getSeen.userAgent, wantUA)
+	}
+}
+
 func TestRun_XMLTVURL_FailureOn500(t *testing.T) {
 	now := time.Now()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/deepcheck/deepcheck_test.go
+++ b/internal/deepcheck/deepcheck_test.go
@@ -255,74 +255,56 @@ func TestRun_XMLTVURL_SuccessOnHEAD200(t *testing.T) {
 	}
 }
 
-func TestRun_XMLTVURL_FallbackToGETOn405(t *testing.T) {
-	now := time.Now()
-	var headCalls, getCalls atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodHead:
-			headCalls.Add(1)
-			w.WriteHeader(http.StatusMethodNotAllowed)
-		case http.MethodGet:
-			getCalls.Add(1)
-			// Validate Range header presence.
-			if r.Header.Get("Range") == "" {
-				t.Errorf("GET fallback should set Range header")
+// TestRun_XMLTVURL_FallbackToGETOnHEADFailure verifies that any non-2xx/3xx
+// HEAD response triggers the cheap Range GET fallback. The list covers the
+// common rejection codes seen in the wild (405 Method Not Allowed, 406 Not
+// Acceptable from xmltv.net — issue #270 — plus other typical rejections).
+func TestRun_XMLTVURL_FallbackToGETOnHEADFailure(t *testing.T) {
+	cases := []struct {
+		name       string
+		headStatus int
+	}{
+		{"400", http.StatusBadRequest},
+		{"403", http.StatusForbidden},
+		{"405", http.StatusMethodNotAllowed},
+		{"406", http.StatusNotAcceptable},
+		{"501", http.StatusNotImplemented},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Now()
+			var headCalls, getCalls atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodHead:
+					headCalls.Add(1)
+					w.WriteHeader(tc.headStatus)
+				case http.MethodGet:
+					getCalls.Add(1)
+					if r.Header.Get("Range") == "" {
+						t.Errorf("GET fallback should set Range header")
+					}
+					w.WriteHeader(http.StatusPartialContent)
+					w.Write([]byte("x"))
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			}))
+			t.Cleanup(srv.Close)
+
+			c := newChecker(t, healthyDB(now), srv.URL, now)
+			rep := c.Run(context.Background())
+			check := findCheck(t, rep, "xmltv_url")
+			if check.Status != StatusSuccess {
+				t.Errorf("xmltv_url status = %q, want SUCCESS (err=%q)", check.Status, check.Error)
 			}
-			w.WriteHeader(http.StatusPartialContent)
-			w.Write([]byte("x"))
-		default:
-			w.WriteHeader(http.StatusMethodNotAllowed)
-		}
-	}))
-	t.Cleanup(srv.Close)
-
-	c := newChecker(t, healthyDB(now), srv.URL, now)
-	rep := c.Run(context.Background())
-	check := findCheck(t, rep, "xmltv_url")
-	if check.Status != StatusSuccess {
-		t.Errorf("xmltv_url status = %q, want SUCCESS (err=%q)", check.Status, check.Error)
-	}
-	if headCalls.Load() != 1 {
-		t.Errorf("HEAD called %d times, want 1", headCalls.Load())
-	}
-	if getCalls.Load() != 1 {
-		t.Errorf("GET called %d times, want 1", getCalls.Load())
-	}
-}
-
-func TestRun_XMLTVURL_FallbackToGETOn406(t *testing.T) {
-	now := time.Now()
-	var headCalls, getCalls atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodHead:
-			headCalls.Add(1)
-			w.WriteHeader(http.StatusNotAcceptable)
-		case http.MethodGet:
-			getCalls.Add(1)
-			if r.Header.Get("Range") == "" {
-				t.Errorf("GET fallback should set Range header")
+			if headCalls.Load() != 1 {
+				t.Errorf("HEAD called %d times, want 1", headCalls.Load())
 			}
-			w.WriteHeader(http.StatusPartialContent)
-			w.Write([]byte("x"))
-		default:
-			w.WriteHeader(http.StatusMethodNotAllowed)
-		}
-	}))
-	t.Cleanup(srv.Close)
-
-	c := newChecker(t, healthyDB(now), srv.URL, now)
-	rep := c.Run(context.Background())
-	check := findCheck(t, rep, "xmltv_url")
-	if check.Status != StatusSuccess {
-		t.Errorf("xmltv_url status = %q, want SUCCESS (err=%q)", check.Status, check.Error)
-	}
-	if headCalls.Load() != 1 {
-		t.Errorf("HEAD called %d times, want 1", headCalls.Load())
-	}
-	if getCalls.Load() != 1 {
-		t.Errorf("GET called %d times, want 1", getCalls.Load())
+			if getCalls.Load() != 1 {
+				t.Errorf("GET called %d times, want 1", getCalls.Load())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- `probeXMLTV` now sends the same `Accept: text/xml, application/xml, */*` and `User-Agent: xmltvguide/1.0` headers as the real XMLTV fetcher, fixing the 406 Not Acceptable from hosts like xmltv.net.
- The HEAD→GET fallback now triggers on any non-2xx/3xx HEAD status (not only 405), so 400/403/406/501 etc. fall through to a cheap `Range: bytes=0-0` GET.
- Adds tests covering the 406 fallback path and asserting both probe requests carry the expected headers.

Fixes #270

## Test plan
- [x] `go test ./internal/deepcheck/...` — all pass, including new tests
- [x] `go test ./...` — full suite green
- [ ] Manual verification against xmltv.net via `/api/deepcheck` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)