### PR TITLE
Add Plex schema migration and channel/airing matchers (#282)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,10 +122,11 @@ SQLite file at `DB_PATH` (default `/data/tvguide.db`). Mount `/data` as a named 
 ### Schema
 
 ```sql
-channels (id PK, display_name, icon, sort_order, lcn, icon_url)
+channels (id PK, display_name, icon, sort_order, lcn, icon_url, plex_channel_id, plex_lineup_id)
 -- lcn:     logical channel number from <lcn> element (nullable); used for display ordering
 -- icon:    local filesystem path of the cached icon file (e.g. /data/images/channels/ch1.png); NULL if not yet downloaded
 -- icon_url: original external URL from the XMLTV source; used to detect URL changes and to re-download if the local file goes missing
+-- plex_channel_id, plex_lineup_id: Plex EPG enrichment IDs; nullable, populated by the Plex poller (see #276/#282)
 
 airings (
   channel_id + start_time  -- composite PK
@@ -135,7 +136,8 @@ airings (
   episode_num_display      -- onscreen/SxxExx format: "S02E04"
   prog_id                  -- dd_progid (TMS/Gracenote stable ID, if present)
   star_rating, content_rating, year, icon, country,
-  is_repeat, is_premiere
+  is_repeat, is_premiere,
+  plex_rating_key          -- Plex EPG ratingKey; nullable, populated by the Plex poller (see #276/#282)
 )
 
 airings_fts  -- FTS5 virtual table for full-text search

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -107,6 +107,9 @@ var migrations = []migration{
 		`INSERT OR IGNORE INTO categories (name)
 		SELECT DISTINCT value FROM airings, json_each(airings.categories)
 		WHERE value IS NOT NULL AND value != ''`},
+	{5, `ALTER TABLE channels ADD COLUMN plex_channel_id TEXT;
+ALTER TABLE channels ADD COLUMN plex_lineup_id TEXT;
+ALTER TABLE airings ADD COLUMN plex_rating_key TEXT;`, ""},
 }
 
 // applyMigration applies a single migration to the database. It checks whether
@@ -175,6 +178,17 @@ func migrationAlreadyApplied(db *sql.DB, version int) (bool, error) {
 		return tableExists(db, "airings_fts")
 	case 4:
 		return tableExists(db, "categories")
+	case 5:
+		// All three columns must be present for the migration to be considered applied.
+		chOK, err := columnExists(db, "channels", "plex_channel_id")
+		if err != nil || !chOK {
+			return false, err
+		}
+		lineupOK, err := columnExists(db, "channels", "plex_lineup_id")
+		if err != nil || !lineupOK {
+			return false, err
+		}
+		return columnExists(db, "airings", "plex_rating_key")
 	}
 	return false, nil
 }

--- a/internal/database/migrations_test.go
+++ b/internal/database/migrations_test.go
@@ -202,3 +202,38 @@ func TestMigration_PopulateSQL_SkipsAlreadyApplied(t *testing.T) {
 		t.Errorf("expected FTS to be empty (populateSQL should not re-run), got %d results", len(results))
 	}
 }
+
+// TestMigration_PlexColumnsExist verifies that after migrations run, the
+// channels table has plex_channel_id and plex_lineup_id columns, and the
+// airings table has a plex_rating_key column. These are nullable enrichment
+// columns populated by the Plex poller (see issue #282).
+func TestMigration_PlexColumnsExist(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Open the DB so all migrations run.
+	openDBAt(t, dbPath)
+
+	rawDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	defer rawDB.Close()
+
+	expectColumn := func(table, column string) {
+		t.Helper()
+		var count int
+		if err := rawDB.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?", table, column,
+		).Scan(&count); err != nil {
+			t.Fatalf("pragma_table_info(%s, %s): %v", table, column, err)
+		}
+		if count != 1 {
+			t.Errorf("expected column %s.%s to exist (count=1), got count=%d", table, column, count)
+		}
+	}
+
+	expectColumn("channels", "plex_channel_id")
+	expectColumn("channels", "plex_lineup_id")
+	expectColumn("airings", "plex_rating_key")
+}

--- a/internal/plex/match.go
+++ b/internal/plex/match.go
@@ -33,67 +33,98 @@ const (
 	UnmatchedNoStartTimeMatch
 )
 
+// tierResult describes the outcome of a single matcher tier.
+type tierResult int
+
+const (
+	tierMiss      tierResult = iota // no candidate matched — fall through to the next tier
+	tierHit                         // exactly one candidate matched
+	tierAmbiguous                   // two or more candidates matched — stop without falling through
+)
+
+// findUnique scans candidates and returns the sole element satisfying pred.
+// The tierResult distinguishes "no match" (caller should fall through) from
+// "ambiguous" (caller should stop with MatchSourceNone).
+func findUnique(candidates []model.Channel, pred func(*model.Channel) bool) (*model.Channel, tierResult) {
+	var match *model.Channel
+	for i := range candidates {
+		if !pred(&candidates[i]) {
+			continue
+		}
+		if match != nil {
+			return nil, tierAmbiguous
+		}
+		match = &candidates[i]
+	}
+	if match == nil {
+		return nil, tierMiss
+	}
+	return match, tierHit
+}
+
 // MatchChannel pairs a Plex lineup channel with one local channel. The cascade
 // is ID → LCN → Name. At each tier, an ambiguous result (two or more
 // candidates match by the same property) returns MatchSourceNone without
 // falling through — see issue #282 for the rationale.
 func MatchChannel(plex LineupChannel, candidates []model.Channel) (*model.Channel, MatchSource) {
-	if len(candidates) == 0 {
-		return nil, MatchSourceNone
+	tiers := []struct {
+		source MatchSource
+		pred   func(*model.Channel) bool
+	}{
+		{MatchSourceID, idPredicate(plex)},
+		{MatchSourceLCN, lcnPredicate(plex)},
+		{MatchSourceName, namePredicate(plex)},
 	}
 
-	// Tier 1: exact xmltv id equality.
-	if plex.XMLTVID != "" {
-		var hits []*model.Channel
-		for i := range candidates {
-			if candidates[i].ID == plex.XMLTVID {
-				hits = append(hits, &candidates[i])
-			}
+	for _, t := range tiers {
+		if t.pred == nil {
+			continue
 		}
-		if len(hits) == 1 {
-			return hits[0], MatchSourceID
-		}
-		if len(hits) > 1 {
+		match, result := findUnique(candidates, t.pred)
+		switch result {
+		case tierHit:
+			return match, t.source
+		case tierAmbiguous:
 			return nil, MatchSourceNone
 		}
 	}
-
-	// Tier 2: exact LCN equality (only when both sides have an LCN).
-	if plex.LCN != "" {
-		if plexLCN, err := strconv.Atoi(plex.LCN); err == nil {
-			var hits []*model.Channel
-			for i := range candidates {
-				if candidates[i].LCN != nil && *candidates[i].LCN == plexLCN {
-					hits = append(hits, &candidates[i])
-				}
-			}
-			if len(hits) == 1 {
-				return hits[0], MatchSourceLCN
-			}
-			if len(hits) > 1 {
-				return nil, MatchSourceNone
-			}
-		}
-	}
-
-	// Tier 3: case-insensitive display_name equality.
-	if plex.DisplayName != "" {
-		target := strings.ToLower(plex.DisplayName)
-		var hits []*model.Channel
-		for i := range candidates {
-			if strings.ToLower(candidates[i].DisplayName) == target {
-				hits = append(hits, &candidates[i])
-			}
-		}
-		if len(hits) == 1 {
-			return hits[0], MatchSourceName
-		}
-		if len(hits) > 1 {
-			return nil, MatchSourceNone
-		}
-	}
-
 	return nil, MatchSourceNone
+}
+
+// idPredicate returns a match function for the ID tier, or nil if Plex has no
+// xmltv id to compare against.
+func idPredicate(plex LineupChannel) func(*model.Channel) bool {
+	if plex.XMLTVID == "" {
+		return nil
+	}
+	return func(c *model.Channel) bool { return c.ID == plex.XMLTVID }
+}
+
+// lcnPredicate returns a match function for the LCN tier, or nil if Plex has
+// no LCN or its LCN is not a valid integer.
+func lcnPredicate(plex LineupChannel) func(*model.Channel) bool {
+	if plex.LCN == "" {
+		return nil
+	}
+	plexLCN, err := strconv.Atoi(plex.LCN)
+	if err != nil {
+		return nil
+	}
+	return func(c *model.Channel) bool {
+		return c.LCN != nil && *c.LCN == plexLCN
+	}
+}
+
+// namePredicate returns a match function for the case-insensitive display-name
+// tier, or nil if Plex has no display name.
+func namePredicate(plex LineupChannel) func(*model.Channel) bool {
+	if plex.DisplayName == "" {
+		return nil
+	}
+	target := strings.ToLower(plex.DisplayName)
+	return func(c *model.Channel) bool {
+		return strings.ToLower(c.DisplayName) == target
+	}
 }
 
 // MatchAiring pairs a Plex grid entry with one airing on the already-matched

--- a/internal/plex/match.go
+++ b/internal/plex/match.go
@@ -1,0 +1,122 @@
+package plex
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/acbgbca/xmltvguide/internal/model"
+)
+
+// MatchSource identifies which property was used to pair a Plex entity with a
+// local TV Guide entity. MatchSourceNone means no match was found (or the
+// match was ambiguous).
+type MatchSource int
+
+const (
+	MatchSourceNone MatchSource = iota
+	MatchSourceID
+	MatchSourceLCN
+	MatchSourceName
+	MatchSourceProgID
+	MatchSourceStartTime
+)
+
+// UnmatchedReason explains why an airing could not be paired with a local
+// candidate. The poller logs this so that operators can investigate.
+type UnmatchedReason int
+
+const (
+	UnmatchedNone UnmatchedReason = iota
+	UnmatchedNoCandidate
+	UnmatchedNoProgID
+	UnmatchedProgIDMismatch
+	UnmatchedNoStartTimeMatch
+)
+
+// MatchChannel pairs a Plex lineup channel with one local channel. The cascade
+// is ID → LCN → Name. At each tier, an ambiguous result (two or more
+// candidates match by the same property) returns MatchSourceNone without
+// falling through — see issue #282 for the rationale.
+func MatchChannel(plex LineupChannel, candidates []model.Channel) (*model.Channel, MatchSource) {
+	if len(candidates) == 0 {
+		return nil, MatchSourceNone
+	}
+
+	// Tier 1: exact xmltv id equality.
+	if plex.XMLTVID != "" {
+		var hits []*model.Channel
+		for i := range candidates {
+			if candidates[i].ID == plex.XMLTVID {
+				hits = append(hits, &candidates[i])
+			}
+		}
+		if len(hits) == 1 {
+			return hits[0], MatchSourceID
+		}
+		if len(hits) > 1 {
+			return nil, MatchSourceNone
+		}
+	}
+
+	// Tier 2: exact LCN equality (only when both sides have an LCN).
+	if plex.LCN != "" {
+		if plexLCN, err := strconv.Atoi(plex.LCN); err == nil {
+			var hits []*model.Channel
+			for i := range candidates {
+				if candidates[i].LCN != nil && *candidates[i].LCN == plexLCN {
+					hits = append(hits, &candidates[i])
+				}
+			}
+			if len(hits) == 1 {
+				return hits[0], MatchSourceLCN
+			}
+			if len(hits) > 1 {
+				return nil, MatchSourceNone
+			}
+		}
+	}
+
+	// Tier 3: case-insensitive display_name equality.
+	if plex.DisplayName != "" {
+		target := strings.ToLower(plex.DisplayName)
+		var hits []*model.Channel
+		for i := range candidates {
+			if strings.ToLower(candidates[i].DisplayName) == target {
+				hits = append(hits, &candidates[i])
+			}
+		}
+		if len(hits) == 1 {
+			return hits[0], MatchSourceName
+		}
+		if len(hits) > 1 {
+			return nil, MatchSourceNone
+		}
+	}
+
+	return nil, MatchSourceNone
+}
+
+// MatchAiring pairs a Plex grid entry with one airing on the already-matched
+// channel. Callers must narrow candidates to the matched channel before
+// invoking. See issue #282 for the strategy rules.
+func MatchAiring(plex GridEntry, candidates []model.Airing) (*model.Airing, MatchSource, UnmatchedReason) {
+	if len(candidates) == 0 {
+		return nil, MatchSourceNone, UnmatchedNoCandidate
+	}
+
+	if plex.DdProgID != "" {
+		for i := range candidates {
+			if candidates[i].ProgID == plex.DdProgID {
+				return &candidates[i], MatchSourceProgID, UnmatchedNone
+			}
+		}
+		return nil, MatchSourceNone, UnmatchedProgIDMismatch
+	}
+
+	for i := range candidates {
+		if candidates[i].Start.Unix() == plex.BeginsAt {
+			return &candidates[i], MatchSourceStartTime, UnmatchedNone
+		}
+	}
+	return nil, MatchSourceNone, UnmatchedNoStartTimeMatch
+}

--- a/internal/plex/match_test.go
+++ b/internal/plex/match_test.go
@@ -122,17 +122,12 @@ func TestMatchChannel(t *testing.T) {
 			if src != tc.wantSource {
 				t.Errorf("source: got %v, want %v", src, tc.wantSource)
 			}
-			if tc.wantID == "" {
-				if got != nil {
-					t.Errorf("expected nil match, got %v", got)
-				}
-				return
+			gotID := ""
+			if got != nil {
+				gotID = got.ID
 			}
-			if got == nil {
-				t.Fatalf("expected match %q, got nil", tc.wantID)
-			}
-			if got.ID != tc.wantID {
-				t.Errorf("matched id: got %q, want %q", got.ID, tc.wantID)
+			if gotID != tc.wantID {
+				t.Errorf("matched id: got %q, want %q", gotID, tc.wantID)
 			}
 		})
 	}
@@ -224,20 +219,16 @@ func TestMatchAiring(t *testing.T) {
 			if reason != tc.wantReason {
 				t.Errorf("reason: got %v, want %v", reason, tc.wantReason)
 			}
-			if tc.wantID == "" {
-				if got != nil {
-					t.Errorf("expected nil match, got %+v", got)
-				}
-				return
+			gotID, gotStart := "", time.Time{}
+			if got != nil {
+				gotID = got.ChannelID
+				gotStart = got.Start
 			}
-			if got == nil {
-				t.Fatalf("expected match, got nil")
+			if gotID != tc.wantID {
+				t.Errorf("matched channel_id: got %q, want %q", gotID, tc.wantID)
 			}
-			if got.ChannelID != tc.wantID {
-				t.Errorf("matched channel_id: got %q, want %q", got.ChannelID, tc.wantID)
-			}
-			if !got.Start.Equal(tc.wantStart) {
-				t.Errorf("matched start: got %v, want %v", got.Start, tc.wantStart)
+			if !gotStart.Equal(tc.wantStart) {
+				t.Errorf("matched start: got %v, want %v", gotStart, tc.wantStart)
 			}
 		})
 	}

--- a/internal/plex/match_test.go
+++ b/internal/plex/match_test.go
@@ -1,0 +1,244 @@
+package plex_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/model"
+	"github.com/acbgbca/xmltvguide/internal/plex"
+)
+
+func intPtr(n int) *int { return &n }
+
+func TestMatchChannel(t *testing.T) {
+	lcn7 := intPtr(7)
+	lcn9 := intPtr(9)
+
+	cases := []struct {
+		name       string
+		plex       plex.LineupChannel
+		candidates []model.Channel
+		wantID     string // empty means no match expected
+		wantSource plex.MatchSource
+	}{
+		{
+			name: "hit by id",
+			plex: plex.LineupChannel{ID: "1", XMLTVID: "abc.xmltv", LCN: "7", DisplayName: "ABC"},
+			candidates: []model.Channel{
+				{ID: "other.xmltv", DisplayName: "Other", LCN: lcn9},
+				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
+			},
+			wantID:     "abc.xmltv",
+			wantSource: plex.MatchSourceID,
+		},
+		{
+			name: "hit by lcn",
+			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "7", DisplayName: "Totally Different"},
+			candidates: []model.Channel{
+				{ID: "other.xmltv", DisplayName: "Other", LCN: lcn9},
+				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
+			},
+			wantID:     "abc.xmltv",
+			wantSource: plex.MatchSourceLCN,
+		},
+		{
+			name: "hit by name case-insensitive",
+			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "", DisplayName: "abc"},
+			candidates: []model.Channel{
+				{ID: "other.xmltv", DisplayName: "Other", LCN: lcn9},
+				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
+			},
+			wantID:     "abc.xmltv",
+			wantSource: plex.MatchSourceName,
+		},
+		{
+			name:       "miss with no candidates",
+			plex:       plex.LineupChannel{ID: "1", XMLTVID: "abc.xmltv", LCN: "7", DisplayName: "ABC"},
+			candidates: nil,
+			wantID:     "",
+			wantSource: plex.MatchSourceNone,
+		},
+		{
+			name: "ambiguous name returns none",
+			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "", DisplayName: "ABC"},
+			candidates: []model.Channel{
+				{ID: "abc1.xmltv", DisplayName: "ABC", LCN: nil},
+				{ID: "abc2.xmltv", DisplayName: "abc", LCN: nil},
+			},
+			wantID:     "",
+			wantSource: plex.MatchSourceNone,
+		},
+		{
+			name: "both have lcn but different falls through to name",
+			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "7", DisplayName: "ABC"},
+			candidates: []model.Channel{
+				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn9},
+			},
+			wantID:     "abc.xmltv",
+			wantSource: plex.MatchSourceName,
+		},
+		{
+			name: "no match at any tier returns none",
+			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "42", DisplayName: "Nothing"},
+			candidates: []model.Channel{
+				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
+			},
+			wantID:     "",
+			wantSource: plex.MatchSourceNone,
+		},
+		{
+			name: "plex has no lcn skips lcn matcher",
+			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "", DisplayName: "ABC"},
+			candidates: []model.Channel{
+				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
+			},
+			wantID:     "abc.xmltv",
+			wantSource: plex.MatchSourceName,
+		},
+		{
+			name: "candidate without lcn is skipped by lcn matcher",
+			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "7", DisplayName: "ABC"},
+			candidates: []model.Channel{
+				{ID: "abc.xmltv", DisplayName: "Different", LCN: nil},
+			},
+			wantID:     "",
+			wantSource: plex.MatchSourceNone,
+		},
+		{
+			name: "ambiguous lcn returns none without falling through",
+			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "7", DisplayName: "ABC"},
+			candidates: []model.Channel{
+				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
+				{ID: "other.xmltv", DisplayName: "Other", LCN: lcn7},
+			},
+			wantID:     "",
+			wantSource: plex.MatchSourceNone,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, src := plex.MatchChannel(tc.plex, tc.candidates)
+			if src != tc.wantSource {
+				t.Errorf("source: got %v, want %v", src, tc.wantSource)
+			}
+			if tc.wantID == "" {
+				if got != nil {
+					t.Errorf("expected nil match, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected match %q, got nil", tc.wantID)
+			}
+			if got.ID != tc.wantID {
+				t.Errorf("matched id: got %q, want %q", got.ID, tc.wantID)
+			}
+		})
+	}
+}
+
+func TestMatchAiring(t *testing.T) {
+	start := time.Date(2025, 6, 10, 14, 0, 0, 0, time.UTC)
+	other := time.Date(2025, 6, 10, 15, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name       string
+		plex       plex.GridEntry
+		candidates []model.Airing
+		wantID     string // channel_id of the matched airing, empty for no match
+		wantStart  time.Time
+		wantSource plex.MatchSource
+		wantReason plex.UnmatchedReason
+	}{
+		{
+			name: "hit by progid",
+			plex: plex.GridEntry{RatingKey: "rk1", BeginsAt: other.Unix(), DdProgID: "EP123"},
+			candidates: []model.Airing{
+				{ChannelID: "ch1", Start: start, ProgID: "EP999"},
+				{ChannelID: "ch1", Start: other, ProgID: "EP123"},
+			},
+			wantID:     "ch1",
+			wantStart:  other,
+			wantSource: plex.MatchSourceProgID,
+			wantReason: plex.UnmatchedNone,
+		},
+		{
+			name: "hit by start time when no progid",
+			plex: plex.GridEntry{RatingKey: "rk1", BeginsAt: start.Unix(), DdProgID: ""},
+			candidates: []model.Airing{
+				{ChannelID: "ch1", Start: other, ProgID: "EP999"},
+				{ChannelID: "ch1", Start: start, ProgID: ""},
+			},
+			wantID:     "ch1",
+			wantStart:  start,
+			wantSource: plex.MatchSourceStartTime,
+			wantReason: plex.UnmatchedNone,
+		},
+		{
+			name: "progid mismatch does not fall through to start time",
+			plex: plex.GridEntry{RatingKey: "rk1", BeginsAt: start.Unix(), DdProgID: "EP123"},
+			candidates: []model.Airing{
+				{ChannelID: "ch1", Start: start, ProgID: "EP999"},
+			},
+			wantID:     "",
+			wantSource: plex.MatchSourceNone,
+			wantReason: plex.UnmatchedProgIDMismatch,
+		},
+		{
+			name:       "no candidates returns unmatched no candidate",
+			plex:       plex.GridEntry{RatingKey: "rk1", BeginsAt: start.Unix(), DdProgID: "EP123"},
+			candidates: nil,
+			wantID:     "",
+			wantSource: plex.MatchSourceNone,
+			wantReason: plex.UnmatchedNoCandidate,
+		},
+		{
+			name: "start time miss returns unmatched no start time",
+			plex: plex.GridEntry{RatingKey: "rk1", BeginsAt: start.Unix(), DdProgID: ""},
+			candidates: []model.Airing{
+				{ChannelID: "ch1", Start: other, ProgID: ""},
+			},
+			wantID:     "",
+			wantSource: plex.MatchSourceNone,
+			wantReason: plex.UnmatchedNoStartTimeMatch,
+		},
+		{
+			name: "candidate progid empty does not match progid path",
+			plex: plex.GridEntry{RatingKey: "rk1", BeginsAt: start.Unix(), DdProgID: "EP123"},
+			candidates: []model.Airing{
+				{ChannelID: "ch1", Start: start, ProgID: ""},
+			},
+			wantID:     "",
+			wantSource: plex.MatchSourceNone,
+			wantReason: plex.UnmatchedProgIDMismatch,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, src, reason := plex.MatchAiring(tc.plex, tc.candidates)
+			if src != tc.wantSource {
+				t.Errorf("source: got %v, want %v", src, tc.wantSource)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason: got %v, want %v", reason, tc.wantReason)
+			}
+			if tc.wantID == "" {
+				if got != nil {
+					t.Errorf("expected nil match, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected match, got nil")
+			}
+			if got.ChannelID != tc.wantID {
+				t.Errorf("matched channel_id: got %q, want %q", got.ChannelID, tc.wantID)
+			}
+			if !got.Start.Equal(tc.wantStart) {
+				t.Errorf("matched start: got %v, want %v", got.Start, tc.wantStart)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds migration v5: nullable `channels.plex_channel_id`, `channels.plex_lineup_id`, and `airings.plex_rating_key` columns. No `populateSQL` — these are pure enrichment columns populated later by the Plex poller (issue 3/3).
- Adds pure-function matchers in `internal/plex/match.go`:
  - `MatchChannel` cascades ID → LCN → Name; ambiguous hits at any tier return `MatchSourceNone` without falling through.
  - `MatchAiring` tries `dd_progid` first when available; a progid mismatch returns `UnmatchedProgIDMismatch` (no fall-through). When Plex has no progid, falls back to exact start-time equality.
- Matchers are pure: no DB, no HTTP, no logging. Caller pre-narrows airing candidates to the matched channel.

Closes #282. Part of #276. Depends on #281 (merged).

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` clean, `gofmt -l` clean
- [x] `TestMigration_PlexColumnsExist` asserts all three new columns exist after migrations run
- [x] `TestMatchChannel` covers: hit by ID, hit by LCN, hit by name (case-insensitive), no candidates, ambiguous name → None, ambiguous LCN → None, LCN miss falls through to name, plex without LCN skips LCN tier, candidate without LCN skipped by LCN tier
- [x] `TestMatchAiring` covers: hit by progid, hit by start-time when no progid, progid mismatch does NOT fall through, no candidates → `UnmatchedNoCandidate`, start-time miss → `UnmatchedNoStartTimeMatch`, empty candidate progid does not match progid path

🤖 Generated with [Claude Code](https://claude.com/claude-code)