### PR TITLE
Plex EPG enrichment 1/3: client, logging, config (#281)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,10 @@ tvguide/
 | `RSS_TTL` | `360` | Default TTL (time-to-live) in minutes for RSS feed responses. Tells feed readers how often to re-poll. Can be overridden per-request via the `ttl` query parameter on `/api/search`. Must be a positive integer; invalid values are ignored. |
 | `HIDDEN_CHANNELS` | *(unset)* | Comma-separated list of channel IDs and/or LCN numbers to hide server-wide. Integer tokens are treated as LCN numbers; all other tokens are treated as channel IDs. Hidden channels are excluded from all API responses (`/api/channels`, `/api/guide`, `/api/search`, `/api/explore/now-next`). Example: `ch1.xmltv.id,6,9,10` |
 | `CHANNEL_NAME_STRIP` | *(unset)* | Comma-separated list of words/phrases to strip from all channel display names at refresh time. Matching is case-insensitive; resulting names are trimmed of surrounding whitespace. Example: `Melbourne,Victoria` turns "ABC Melbourne" into "ABC" and "Nine Victoria" into "Nine". |
+| `LOG_LEVEL` | `info` | Global log level for the `internal/logging` package. Accepts `debug`, `info`, `warn`, `error` (case-insensitive). Invalid values fall back to `info` and emit a warning at startup. |
+| `PLEX_URL` | *(unset)* | Origin of the Plex Media Server used as an EPG enrichment source (e.g. `http://plex.local:32400`). Enrichment is a no-op while this is unset. Requires `PLEX_TOKEN`; if `PLEX_TOKEN` is empty, Plex enrichment is disabled with an error log line and the XMLTV path continues to work. |
+| `PLEX_TOKEN` | *(unset)* | `X-Plex-Token` value for authenticating against the Plex Media Server identified by `PLEX_URL`. Required whenever `PLEX_URL` is set. |
+| `PLEX_POLL_INTERVAL` | `12h` | How often to re-poll the Plex EPG endpoints for enrichment. Accepts Go duration strings: `6h`, `30m`, etc. Independent of `POLL_INTERVAL` (the XMLTV cadence). |
 
 ## How to build and run
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,72 @@
+// Package logging provides a thin wrapper around log/slog for leveled logging.
+//
+// Call Init once at startup to configure the default slog handler. Other
+// packages then use Debug/Info/Warn/Error which forward to slog. The package
+// is designed to be a forward-looking replacement for log.Printf; existing
+// log.Printf call sites can be migrated incrementally.
+package logging
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Init configures the default slog handler at the requested level, writing
+// to os.Stderr. An unrecognised level falls back to info and emits a warning
+// describing the bad value.
+func Init(level string) {
+	InitWithWriter(level, os.Stderr)
+}
+
+// InitWithWriter behaves like Init but routes output to w instead of os.Stderr.
+// Intended for tests that need to capture output.
+func InitWithWriter(level string, w io.Writer) {
+	parsed, ok := parseLevel(level)
+	handler := slog.NewTextHandler(w, &slog.HandlerOptions{Level: parsed})
+	slog.SetDefault(slog.New(handler))
+	if !ok {
+		Warn(fmt.Sprintf("invalid log level %q; falling back to info", level))
+	}
+}
+
+// parseLevel maps a case-insensitive level string to a slog.Level. The second
+// return value is false when the input was not recognised; the caller is
+// responsible for falling back and warning.
+func parseLevel(level string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "debug":
+		return slog.LevelDebug, true
+	case "", "info":
+		return slog.LevelInfo, level == "" || strings.EqualFold(level, "info")
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error":
+		return slog.LevelError, true
+	default:
+		return slog.LevelInfo, false
+	}
+}
+
+// Debug emits a DEBUG-level log line.
+func Debug(msg string, args ...any) {
+	slog.Default().Log(context.Background(), slog.LevelDebug, msg, args...)
+}
+
+// Info emits an INFO-level log line.
+func Info(msg string, args ...any) {
+	slog.Default().Log(context.Background(), slog.LevelInfo, msg, args...)
+}
+
+// Warn emits a WARN-level log line.
+func Warn(msg string, args ...any) {
+	slog.Default().Log(context.Background(), slog.LevelWarn, msg, args...)
+}
+
+// Error emits an ERROR-level log line.
+func Error(msg string, args ...any) {
+	slog.Default().Log(context.Background(), slog.LevelError, msg, args...)
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,121 @@
+package logging_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/acbgbca/xmltvguide/internal/logging"
+)
+
+// captureOutput swaps the default slog handler so the test can read what was
+// emitted. It restores the previous default on cleanup.
+func captureOutput(t *testing.T, level string) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	logging.InitWithWriter(level, buf)
+	return buf
+}
+
+func TestInit_InfoLevelSuppressesDebug(t *testing.T) {
+	buf := captureOutput(t, "info")
+
+	logging.Debug("debug-line")
+	logging.Info("info-line")
+
+	out := buf.String()
+	if strings.Contains(out, "debug-line") {
+		t.Errorf("expected debug to be suppressed at info level; output: %q", out)
+	}
+	if !strings.Contains(out, "info-line") {
+		t.Errorf("expected info-line in output; got: %q", out)
+	}
+}
+
+func TestInit_DebugLevelEmitsAllLevels(t *testing.T) {
+	buf := captureOutput(t, "debug")
+
+	logging.Debug("d")
+	logging.Info("i")
+	logging.Warn("w")
+	logging.Error("e")
+
+	out := buf.String()
+	for _, want := range []string{"d", "i", "w", "e"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output at debug level; got: %q", want, out)
+		}
+	}
+}
+
+func TestInit_WarnLevelSuppressesDebugAndInfo(t *testing.T) {
+	buf := captureOutput(t, "warn")
+
+	logging.Debug("d-line")
+	logging.Info("i-line")
+	logging.Warn("w-line")
+	logging.Error("e-line")
+
+	out := buf.String()
+	if strings.Contains(out, "d-line") {
+		t.Errorf("debug should be suppressed at warn level; got: %q", out)
+	}
+	if strings.Contains(out, "i-line") {
+		t.Errorf("info should be suppressed at warn level; got: %q", out)
+	}
+	if !strings.Contains(out, "w-line") {
+		t.Errorf("warn missing from output: %q", out)
+	}
+	if !strings.Contains(out, "e-line") {
+		t.Errorf("error missing from output: %q", out)
+	}
+}
+
+func TestInit_ErrorLevelEmitsOnlyError(t *testing.T) {
+	buf := captureOutput(t, "error")
+
+	logging.Debug("d-line")
+	logging.Info("i-line")
+	logging.Warn("w-line")
+	logging.Error("e-line")
+
+	out := buf.String()
+	if strings.Contains(out, "d-line") || strings.Contains(out, "i-line") || strings.Contains(out, "w-line") {
+		t.Errorf("only error should be emitted at error level; got: %q", out)
+	}
+	if !strings.Contains(out, "e-line") {
+		t.Errorf("error missing from output: %q", out)
+	}
+}
+
+func TestInit_InvalidLevelFallsBackToInfoAndWarns(t *testing.T) {
+	buf := captureOutput(t, "verbose")
+
+	// The init call should have emitted a warning about the invalid level.
+	if !strings.Contains(strings.ToLower(buf.String()), "invalid log level") {
+		t.Errorf("expected init to warn about invalid level; got: %q", buf.String())
+	}
+
+	buf.Reset()
+
+	logging.Debug("dbg")
+	logging.Info("inf")
+	if strings.Contains(buf.String(), "dbg") {
+		t.Errorf("invalid level should fall back to info (debug suppressed); got: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "inf") {
+		t.Errorf("invalid level should fall back to info (info emitted); got: %q", buf.String())
+	}
+}
+
+func TestInit_CaseInsensitive(t *testing.T) {
+	buf := captureOutput(t, "DEBUG")
+	logging.Debug("dbg-line")
+	if !strings.Contains(buf.String(), "dbg-line") {
+		t.Errorf("DEBUG (uppercase) should be accepted; got: %q", buf.String())
+	}
+}

--- a/internal/plex/client.go
+++ b/internal/plex/client.go
@@ -1,0 +1,141 @@
+package plex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/logging"
+)
+
+// ErrUnauthorized is returned by all client methods when the server responds
+// with 401 or 403. Callers can match it with errors.Is to surface an
+// actionable "PLEX_TOKEN appears invalid" message.
+var ErrUnauthorized = errors.New("plex: unauthorized")
+
+// Client is a typed HTTP client for the Plex EPG endpoints used by this app.
+type Client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+// NewClient builds a Client. baseURL is the Plex Media Server origin (no
+// trailing slash required). httpClient, if nil, falls back to a default
+// client with a sensible timeout.
+func NewClient(baseURL, token string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		token:      token,
+		httpClient: httpClient,
+	}
+}
+
+// Ping issues GET /identity. Returns nil on 200, ErrUnauthorized on 401/403,
+// wrapped error otherwise.
+func (c *Client) Ping(ctx context.Context) error {
+	_, err := c.doRequest(ctx, "/identity", nil)
+	return err
+}
+
+// GetDVRs issues GET /livetv/dvrs.
+func (c *Client) GetDVRs(ctx context.Context) ([]DVR, error) {
+	body, err := c.doRequest(ctx, "/livetv/dvrs", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out dvrsResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("plex GET /livetv/dvrs: json decode: %w", err)
+	}
+	return out.MediaContainer.Dvr, nil
+}
+
+// GetLineupChannels issues GET /epg/lineups/{lineupID}/channels.
+func (c *Client) GetLineupChannels(ctx context.Context, lineupID string) ([]LineupChannel, error) {
+	path := "/epg/lineups/" + lineupID + "/channels"
+	body, err := c.doRequest(ctx, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out lineupChannelsResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("plex GET %s: json decode: %w", path, err)
+	}
+	return out.MediaContainer.Channel, nil
+}
+
+// GetGrid issues GET /{gridKey}/grid?type=4&beginsAt=<unix>&endsAt=<unix>.
+func (c *Client) GetGrid(ctx context.Context, gridKey string, beginsAt, endsAt time.Time) ([]GridEntry, error) {
+	// gridKey is a path prefix returned by /livetv/dvrs; preserve its leading
+	// slash but tolerate inputs without one.
+	if !strings.HasPrefix(gridKey, "/") {
+		gridKey = "/" + gridKey
+	}
+	path := gridKey + "/grid"
+	query := map[string]string{
+		"type":     "4",
+		"beginsAt": strconv.FormatInt(beginsAt.Unix(), 10),
+		"endsAt":   strconv.FormatInt(endsAt.Unix(), 10),
+	}
+	body, err := c.doRequest(ctx, path, query)
+	if err != nil {
+		return nil, err
+	}
+	var out gridResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("plex GET %s: json decode: %w", path, err)
+	}
+	return out.MediaContainer.Metadata, nil
+}
+
+// doRequest is the single point at which all requests are issued. It sets the
+// auth + accept headers, executes the request, logs a debug line summarising
+// the result, and maps 401/403 to ErrUnauthorized.
+func (c *Client) doRequest(ctx context.Context, path string, query map[string]string) ([]byte, error) {
+	url := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("plex GET %s: %w", path, err)
+	}
+	if len(query) > 0 {
+		q := req.URL.Query()
+		for k, v := range query {
+			q.Set(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+	req.Header.Set("X-Plex-Token", c.token)
+	req.Header.Set("Accept", "application/json")
+
+	start := time.Now()
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("plex GET %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, readErr := io.ReadAll(resp.Body)
+	elapsed := time.Since(start)
+	logging.Debug(fmt.Sprintf("plex GET %s → %d (%d bytes, %dms)", path, resp.StatusCode, len(body), elapsed.Milliseconds()))
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("plex GET %s: %w", path, ErrUnauthorized)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("plex GET %s: unexpected status %d", path, resp.StatusCode)
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("plex GET %s: reading body: %w", path, readErr)
+	}
+	return body, nil
+}

--- a/internal/plex/client_test.go
+++ b/internal/plex/client_test.go
@@ -1,0 +1,355 @@
+package plex_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/plex"
+)
+
+// startServer wraps httptest.NewServer with cleanup.
+func startServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newClient(t *testing.T, baseURL, token string) *plex.Client {
+	t.Helper()
+	return plex.NewClient(baseURL, token, &http.Client{Timeout: 2 * time.Second})
+}
+
+// --- Ping ---
+
+func TestPing_Success(t *testing.T) {
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/identity" {
+			t.Errorf("expected /identity, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Plex-Token"); got != "tok" {
+			t.Errorf("missing/wrong X-Plex-Token: %q", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("expected Accept application/json, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"MediaContainer":{"machineIdentifier":"abc"}}`))
+	}))
+
+	c := newClient(t, srv.URL, "tok")
+	if err := c.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: unexpected error: %v", err)
+	}
+}
+
+func TestPing_Unauthorized(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+			}))
+			c := newClient(t, srv.URL, "tok")
+			err := c.Ping(context.Background())
+			if !errors.Is(err, plex.ErrUnauthorized) {
+				t.Errorf("expected ErrUnauthorized for %d, got %v", code, err)
+			}
+		})
+	}
+}
+
+func TestPing_ServerErrorWrapsURL(t *testing.T) {
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	c := newClient(t, srv.URL, "tok")
+	err := c.Ping(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+	if !strings.Contains(err.Error(), "/identity") {
+		t.Errorf("error should mention URL path; got: %v", err)
+	}
+}
+
+// --- GetDVRs ---
+
+func TestGetDVRs_HappyPath(t *testing.T) {
+	body := `{
+		"MediaContainer": {
+			"Dvr": [
+				{"id": 1, "lineupIDs": ["xmltv:1"], "gridKey": "/tv.plex.providers.epg.xmltv:1"},
+				{"id": 2, "lineupIDs": ["cloud:7", "cloud:8"], "gridKey": "/tv.plex.providers.epg.cloud:2"}
+			]
+		}
+	}`
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/livetv/dvrs" {
+			t.Errorf("expected /livetv/dvrs, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Plex-Token"); got != "tok" {
+			t.Errorf("missing X-Plex-Token: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+
+	c := newClient(t, srv.URL, "tok")
+	dvrs, err := c.GetDVRs(context.Background())
+	if err != nil {
+		t.Fatalf("GetDVRs: %v", err)
+	}
+	if len(dvrs) != 2 {
+		t.Fatalf("expected 2 DVRs, got %d", len(dvrs))
+	}
+	if dvrs[0].ID != 1 {
+		t.Errorf("dvrs[0].ID = %d, want 1", dvrs[0].ID)
+	}
+	if dvrs[0].GridKey != "/tv.plex.providers.epg.xmltv:1" {
+		t.Errorf("dvrs[0].GridKey = %q", dvrs[0].GridKey)
+	}
+	if len(dvrs[0].LineupIDs) != 1 || dvrs[0].LineupIDs[0] != "xmltv:1" {
+		t.Errorf("dvrs[0].LineupIDs = %v", dvrs[0].LineupIDs)
+	}
+	if len(dvrs[1].LineupIDs) != 2 {
+		t.Errorf("dvrs[1].LineupIDs = %v, want 2 entries", dvrs[1].LineupIDs)
+	}
+}
+
+func TestGetDVRs_Unauthorized(t *testing.T) {
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	c := newClient(t, srv.URL, "tok")
+	_, err := c.GetDVRs(context.Background())
+	if !errors.Is(err, plex.ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+func TestGetDVRs_5xxWrapsURL(t *testing.T) {
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	c := newClient(t, srv.URL, "tok")
+	_, err := c.GetDVRs(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "/livetv/dvrs") {
+		t.Errorf("error should include request URL; got: %v", err)
+	}
+}
+
+func TestGetDVRs_MalformedJSON(t *testing.T) {
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not json{`))
+	}))
+	c := newClient(t, srv.URL, "tok")
+	_, err := c.GetDVRs(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "json") {
+		t.Errorf("error should mention json decode; got: %v", err)
+	}
+}
+
+// --- GetLineupChannels ---
+
+func TestGetLineupChannels_HappyPath(t *testing.T) {
+	body := `{
+		"MediaContainer": {
+			"Channel": [
+				{"id": "ch-1", "xmltvId": "abc.com.au", "lcn": "2", "title": "ABC"},
+				{"id": "ch-2", "title": "SBS Viceland"}
+			]
+		}
+	}`
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/epg/lineups/xmltv:1/channels" {
+			t.Errorf("expected /epg/lineups/xmltv:1/channels, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+
+	c := newClient(t, srv.URL, "tok")
+	chans, err := c.GetLineupChannels(context.Background(), "xmltv:1")
+	if err != nil {
+		t.Fatalf("GetLineupChannels: %v", err)
+	}
+	if len(chans) != 2 {
+		t.Fatalf("expected 2 channels, got %d", len(chans))
+	}
+	if chans[0].ID != "ch-1" {
+		t.Errorf("chans[0].ID = %q", chans[0].ID)
+	}
+	if chans[0].XMLTVID != "abc.com.au" {
+		t.Errorf("chans[0].XMLTVID = %q", chans[0].XMLTVID)
+	}
+	if chans[0].LCN != "2" {
+		t.Errorf("chans[0].LCN = %q", chans[0].LCN)
+	}
+	if chans[0].DisplayName != "ABC" {
+		t.Errorf("chans[0].DisplayName = %q", chans[0].DisplayName)
+	}
+	if chans[1].XMLTVID != "" || chans[1].LCN != "" {
+		t.Errorf("optional fields should be empty: %+v", chans[1])
+	}
+}
+
+func TestGetLineupChannels_Unauthorized(t *testing.T) {
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	c := newClient(t, srv.URL, "tok")
+	_, err := c.GetLineupChannels(context.Background(), "xmltv:1")
+	if !errors.Is(err, plex.ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+// --- GetGrid ---
+
+func TestGetGrid_HappyPath(t *testing.T) {
+	begins := time.Date(2025, 6, 10, 12, 0, 0, 0, time.UTC)
+	ends := begins.Add(2 * time.Hour)
+
+	body := `{
+		"MediaContainer": {
+			"Metadata": [
+				{"ratingKey": "rk-1", "channel": "ch-1", "beginsAt": 1749556800, "endsAt": 1749560400, "title": "News at Noon", "ddProgID": "EP000123450001"},
+				{"ratingKey": "rk-2", "channel": "ch-1", "beginsAt": 1749560400, "endsAt": 1749564000, "title": "Sports"}
+			]
+		}
+	}`
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/tv.plex.providers.epg.xmltv:1/grid") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("type") != "4" {
+			t.Errorf("type query = %q, want 4", q.Get("type"))
+		}
+		if q.Get("beginsAt") == "" {
+			t.Errorf("beginsAt missing")
+		}
+		if q.Get("endsAt") == "" {
+			t.Errorf("endsAt missing")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+
+	c := newClient(t, srv.URL, "tok")
+	entries, err := c.GetGrid(context.Background(), "/tv.plex.providers.epg.xmltv:1", begins, ends)
+	if err != nil {
+		t.Fatalf("GetGrid: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(entries))
+	}
+	if entries[0].RatingKey != "rk-1" {
+		t.Errorf("entries[0].RatingKey = %q", entries[0].RatingKey)
+	}
+	if entries[0].Channel != "ch-1" {
+		t.Errorf("entries[0].Channel = %q", entries[0].Channel)
+	}
+	if entries[0].BeginsAt != 1749556800 {
+		t.Errorf("entries[0].BeginsAt = %d", entries[0].BeginsAt)
+	}
+	if entries[0].EndsAt != 1749560400 {
+		t.Errorf("entries[0].EndsAt = %d", entries[0].EndsAt)
+	}
+	if entries[0].Title != "News at Noon" {
+		t.Errorf("entries[0].Title = %q", entries[0].Title)
+	}
+	if entries[0].DdProgID != "EP000123450001" {
+		t.Errorf("entries[0].DdProgID = %q", entries[0].DdProgID)
+	}
+	if entries[1].DdProgID != "" {
+		t.Errorf("entries[1].DdProgID should be empty when absent; got %q", entries[1].DdProgID)
+	}
+}
+
+func TestGetGrid_PassesUnixTimes(t *testing.T) {
+	begins := time.Date(2025, 6, 10, 0, 0, 0, 0, time.UTC)
+	ends := time.Date(2025, 6, 11, 0, 0, 0, 0, time.UTC)
+
+	var capturedBegins, capturedEnds string
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBegins = r.URL.Query().Get("beginsAt")
+		capturedEnds = r.URL.Query().Get("endsAt")
+		_, _ = w.Write([]byte(`{"MediaContainer":{"Metadata":[]}}`))
+	}))
+
+	c := newClient(t, srv.URL, "tok")
+	if _, err := c.GetGrid(context.Background(), "/grid-key", begins, ends); err != nil {
+		t.Fatalf("GetGrid: %v", err)
+	}
+
+	wantBegins := "1749513600" // unix seconds for 2025-06-10 UTC
+	wantEnds := "1749600000"
+	if capturedBegins != wantBegins {
+		t.Errorf("beginsAt = %q, want %q", capturedBegins, wantBegins)
+	}
+	if capturedEnds != wantEnds {
+		t.Errorf("endsAt = %q, want %q", capturedEnds, wantEnds)
+	}
+}
+
+func TestGetGrid_NetworkTimeoutWraps(t *testing.T) {
+	// Server delays beyond the client timeout.
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	c := plex.NewClient(srv.URL, "tok", &http.Client{Timeout: 50 * time.Millisecond})
+
+	_, err := c.GetGrid(context.Background(), "/grid-key", time.Now(), time.Now().Add(time.Hour))
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "/grid-key") {
+		t.Errorf("error should include URL; got: %v", err)
+	}
+}
+
+// --- Cross-cutting: every request sends X-Plex-Token ---
+
+func TestClient_AlwaysSendsToken(t *testing.T) {
+	calls := 0
+	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Header.Get("X-Plex-Token") != "secret-token" {
+			t.Errorf("request %d missing X-Plex-Token: %q", calls, r.Header.Get("X-Plex-Token"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/identity":
+			_, _ = w.Write([]byte(`{"MediaContainer":{}}`))
+		case r.URL.Path == "/livetv/dvrs":
+			_, _ = w.Write([]byte(`{"MediaContainer":{"Dvr":[]}}`))
+		case strings.Contains(r.URL.Path, "/channels"):
+			_, _ = w.Write([]byte(`{"MediaContainer":{"Channel":[]}}`))
+		case strings.Contains(r.URL.Path, "/grid"):
+			_, _ = w.Write([]byte(`{"MediaContainer":{"Metadata":[]}}`))
+		}
+	}))
+
+	c := newClient(t, srv.URL, "secret-token")
+	ctx := context.Background()
+	_ = c.Ping(ctx)
+	_, _ = c.GetDVRs(ctx)
+	_, _ = c.GetLineupChannels(ctx, "lineup")
+	_, _ = c.GetGrid(ctx, "/grid-key", time.Now(), time.Now().Add(time.Hour))
+
+	if calls != 4 {
+		t.Errorf("expected 4 calls, got %d", calls)
+	}
+}

--- a/internal/plex/types.go
+++ b/internal/plex/types.go
@@ -1,0 +1,52 @@
+// Package plex contains a typed HTTP client for the subset of the Plex
+// Media Server EPG API used by this app.
+package plex
+
+// DVR represents a single DVR configured on a Plex Media Server. The minimal
+// fields here are what the EPG enrichment poller needs: an identifier, the
+// lineup IDs the DVR draws from, and the path prefix used to query the
+// EPG grid (`{GridKey}/grid?...`).
+type DVR struct {
+	ID        int      `json:"id"`
+	LineupIDs []string `json:"lineupIDs,omitempty"`
+	GridKey   string   `json:"gridKey,omitempty"`
+}
+
+// LineupChannel describes one channel within a Plex EPG lineup.
+type LineupChannel struct {
+	ID          string `json:"id"`
+	XMLTVID     string `json:"xmltvId,omitempty"`
+	LCN         string `json:"lcn,omitempty"`
+	DisplayName string `json:"title,omitempty"`
+}
+
+// GridEntry describes a single airing returned by the EPG grid endpoint.
+// BeginsAt and EndsAt are unix-seconds timestamps as returned by Plex.
+type GridEntry struct {
+	RatingKey string `json:"ratingKey"`
+	Channel   string `json:"channel,omitempty"`
+	BeginsAt  int64  `json:"beginsAt"`
+	EndsAt    int64  `json:"endsAt"`
+	Title     string `json:"title,omitempty"`
+	DdProgID  string `json:"ddProgID,omitempty"`
+}
+
+// Internal response wrappers — Plex wraps all responses in a MediaContainer.
+
+type dvrsResponse struct {
+	MediaContainer struct {
+		Dvr []DVR `json:"Dvr"`
+	} `json:"MediaContainer"`
+}
+
+type lineupChannelsResponse struct {
+	MediaContainer struct {
+		Channel []LineupChannel `json:"Channel"`
+	} `json:"MediaContainer"`
+}
+
+type gridResponse struct {
+	MediaContainer struct {
+		Metadata []GridEntry `json:"Metadata"`
+	} `json:"MediaContainer"`
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/acbgbca/xmltvguide/internal/api"
 	"github.com/acbgbca/xmltvguide/internal/database"
 	"github.com/acbgbca/xmltvguide/internal/images"
+	"github.com/acbgbca/xmltvguide/internal/logging"
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
 )
 
@@ -28,17 +29,21 @@ import (
 var webFS embed.FS
 
 type config struct {
-	xmltvURL       string
-	pollInterval   time.Duration
-	retentionDays  int
-	dbPath         string
-	imageCacheDir  string
-	port           string
-	hiddenIDs      []string
-	hiddenLCNs     []int
-	stripWords     []string
-	rssTTL         int
-	refreshOnStart bool
+	xmltvURL         string
+	pollInterval     time.Duration
+	retentionDays    int
+	dbPath           string
+	imageCacheDir    string
+	port             string
+	hiddenIDs        []string
+	hiddenLCNs       []int
+	stripWords       []string
+	rssTTL           int
+	refreshOnStart   bool
+	logLevel         string
+	plexURL          string
+	plexToken        string
+	plexPollInterval time.Duration
 }
 
 func parseConfig() (config, error) {
@@ -92,18 +97,44 @@ func parseConfig() (config, error) {
 
 	refreshOnStart := os.Getenv("REFRESH_ON_START") == "true"
 
+	logLevel := os.Getenv("LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = "info"
+	}
+
+	plexURL := os.Getenv("PLEX_URL")
+	plexToken := os.Getenv("PLEX_TOKEN")
+	plexPollInterval := 12 * time.Hour
+	if v := os.Getenv("PLEX_POLL_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return config{}, fmt.Errorf("invalid PLEX_POLL_INTERVAL %q: %w", v, err)
+		}
+		plexPollInterval = d
+	}
+	// Misconfigured Plex (URL set, token empty) disables enrichment with a clear
+	// error. We never crash on this — the XMLTV path must continue to work.
+	if plexURL != "" && plexToken == "" {
+		logging.Error("PLEX_URL configured but PLEX_TOKEN is empty — set PLEX_TOKEN to enable Plex enrichment. Skipping Plex poller.")
+		plexURL = ""
+	}
+
 	return config{
-		xmltvURL:       xmltvURL,
-		pollInterval:   pollInterval,
-		retentionDays:  retentionDays,
-		dbPath:         dbPath,
-		imageCacheDir:  imageCacheDir,
-		port:           port,
-		hiddenIDs:      hiddenIDs,
-		hiddenLCNs:     hiddenLCNs,
-		stripWords:     stripWords,
-		rssTTL:         rssTTL,
-		refreshOnStart: refreshOnStart,
+		xmltvURL:         xmltvURL,
+		pollInterval:     pollInterval,
+		retentionDays:    retentionDays,
+		dbPath:           dbPath,
+		imageCacheDir:    imageCacheDir,
+		port:             port,
+		hiddenIDs:        hiddenIDs,
+		hiddenLCNs:       hiddenLCNs,
+		stripWords:       stripWords,
+		rssTTL:           rssTTL,
+		refreshOnStart:   refreshOnStart,
+		logLevel:         logLevel,
+		plexURL:          plexURL,
+		plexToken:        plexToken,
+		plexPollInterval: plexPollInterval,
 	}, nil
 }
 
@@ -202,6 +233,12 @@ func main() {
 		}
 		os.Exit(0)
 	}
+
+	// Initialise logging from LOG_LEVEL before parseConfig so any errors
+	// emitted while parsing (e.g. PLEX_URL without PLEX_TOKEN) are routed
+	// through the configured handler. parseConfig also records the resolved
+	// level in the config for documentation/inspection purposes.
+	logging.Init(os.Getenv("LOG_LEVEL"))
 
 	cfg, err := parseConfig()
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -165,6 +165,98 @@ func TestParseConfig_InvalidRssTTLIsIgnored(t *testing.T) {
 	}
 }
 
+func TestParseConfig_LogLevelDefault(t *testing.T) {
+	t.Setenv("XMLTV_URL", "http://example.com/guide.xml")
+	t.Setenv("LOG_LEVEL", "")
+
+	cfg, err := parseConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.logLevel != "info" {
+		t.Errorf("logLevel = %q, want %q", cfg.logLevel, "info")
+	}
+}
+
+func TestParseConfig_LogLevelCustom(t *testing.T) {
+	t.Setenv("XMLTV_URL", "http://example.com/guide.xml")
+	t.Setenv("LOG_LEVEL", "DEBUG")
+
+	cfg, err := parseConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.logLevel != "DEBUG" {
+		t.Errorf("logLevel = %q, want %q", cfg.logLevel, "DEBUG")
+	}
+}
+
+func TestParseConfig_PlexDefaults(t *testing.T) {
+	t.Setenv("XMLTV_URL", "http://example.com/guide.xml")
+	t.Setenv("PLEX_URL", "")
+	t.Setenv("PLEX_TOKEN", "")
+	t.Setenv("PLEX_POLL_INTERVAL", "")
+
+	cfg, err := parseConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.plexURL != "" {
+		t.Errorf("plexURL = %q, want empty", cfg.plexURL)
+	}
+	if cfg.plexToken != "" {
+		t.Errorf("plexToken = %q, want empty", cfg.plexToken)
+	}
+	if cfg.plexPollInterval != 12*time.Hour {
+		t.Errorf("plexPollInterval = %v, want %v", cfg.plexPollInterval, 12*time.Hour)
+	}
+}
+
+func TestParseConfig_PlexCustom(t *testing.T) {
+	t.Setenv("XMLTV_URL", "http://example.com/guide.xml")
+	t.Setenv("PLEX_URL", "http://plex.local:32400")
+	t.Setenv("PLEX_TOKEN", "secret")
+	t.Setenv("PLEX_POLL_INTERVAL", "6h")
+
+	cfg, err := parseConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.plexURL != "http://plex.local:32400" {
+		t.Errorf("plexURL = %q", cfg.plexURL)
+	}
+	if cfg.plexToken != "secret" {
+		t.Errorf("plexToken = %q", cfg.plexToken)
+	}
+	if cfg.plexPollInterval != 6*time.Hour {
+		t.Errorf("plexPollInterval = %v", cfg.plexPollInterval)
+	}
+}
+
+func TestParseConfig_PlexURLWithoutTokenIsDisabled(t *testing.T) {
+	t.Setenv("XMLTV_URL", "http://example.com/guide.xml")
+	t.Setenv("PLEX_URL", "http://plex.local:32400")
+	t.Setenv("PLEX_TOKEN", "")
+
+	cfg, err := parseConfig()
+	if err != nil {
+		t.Fatalf("parseConfig should not fail on missing token, got: %v", err)
+	}
+	if cfg.plexURL != "" {
+		t.Errorf("expected plexURL to be cleared when token is missing, got %q", cfg.plexURL)
+	}
+}
+
+func TestParseConfig_InvalidPlexPollInterval(t *testing.T) {
+	t.Setenv("XMLTV_URL", "http://example.com/guide.xml")
+	t.Setenv("PLEX_POLL_INTERVAL", "notaduration")
+
+	_, err := parseConfig()
+	if err == nil {
+		t.Fatal("expected error for invalid PLEX_POLL_INTERVAL")
+	}
+}
+
 func TestParseConfig_NegativeRssTTLIsIgnored(t *testing.T) {
 	t.Setenv("XMLTV_URL", "http://example.com/guide.xml")
 	t.Setenv("POLL_INTERVAL", "")


### PR DESCRIPTION
## Summary
- New `internal/logging` package: slog-based leveled logger (`Init`/`Debug`/`Info`/`Warn`/`Error`); invalid `LOG_LEVEL` values fall back to info with a warning.
- New `internal/plex` package: typed client for `/identity`, `/livetv/dvrs`, `/epg/lineups/{id}/channels`, `/{gridKey}/grid` with `X-Plex-Token` auth and `ErrUnauthorized` sentinel for 401/403.
- Config additions: `LOG_LEVEL`, `PLEX_URL`, `PLEX_TOKEN`, `PLEX_POLL_INTERVAL`. `PLEX_URL` without `PLEX_TOKEN` logs the exact error from the issue and disables enrichment — XMLTV path keeps running.
- CLAUDE.md Configuration table documents all four new env vars.

No behaviour change yet — the Plex client is exercised only via unit tests at this stage. Database, poller, and API wiring land in #282 and #283.

Closes part of #276. Issue: #281.

## Test plan
- [ ] `go test ./...` passes
- [ ] Verify `internal/logging` tests cover level filtering, fallback on invalid input, case-insensitive parsing
- [ ] Verify `internal/plex` tests cover happy paths, 401/403 → `ErrUnauthorized`, 5xx URL-wrapping, malformed JSON, timeout, and the cross-cutting header check
- [ ] Confirm app starts cleanly with `PLEX_URL` set and `PLEX_TOKEN` unset (should log error, continue running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)