### PR TITLE
Add Plex EPG poller, status endpoint, and deepcheck (#283)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,12 +17,17 @@ A personal PWA TV guide that parses XMLTV data and displays it as a scrollable g
 ```
 tvguide/
 ├── main.go                      # Entry point: config, XMLTV poller, HTTP server, embed
+├── plex_poller.go               # Plex enrichment ticker + status snapshot wiring
 ├── go.mod                       # Module: github.com/acbgbca/xmltvguide
 ├── go.sum                       # Generated on first Docker build (commit after first build)
 ├── internal/
 │   ├── xmltv/parser.go          # Fetch XMLTV from URL and parse into structs
+│   ├── plex/                    # Plex API client + match algorithms
+│   │   ├── client.go            # HTTP client (Ping, GetDVRs, GetLineupChannels, GetGrid)
+│   │   └── match.go             # MatchChannel (id/lcn/name cascade) and MatchAiring (progid/start-time)
 │   ├── database/db.go           # SQLite store: schema, Refresh, GetChannels, GetAirings, DeepCheck
-│   ├── deepcheck/deepcheck.go   # On-demand deep health probe (DB, disk, XMLTV reachability)
+│   ├── database/plex_refresh.go # RefreshPlex orchestrator — pairs Plex IDs onto channels/airings
+│   ├── deepcheck/deepcheck.go   # On-demand deep health probe (DB, disk, XMLTV, Plex reachability)
 │   └── api/                     # REST API handlers (one file per resource)
 │       ├── handler.go           # Router setup and shared middleware
 │       ├── guide.go             # GET /api/guide
@@ -33,6 +38,7 @@ tvguide/
 │       ├── rss.go               # RSS feed formatting
 │       ├── health.go            # GET /api/health
 │       ├── deepcheck.go         # GET /api/deepcheck
+│       ├── plex.go              # GET /api/plex/status
 │       └── debug.go             # Debug/status endpoints
 ├── web/                         # Frontend — embedded into binary via go:embed
 │   ├── index.html               # App shell (no JS framework)
@@ -80,7 +86,8 @@ tvguide/
 | `GET /api/explore/now-next` | For every channel, returns the currently-airing show (`current`) and the next upcoming show (`next`). Either field may be `null`. Ordered by channel sort order (lcn, then source order). |
 | `POST /api/guide/refresh` | Triggers a refresh of TV guide data. `sync=true`: waits for completion and returns `200 {"ok":true}` or `500 {"error":"..."}`. Default (async): returns `202 Accepted` immediately. |
 | `GET /api/health` | Healthcheck endpoint. Probes SQLite connectivity and FTS availability. Returns `200 {"status":"ok"}` when healthy or `500 {"error":"..."}` when unhealthy. Used by the Docker `HEALTHCHECK` instruction via the `--healthcheck` binary flag — this remains the Docker liveness probe and is unchanged. |
-| `GET /api/deepcheck` | Deep health check across database, FTS, data presence/freshness, XMLTV source reachability, and disk writability for `/data`, `/tmp`, and the image cache. Returns JSON `{status, checks[]}`: each entry is `{name, status, error?, info?}` with `status` one of `SUCCESS`/`FAILURE`. HTTP `200` when global status is `SUCCESS`, `503 Service Unavailable` otherwise. Every check runs independently — one failure does not skip the others. Intended for occasional on-demand diagnostics, not high-frequency probing — use `/api/health` for that. |
+| `GET /api/deepcheck` | Deep health check across database, FTS, data presence/freshness, XMLTV source reachability, disk writability for `/data`, `/tmp`, and the image cache, and Plex reachability (when configured). Returns JSON `{status, checks[]}`: each entry is `{name, status, error?, info?}` with `status` one of `SUCCESS`/`FAILURE`. HTTP `200` when global status is `SUCCESS`, `503 Service Unavailable` otherwise. The `plex_reachable` check reports `info="not configured"` when `PLEX_URL` is unset and never fails the report in that case. Every check runs independently — one failure does not skip the others. Intended for occasional on-demand diagnostics, not high-frequency probing — use `/api/health` for that. |
+| `GET /api/plex/status` | Snapshot of the most recent Plex EPG enrichment poll. When `PLEX_URL` is unset, returns `{"enabled": false}` only. When enabled, returns `lastPoll`, `nextPoll`, `lastDurationMs`, and `channels`/`airings` blocks containing total/matched counts, per-source counters (`byId`/`byLcn`/`byName` for channels; `byProgId`/`byStartTime` for airings), and the full list of unmatched entries with reasons. HTTP 200 in both cases — the endpoint always exists. |
 | `GET /` | Serves the embedded frontend (SPA shell) |
 | `GET /{any}` | SPA fallback — serves `index.html` for any path not matching API, images, or static files. Enables client-side routing via History API. |
 
@@ -126,7 +133,7 @@ channels (id PK, display_name, icon, sort_order, lcn, icon_url, plex_channel_id,
 -- lcn:     logical channel number from <lcn> element (nullable); used for display ordering
 -- icon:    local filesystem path of the cached icon file (e.g. /data/images/channels/ch1.png); NULL if not yet downloaded
 -- icon_url: original external URL from the XMLTV source; used to detect URL changes and to re-download if the local file goes missing
--- plex_channel_id, plex_lineup_id: Plex EPG enrichment IDs; nullable, populated by the Plex poller (see #276/#282)
+-- plex_channel_id, plex_lineup_id: Plex EPG enrichment IDs; nullable, populated by the Plex poller — see "Plex enrichment" section
 
 airings (
   channel_id + start_time  -- composite PK
@@ -137,7 +144,7 @@ airings (
   prog_id                  -- dd_progid (TMS/Gracenote stable ID, if present)
   star_rating, content_rating, year, icon, country,
   is_repeat, is_premiere,
-  plex_rating_key          -- Plex EPG ratingKey; nullable, populated by the Plex poller (see #276/#282)
+  plex_rating_key          -- Plex EPG ratingKey; nullable, populated by the Plex poller — see "Plex enrichment" section
 )
 
 airings_fts  -- FTS5 virtual table for full-text search
@@ -258,6 +265,56 @@ When adding a new static asset under `web/`, also add it to the `STATIC` list in
 - Time format: `YYYYMMDDHHmmss ±HHMM` — the parser handles both `+1100` and `+11:00` offset styles.
 - Large files (e.g. Melbourne.xml ~50MB) are parsed fully into memory on each poll, then written to SQLite in a single transaction.
 - The HTTP request sets `Accept: text/xml, application/xml, */*` and `User-Agent: xmltvguide/1.0` — required because some XMLTV hosts return 406 without an explicit Accept header.
+
+## Plex enrichment
+
+Plex enrichment is purely **additive**: it populates three new columns on existing rows but never modifies XMLTV-derived fields. The integration is a no-op when `PLEX_URL` is unset — no goroutine, no requests, and `/api/plex/status` returns `{"enabled": false}`.
+
+### What it does
+
+A background ticker (cadence: `PLEX_POLL_INTERVAL`, default 12 h) calls `db.RefreshPlex`. One cycle:
+
+1. `GET /livetv/dvrs` — discover lineup IDs and grid keys.
+2. For each lineup, `GET /epg/lineups/{id}/channels` — match each Plex channel to a local channel via the **channel cascade**: xmltv ID → LCN → display name (case-insensitive). Ambiguous matches (two or more candidates at the same tier) abort without falling through; see `internal/plex/match.go` for the rationale. On match, `UPDATE channels SET plex_channel_id, plex_lineup_id`.
+3. For each unique grid key, `GET /{gridKey}/grid?type=4&beginsAt=now&endsAt=now+RETENTION_DAYS` — group entries by Plex channel, resolve to a local channel via step 2's map, then match each entry against airings on that channel only via the **airing strategy**: `dd_progid` when Plex has one; otherwise exact start-time match. On match, `UPDATE airings SET plex_rating_key`.
+4. All UPDATEs commit in a single transaction. Per-step fetch errors are accumulated in `result.Errors` and do not abort the transaction — partial enrichment is preferred over rolling back successful matches.
+
+### Where the IDs are stored
+
+| Column | Table | Populated by |
+|---|---|---|
+| `plex_channel_id` | `channels` | step 2 |
+| `plex_lineup_id` | `channels` | step 2 |
+| `plex_rating_key` | `airings` | step 3 |
+
+All three columns are nullable. Unmatched rows stay `NULL`. The XMLTV refresh path never reads or writes these columns; the Plex poller never reads or writes any XMLTV column.
+
+### Log output
+
+Each poll emits an INFO summary block:
+
+```
+[plex] poll started (2 lineups discovered)
+[plex] channels: matched 38/45 (32 by id, 4 by lcn, 2 by name)
+[plex]   unmatched Plex channels: [plex.foo plex.bar plex.baz] (and 4 more)
+[plex] airings: matched 1180/1240 (1145 by progid, 35 by start-time)
+[plex]   unmatched sample: "Movie B" on ch5.au @ 21:00 (progid_mismatch)
+[plex] poll completed in 2.3s
+```
+
+Unmatched lists are truncated to 5 entries in logs; the full lists are available via `/api/plex/status`.
+
+Actionable error log lines for common failure modes:
+
+| Condition | Level | Message |
+|---|---|---|
+| Plex unreachable on startup probe | ERROR | `Plex unreachable at <URL>: <err>. Plex enrichment disabled until reachable. Verify PLEX_URL and that Plex is running.` |
+| 401/403 from any endpoint | ERROR | `Plex returned 401 — PLEX_TOKEN appears invalid. Regenerate at https://plex.tv → Account → Authorized Devices.` |
+| Timeout / 5xx during poll | WARN | `Plex poll failed (<endpoint>): <err>. Will retry in <interval>.` |
+| 0 DVRs returned | WARN | `Plex returned 0 DVRs — Plex Live TV / DVR may not be configured on this server.` |
+| Poll succeeded but 0 channels matched | WARN | `Plex returned N channels but none matched TV Guide channels. Check that both sources reference the same lineup (compare channel IDs/LCNs/names).` |
+
+DEBUG (opt-in via `LOG_LEVEL=debug`): per-HTTP-request `GET <url> → <status> (<bytes>, <ms>)` and per-channel match decisions.
 
 ## Testing
 

--- a/internal/api/deepcheck.go
+++ b/internal/api/deepcheck.go
@@ -23,6 +23,8 @@ func (h *Handler) getDeepCheck(w http.ResponseWriter, r *http.Request) {
 		PollInterval:  h.deep.PollInterval,
 		DBPath:        h.deep.DBPath,
 		ImageCacheDir: h.deep.ImageCacheDir,
+		PlexURL:       h.deep.PlexURL,
+		PlexClient:    h.deep.PlexClient,
 	}
 	report := checker.Run(ctx)
 	if report.Status != deepcheck.StatusSuccess {

--- a/internal/api/deepcheck_test.go
+++ b/internal/api/deepcheck_test.go
@@ -116,6 +116,7 @@ func TestDeepCheck_HappyPath_Returns200AndSuccess(t *testing.T) {
 		"disk_data",
 		"disk_tmp",
 		"image_cache",
+		"plex_reachable",
 	}
 	if len(body.Checks) != len(wantOrder) {
 		t.Fatalf("got %d checks, want %d (%+v)", len(body.Checks), len(wantOrder), body.Checks)
@@ -161,8 +162,8 @@ func TestDeepCheck_UnreachableXMLTV_Returns503(t *testing.T) {
 	}
 
 	// All checks should be present even when xmltv_url fails.
-	if len(body.Checks) != 9 {
-		t.Errorf("expected 9 checks, got %d", len(body.Checks))
+	if len(body.Checks) != 10 {
+		t.Errorf("expected 10 checks, got %d", len(body.Checks))
 	}
 	var xmltv *struct {
 		Name, Status, Error string

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -33,14 +33,17 @@ type DeepCheckConfig struct {
 	PollInterval  time.Duration
 	DBPath        string
 	ImageCacheDir string
+	PlexURL       string
+	PlexClient    deepcheck.PlexProbe
 }
 
 // Handler holds the HTTP handler dependencies.
 type Handler struct {
-	db        store
-	rssTTL    int          // default RSS TTL in minutes; 0 means use hard-coded default (360)
-	refreshFn func() error // optional; nil means refresh endpoint returns 501
-	deep      DeepCheckConfig
+	db           store
+	rssTTL       int          // default RSS TTL in minutes; 0 means use hard-coded default (360)
+	refreshFn    func() error // optional; nil means refresh endpoint returns 501
+	deep         DeepCheckConfig
+	plexStatusFn PlexStatusFunc // optional; nil means /api/plex/status returns {"enabled": false}
 }
 
 // New creates a new Handler backed by db. rssTTL is the server-wide default
@@ -65,6 +68,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/guide/refresh", h.postGuideRefresh)
 	mux.HandleFunc("GET /api/health", h.getHealth)
 	mux.HandleFunc("GET /api/deepcheck", h.getDeepCheck)
+	mux.HandleFunc("GET /api/plex/status", h.getPlexStatus)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/api/plex.go
+++ b/internal/api/plex.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"net/http"
+	"time"
+)
+
+// PlexMatchStats summarises Plex match counts for one entity kind. Per-source
+// counters are non-zero only for the kind they apply to (channels:
+// ByID/ByLCN/ByName; airings: ByProgID/ByStartTime). Zero counters are omitted
+// from the JSON response via omitempty.
+type PlexMatchStats struct {
+	Total       int
+	Matched     int
+	ByID        int
+	ByLCN       int
+	ByName      int
+	ByProgID    int
+	ByStartTime int
+}
+
+// PlexUnmatchedChannel is one row of /api/plex/status .channels.unmatched.
+type PlexUnmatchedChannel struct {
+	PlexID      string
+	DisplayName string
+	Reason      string
+}
+
+// PlexUnmatchedAiring is one row of /api/plex/status .airings.unmatched.
+type PlexUnmatchedAiring struct {
+	ChannelID string
+	Title     string
+	StartTime time.Time
+	Reason    string
+}
+
+// PlexStatusSnapshot is the view of the latest Plex poll cycle that the
+// /api/plex/status handler renders. Pass via Handler.SetPlexStatusFunc.
+type PlexStatusSnapshot struct {
+	Enabled           bool
+	LastPoll          time.Time
+	NextPoll          time.Time
+	LastDuration      time.Duration
+	Lineups           int
+	ChannelMatches    PlexMatchStats
+	AiringMatches     PlexMatchStats
+	UnmatchedChannels []PlexUnmatchedChannel
+	UnmatchedAirings  []PlexUnmatchedAiring
+	Errors            []string
+}
+
+// PlexStatusFunc returns the latest Plex poll snapshot. The bool indicates
+// whether Plex enrichment is enabled at all. When false the handler returns
+// {"enabled": false}.
+type PlexStatusFunc func() (PlexStatusSnapshot, bool)
+
+// SetPlexStatusFunc registers the function that supplies the current Plex
+// poll snapshot to /api/plex/status. If unset, the endpoint returns
+// {"enabled": false} regardless of how the poller is wired.
+func (h *Handler) SetPlexStatusFunc(fn PlexStatusFunc) {
+	h.plexStatusFn = fn
+}
+
+// channelStatsView and airingStatsView mirror PlexMatchStats but with
+// kind-specific JSON tags + omitempty so zero counters drop out of the
+// response.
+type channelStatsView struct {
+	Total     int                        `json:"total"`
+	Matched   int                        `json:"matched"`
+	ByID      int                        `json:"byId,omitempty"`
+	ByLCN     int                        `json:"byLcn,omitempty"`
+	ByName    int                        `json:"byName,omitempty"`
+	Unmatched []plexUnmatchedChannelView `json:"unmatched,omitempty"`
+}
+
+type airingStatsView struct {
+	Total       int                       `json:"total"`
+	Matched     int                       `json:"matched"`
+	ByProgID    int                       `json:"byProgId,omitempty"`
+	ByStartTime int                       `json:"byStartTime,omitempty"`
+	Unmatched   []plexUnmatchedAiringView `json:"unmatched,omitempty"`
+}
+
+type plexUnmatchedChannelView struct {
+	PlexID      string `json:"plexId"`
+	DisplayName string `json:"displayName,omitempty"`
+	Reason      string `json:"reason"`
+}
+
+type plexUnmatchedAiringView struct {
+	ChannelID string    `json:"channelId"`
+	Title     string    `json:"title,omitempty"`
+	StartTime time.Time `json:"startTime"`
+	Reason    string    `json:"reason"`
+}
+
+type plexStatusEnabledView struct {
+	Enabled        bool             `json:"enabled"`
+	LastPoll       time.Time        `json:"lastPoll"`
+	NextPoll       time.Time        `json:"nextPoll"`
+	LastDurationMs int64            `json:"lastDurationMs"`
+	Channels       channelStatsView `json:"channels"`
+	Airings        airingStatsView  `json:"airings"`
+	Errors         []string         `json:"errors"`
+}
+
+type plexStatusDisabledView struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (h *Handler) getPlexStatus(w http.ResponseWriter, r *http.Request) {
+	if h.plexStatusFn == nil {
+		writeJSON(w, plexStatusDisabledView{Enabled: false})
+		return
+	}
+	snap, enabled := h.plexStatusFn()
+	if !enabled {
+		writeJSON(w, plexStatusDisabledView{Enabled: false})
+		return
+	}
+
+	view := plexStatusEnabledView{
+		Enabled:        true,
+		LastPoll:       snap.LastPoll,
+		NextPoll:       snap.NextPoll,
+		LastDurationMs: snap.LastDuration.Milliseconds(),
+		Channels: channelStatsView{
+			Total:     snap.ChannelMatches.Total,
+			Matched:   snap.ChannelMatches.Matched,
+			ByID:      snap.ChannelMatches.ByID,
+			ByLCN:     snap.ChannelMatches.ByLCN,
+			ByName:    snap.ChannelMatches.ByName,
+			Unmatched: mapUnmatchedChannels(snap.UnmatchedChannels),
+		},
+		Airings: airingStatsView{
+			Total:       snap.AiringMatches.Total,
+			Matched:     snap.AiringMatches.Matched,
+			ByProgID:    snap.AiringMatches.ByProgID,
+			ByStartTime: snap.AiringMatches.ByStartTime,
+			Unmatched:   mapUnmatchedAirings(snap.UnmatchedAirings),
+		},
+		Errors: snap.Errors,
+	}
+	if view.Errors == nil {
+		view.Errors = []string{}
+	}
+	writeJSON(w, view)
+}
+
+func mapUnmatchedChannels(in []PlexUnmatchedChannel) []plexUnmatchedChannelView {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]plexUnmatchedChannelView, len(in))
+	for i, c := range in {
+		out[i] = plexUnmatchedChannelView(c)
+	}
+	return out
+}
+
+func mapUnmatchedAirings(in []PlexUnmatchedAiring) []plexUnmatchedAiringView {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]plexUnmatchedAiringView, len(in))
+	for i, a := range in {
+		out[i] = plexUnmatchedAiringView(a)
+	}
+	return out
+}

--- a/internal/api/plex_test.go
+++ b/internal/api/plex_test.go
@@ -1,0 +1,174 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/api"
+	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/images"
+)
+
+func TestPlexStatus_Disabled_ReturnsEnabledFalse(t *testing.T) {
+	// No SetPlexStatusFunc registered → endpoint should still exist and
+	// return {"enabled": false}.
+	srv := newSeededServer(t)
+
+	resp, err := httpGet(t, srv.URL+"/api/plex/status")
+	if err != nil {
+		t.Fatalf("GET /api/plex/status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if enabled, _ := body["enabled"].(bool); enabled {
+		t.Errorf("expected enabled=false, got %v", body)
+	}
+	// No other fields should be present.
+	if _, ok := body["channels"]; ok {
+		t.Errorf("expected no channels field when disabled, got %v", body)
+	}
+	if _, ok := body["lastPoll"]; ok {
+		t.Errorf("expected no lastPoll field when disabled, got %v", body)
+	}
+}
+
+func TestPlexStatus_Enabled_ReturnsDocumentedShape(t *testing.T) {
+	now := time.Date(2026, 5, 23, 13, 0, 0, 0, time.UTC)
+	next := time.Date(2026, 5, 24, 1, 0, 0, 0, time.UTC)
+	startTime := time.Date(2026, 5, 23, 21, 0, 0, 0, time.UTC)
+
+	snapshot := api.PlexStatusSnapshot{
+		Enabled:        true,
+		LastPoll:       now,
+		NextPoll:       next,
+		LastDuration:   2300 * time.Millisecond,
+		Lineups:        1,
+		ChannelMatches: api.PlexMatchStats{Total: 45, Matched: 38, ByID: 32, ByLCN: 4, ByName: 2},
+		AiringMatches:  api.PlexMatchStats{Total: 1240, Matched: 1180, ByProgID: 1145, ByStartTime: 35},
+		UnmatchedChannels: []api.PlexUnmatchedChannel{
+			{PlexID: "plex.foo", DisplayName: "Foo TV", Reason: "no_id_lcn_or_name_match"},
+		},
+		UnmatchedAirings: []api.PlexUnmatchedAiring{
+			{ChannelID: "ch5.au", Title: "Movie B", StartTime: startTime, Reason: "progid_mismatch"},
+		},
+		Errors: []string{},
+	}
+
+	dir := t.TempDir()
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	mux := http.NewServeMux()
+	h := api.New(db, 0, nil, api.DeepCheckConfig{})
+	h.SetPlexStatusFunc(func() (api.PlexStatusSnapshot, bool) { return snapshot, true })
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := httpGet(t, srv.URL+"/api/plex/status")
+	if err != nil {
+		t.Fatalf("GET /api/plex/status: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if enabled, _ := body["enabled"].(bool); !enabled {
+		t.Errorf("enabled = %v, want true", body["enabled"])
+	}
+	if ms, _ := body["lastDurationMs"].(float64); ms != 2300 {
+		t.Errorf("lastDurationMs = %v, want 2300", body["lastDurationMs"])
+	}
+	if got, _ := body["lastPoll"].(string); got != "2026-05-23T13:00:00Z" {
+		t.Errorf("lastPoll = %q, want 2026-05-23T13:00:00Z", got)
+	}
+	if got, _ := body["nextPoll"].(string); got != "2026-05-24T01:00:00Z" {
+		t.Errorf("nextPoll = %q, want 2026-05-24T01:00:00Z", got)
+	}
+
+	channels, ok := body["channels"].(map[string]any)
+	if !ok {
+		t.Fatalf("channels missing or wrong type: %v", body["channels"])
+	}
+	if channels["total"] != float64(45) {
+		t.Errorf("channels.total = %v, want 45", channels["total"])
+	}
+	if channels["matched"] != float64(38) {
+		t.Errorf("channels.matched = %v, want 38", channels["matched"])
+	}
+	if channels["byId"] != float64(32) {
+		t.Errorf("channels.byId = %v, want 32", channels["byId"])
+	}
+	if channels["byLcn"] != float64(4) {
+		t.Errorf("channels.byLcn = %v, want 4", channels["byLcn"])
+	}
+	if channels["byName"] != float64(2) {
+		t.Errorf("channels.byName = %v, want 2", channels["byName"])
+	}
+	// Channel airing-specific fields should NOT appear in the channels block.
+	if _, ok := channels["byProgId"]; ok {
+		t.Errorf("channels.byProgId should be absent")
+	}
+	if _, ok := channels["byStartTime"]; ok {
+		t.Errorf("channels.byStartTime should be absent")
+	}
+
+	unmatched, ok := channels["unmatched"].([]any)
+	if !ok || len(unmatched) != 1 {
+		t.Fatalf("channels.unmatched not [1 entry]: %v", channels["unmatched"])
+	}
+	uc := unmatched[0].(map[string]any)
+	if uc["plexId"] != "plex.foo" || uc["displayName"] != "Foo TV" || uc["reason"] != "no_id_lcn_or_name_match" {
+		t.Errorf("unmatched channel = %v, missing expected fields", uc)
+	}
+
+	airings, ok := body["airings"].(map[string]any)
+	if !ok {
+		t.Fatalf("airings missing: %v", body["airings"])
+	}
+	if airings["total"] != float64(1240) || airings["matched"] != float64(1180) {
+		t.Errorf("airings totals wrong: %v", airings)
+	}
+	if airings["byProgId"] != float64(1145) {
+		t.Errorf("airings.byProgId = %v, want 1145", airings["byProgId"])
+	}
+	if airings["byStartTime"] != float64(35) {
+		t.Errorf("airings.byStartTime = %v, want 35", airings["byStartTime"])
+	}
+	// Airing channel-specific fields should NOT appear in the airings block.
+	if _, ok := airings["byId"]; ok {
+		t.Errorf("airings.byId should be absent")
+	}
+	if _, ok := airings["byLcn"]; ok {
+		t.Errorf("airings.byLcn should be absent")
+	}
+
+	ua, ok := airings["unmatched"].([]any)
+	if !ok || len(ua) != 1 {
+		t.Fatalf("airings.unmatched not [1 entry]: %v", airings["unmatched"])
+	}
+	uam := ua[0].(map[string]any)
+	if uam["channelId"] != "ch5.au" || uam["title"] != "Movie B" || uam["reason"] != "progid_mismatch" {
+		t.Errorf("unmatched airing = %v, missing expected fields", uam)
+	}
+}

--- a/internal/api/plex_test.go
+++ b/internal/api/plex_test.go
@@ -43,15 +43,13 @@ func TestPlexStatus_Disabled_ReturnsEnabledFalse(t *testing.T) {
 	}
 }
 
-func TestPlexStatus_Enabled_ReturnsDocumentedShape(t *testing.T) {
-	now := time.Date(2026, 5, 23, 13, 0, 0, 0, time.UTC)
-	next := time.Date(2026, 5, 24, 1, 0, 0, 0, time.UTC)
-	startTime := time.Date(2026, 5, 23, 21, 0, 0, 0, time.UTC)
-
-	snapshot := api.PlexStatusSnapshot{
+// plexStatusFixture is the canonical snapshot used by the enabled-mode tests
+// below — large enough to populate every documented JSON field.
+func plexStatusFixture() api.PlexStatusSnapshot {
+	return api.PlexStatusSnapshot{
 		Enabled:        true,
-		LastPoll:       now,
-		NextPoll:       next,
+		LastPoll:       time.Date(2026, 5, 23, 13, 0, 0, 0, time.UTC),
+		NextPoll:       time.Date(2026, 5, 24, 1, 0, 0, 0, time.UTC),
 		LastDuration:   2300 * time.Millisecond,
 		Lineups:        1,
 		ChannelMatches: api.PlexMatchStats{Total: 45, Matched: 38, ByID: 32, ByLCN: 4, ByName: 2},
@@ -60,11 +58,16 @@ func TestPlexStatus_Enabled_ReturnsDocumentedShape(t *testing.T) {
 			{PlexID: "plex.foo", DisplayName: "Foo TV", Reason: "no_id_lcn_or_name_match"},
 		},
 		UnmatchedAirings: []api.PlexUnmatchedAiring{
-			{ChannelID: "ch5.au", Title: "Movie B", StartTime: startTime, Reason: "progid_mismatch"},
+			{ChannelID: "ch5.au", Title: "Movie B", StartTime: time.Date(2026, 5, 23, 21, 0, 0, 0, time.UTC), Reason: "progid_mismatch"},
 		},
 		Errors: []string{},
 	}
+}
 
+// fetchPlexStatusBody starts a real handler stub with the supplied snapshot
+// and returns the decoded JSON body.
+func fetchPlexStatusBody(t *testing.T, snapshot api.PlexStatusSnapshot) map[string]any {
+	t.Helper()
 	dir := t.TempDir()
 	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
 	if err != nil {
@@ -92,7 +95,11 @@ func TestPlexStatus_Enabled_ReturnsDocumentedShape(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
+	return body
+}
 
+func TestPlexStatus_Enabled_TopLevelFields(t *testing.T) {
+	body := fetchPlexStatusBody(t, plexStatusFixture())
 	if enabled, _ := body["enabled"].(bool); !enabled {
 		t.Errorf("enabled = %v, want true", body["enabled"])
 	}
@@ -105,33 +112,21 @@ func TestPlexStatus_Enabled_ReturnsDocumentedShape(t *testing.T) {
 	if got, _ := body["nextPoll"].(string); got != "2026-05-24T01:00:00Z" {
 		t.Errorf("nextPoll = %q, want 2026-05-24T01:00:00Z", got)
 	}
+}
 
+func TestPlexStatus_Enabled_ChannelsBlock(t *testing.T) {
+	body := fetchPlexStatusBody(t, plexStatusFixture())
 	channels, ok := body["channels"].(map[string]any)
 	if !ok {
 		t.Fatalf("channels missing or wrong type: %v", body["channels"])
 	}
-	if channels["total"] != float64(45) {
-		t.Errorf("channels.total = %v, want 45", channels["total"])
-	}
-	if channels["matched"] != float64(38) {
-		t.Errorf("channels.matched = %v, want 38", channels["matched"])
-	}
-	if channels["byId"] != float64(32) {
-		t.Errorf("channels.byId = %v, want 32", channels["byId"])
-	}
-	if channels["byLcn"] != float64(4) {
-		t.Errorf("channels.byLcn = %v, want 4", channels["byLcn"])
-	}
-	if channels["byName"] != float64(2) {
-		t.Errorf("channels.byName = %v, want 2", channels["byName"])
-	}
-	// Channel airing-specific fields should NOT appear in the channels block.
-	if _, ok := channels["byProgId"]; ok {
-		t.Errorf("channels.byProgId should be absent")
-	}
-	if _, ok := channels["byStartTime"]; ok {
-		t.Errorf("channels.byStartTime should be absent")
-	}
+	expectJSONFloat(t, channels, "total", 45)
+	expectJSONFloat(t, channels, "matched", 38)
+	expectJSONFloat(t, channels, "byId", 32)
+	expectJSONFloat(t, channels, "byLcn", 4)
+	expectJSONFloat(t, channels, "byName", 2)
+	expectJSONAbsent(t, channels, "byProgId")
+	expectJSONAbsent(t, channels, "byStartTime")
 
 	unmatched, ok := channels["unmatched"].([]any)
 	if !ok || len(unmatched) != 1 {
@@ -141,27 +136,20 @@ func TestPlexStatus_Enabled_ReturnsDocumentedShape(t *testing.T) {
 	if uc["plexId"] != "plex.foo" || uc["displayName"] != "Foo TV" || uc["reason"] != "no_id_lcn_or_name_match" {
 		t.Errorf("unmatched channel = %v, missing expected fields", uc)
 	}
+}
 
+func TestPlexStatus_Enabled_AiringsBlock(t *testing.T) {
+	body := fetchPlexStatusBody(t, plexStatusFixture())
 	airings, ok := body["airings"].(map[string]any)
 	if !ok {
 		t.Fatalf("airings missing: %v", body["airings"])
 	}
-	if airings["total"] != float64(1240) || airings["matched"] != float64(1180) {
-		t.Errorf("airings totals wrong: %v", airings)
-	}
-	if airings["byProgId"] != float64(1145) {
-		t.Errorf("airings.byProgId = %v, want 1145", airings["byProgId"])
-	}
-	if airings["byStartTime"] != float64(35) {
-		t.Errorf("airings.byStartTime = %v, want 35", airings["byStartTime"])
-	}
-	// Airing channel-specific fields should NOT appear in the airings block.
-	if _, ok := airings["byId"]; ok {
-		t.Errorf("airings.byId should be absent")
-	}
-	if _, ok := airings["byLcn"]; ok {
-		t.Errorf("airings.byLcn should be absent")
-	}
+	expectJSONFloat(t, airings, "total", 1240)
+	expectJSONFloat(t, airings, "matched", 1180)
+	expectJSONFloat(t, airings, "byProgId", 1145)
+	expectJSONFloat(t, airings, "byStartTime", 35)
+	expectJSONAbsent(t, airings, "byId")
+	expectJSONAbsent(t, airings, "byLcn")
 
 	ua, ok := airings["unmatched"].([]any)
 	if !ok || len(ua) != 1 {
@@ -170,5 +158,19 @@ func TestPlexStatus_Enabled_ReturnsDocumentedShape(t *testing.T) {
 	uam := ua[0].(map[string]any)
 	if uam["channelId"] != "ch5.au" || uam["title"] != "Movie B" || uam["reason"] != "progid_mismatch" {
 		t.Errorf("unmatched airing = %v, missing expected fields", uam)
+	}
+}
+
+func expectJSONFloat(t *testing.T, m map[string]any, key string, want float64) {
+	t.Helper()
+	if got, _ := m[key].(float64); got != want {
+		t.Errorf("%s = %v, want %v", key, m[key], want)
+	}
+}
+
+func expectJSONAbsent(t *testing.T, m map[string]any, key string) {
+	t.Helper()
+	if _, ok := m[key]; ok {
+		t.Errorf("expected %s to be absent, got %v", key, m[key])
 	}
 }

--- a/internal/database/airings.go
+++ b/internal/database/airings.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -36,7 +37,8 @@ func (d *DB) GetAirings(ctx context.Context, date time.Time) ([]model.Airing, er
 			COALESCE(icon, ''),
 			COALESCE(country, ''),
 			is_repeat,
-			is_premiere
+			is_premiere,
+			plex_rating_key
 		FROM airings
 		WHERE stop_time > ? AND start_time < ?
 		ORDER BY start_time
@@ -55,6 +57,7 @@ func (d *DB) GetAirings(ctx context.Context, date time.Time) ([]model.Airing, er
 		var a model.Airing
 		var startStr, stopStr, catsJSON string
 		var isRepeat, isPremiere int
+		var plexRatingKey sql.NullString
 
 		if err := rows.Scan(
 			&a.ChannelID, &startStr, &stopStr,
@@ -62,6 +65,7 @@ func (d *DB) GetAirings(ctx context.Context, date time.Time) ([]model.Airing, er
 			&a.EpisodeNum, &a.EpisodeNumDisplay, &a.ProgID,
 			&a.StarRating, &a.ContentRating, &a.Year, &a.Icon, &a.Country,
 			&isRepeat, &isPremiere,
+			&plexRatingKey,
 		); err != nil {
 			return nil, fmt.Errorf("scanning airing: %w", err)
 		}
@@ -71,6 +75,10 @@ func (d *DB) GetAirings(ctx context.Context, date time.Time) ([]model.Airing, er
 		json.Unmarshal([]byte(catsJSON), &a.Categories) //nolint:errcheck,gosec // malformed JSON yields nil slice, which is acceptable
 		a.IsRepeat = isRepeat == 1
 		a.IsPremiere = isPremiere == 1
+		if plexRatingKey.Valid {
+			s := plexRatingKey.String
+			a.PlexRatingKey = &s
+		}
 
 		airings = append(airings, a)
 	}

--- a/internal/database/channels.go
+++ b/internal/database/channels.go
@@ -14,7 +14,7 @@ import (
 // that have an icon; it is empty for channels without one.
 func (d *DB) GetChannels(ctx context.Context) ([]model.Channel, error) {
 	rows, err := d.db.QueryContext(ctx, `
-		SELECT id, display_name, COALESCE(icon_url, ''), lcn
+		SELECT id, display_name, COALESCE(icon_url, ''), lcn, plex_channel_id, plex_lineup_id
 		FROM channels
 		ORDER BY sort_order
 	`)
@@ -32,7 +32,8 @@ func (d *DB) GetChannels(ctx context.Context) ([]model.Channel, error) {
 		var ch model.Channel
 		var lcn sql.NullInt64
 		var iconURL string
-		if err := rows.Scan(&ch.ID, &ch.DisplayName, &iconURL, &lcn); err != nil {
+		var plexChannelID, plexLineupID sql.NullString
+		if err := rows.Scan(&ch.ID, &ch.DisplayName, &iconURL, &lcn, &plexChannelID, &plexLineupID); err != nil {
 			return nil, fmt.Errorf("scanning channel: %w", err)
 		}
 		if iconURL != "" {
@@ -41,6 +42,14 @@ func (d *DB) GetChannels(ctx context.Context) ([]model.Channel, error) {
 		if lcn.Valid {
 			n := int(lcn.Int64)
 			ch.LCN = &n
+		}
+		if plexChannelID.Valid {
+			s := plexChannelID.String
+			ch.PlexChannelID = &s
+		}
+		if plexLineupID.Valid {
+			s := plexLineupID.String
+			ch.PlexLineupID = &s
 		}
 		channels = append(channels, ch)
 	}

--- a/internal/database/plex_refresh.go
+++ b/internal/database/plex_refresh.go
@@ -1,0 +1,418 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/logging"
+	"github.com/acbgbca/xmltvguide/internal/model"
+	"github.com/acbgbca/xmltvguide/internal/plex"
+)
+
+// PlexAPI is the narrow interface RefreshPlex needs from the Plex client.
+// *plex.Client satisfies it; tests can stub it.
+type PlexAPI interface {
+	GetDVRs(ctx context.Context) ([]plex.DVR, error)
+	GetLineupChannels(ctx context.Context, lineupID string) ([]plex.LineupChannel, error)
+	GetGrid(ctx context.Context, gridKey string, beginsAt, endsAt time.Time) ([]plex.GridEntry, error)
+}
+
+// PlexMatchStats summarises how many entities were matched and via which
+// source. Per-source counters are populated only for the relevant kind:
+// channels populate ByID/ByLCN/ByName; airings populate ByProgID/ByStartTime.
+type PlexMatchStats struct {
+	Total       int
+	Matched     int
+	ByID        int
+	ByLCN       int
+	ByName      int
+	ByProgID    int
+	ByStartTime int
+}
+
+// PlexUnmatchedChannel records a Plex channel that could not be paired with a
+// local TV Guide channel. The reason is a short stable token suitable for
+// surfacing through the JSON API.
+type PlexUnmatchedChannel struct {
+	PlexID      string
+	DisplayName string
+	Reason      string
+}
+
+// PlexUnmatchedAiring records a Plex grid entry that could not be paired with
+// a local airing on the matched channel.
+type PlexUnmatchedAiring struct {
+	ChannelID string
+	Title     string
+	StartTime time.Time
+	Reason    string
+}
+
+// PlexPollResult is the outcome of one RefreshPlex cycle.
+type PlexPollResult struct {
+	StartedAt        time.Time
+	Duration         time.Duration
+	Lineups          int
+	ChannelMatches   PlexMatchStats
+	AiringMatches    PlexMatchStats
+	UnmatchedChan    []PlexUnmatchedChannel
+	UnmatchedAirings []PlexUnmatchedAiring
+	Errors           []string
+}
+
+// channelUpdate is one pending UPDATE row for the channels table.
+type channelUpdate struct {
+	channelID     string
+	plexChannelID string
+	plexLineupID  string
+}
+
+// airingUpdate is one pending UPDATE row for the airings table.
+type airingUpdate struct {
+	channelID     string
+	startTime     time.Time
+	plexRatingKey string
+}
+
+// RefreshPlex performs one Plex EPG enrichment cycle: discover DVRs, match
+// every Plex channel against the local channels table, then match every Plex
+// grid entry against the airings on its already-matched local channel. All
+// successful matches are persisted as UPDATEs to plex_channel_id /
+// plex_lineup_id / plex_rating_key in a single transaction.
+//
+// Per-step errors are appended to the returned result.Errors slice and do not
+// abort the cycle — partial enrichment is preferred over rolling back
+// successful matches. The function returns a non-nil error only when the
+// follow-on database transaction itself fails.
+func (d *DB) RefreshPlex(ctx context.Context, client PlexAPI) (PlexPollResult, error) {
+	result := PlexPollResult{StartedAt: time.Now()}
+	defer func() {
+		result.Duration = time.Since(result.StartedAt)
+	}()
+
+	logging.Info("[plex] poll started")
+
+	dvrs, err := client.GetDVRs(ctx)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("GetDVRs: %v", err))
+		logPlexFetchError("GetDVRs", err)
+		return result, nil
+	}
+
+	type dvrTask struct {
+		gridKey   string
+		lineupIDs []string
+	}
+	var tasks []dvrTask
+	totalLineups := 0
+	for _, dvr := range dvrs {
+		tasks = append(tasks, dvrTask{gridKey: dvr.GridKey, lineupIDs: dvr.LineupIDs})
+		totalLineups += len(dvr.LineupIDs)
+	}
+	result.Lineups = totalLineups
+	if totalLineups == 0 {
+		logging.Warn("WARN: Plex returned 0 DVRs — Plex Live TV / DVR may not be configured on this server.")
+	}
+	logging.Info(fmt.Sprintf("[plex] poll started (%d lineups discovered)", totalLineups))
+
+	// Load local channels once for channel matching.
+	localChannels, err := d.GetChannels(ctx)
+	if err != nil {
+		return result, fmt.Errorf("loading channels: %w", err)
+	}
+
+	// channelMatchMap: Plex channel ID → local channel ID. Used to resolve
+	// grid entries back to local channels in the airing-match phase.
+	channelMatchMap := map[string]string{}
+	var channelUpdates []channelUpdate
+
+	for _, task := range tasks {
+		for _, lineupID := range task.lineupIDs {
+			pcs, err := client.GetLineupChannels(ctx, lineupID)
+			if err != nil {
+				msg := fmt.Sprintf("GetLineupChannels(%s): %v", lineupID, err)
+				result.Errors = append(result.Errors, msg)
+				logPlexFetchError(msg, err)
+				continue
+			}
+			for _, pc := range pcs {
+				result.ChannelMatches.Total++
+				matched, src := plex.MatchChannel(pc, localChannels)
+				if matched != nil {
+					result.ChannelMatches.Matched++
+					switch src {
+					case plex.MatchSourceID:
+						result.ChannelMatches.ByID++
+					case plex.MatchSourceLCN:
+						result.ChannelMatches.ByLCN++
+					case plex.MatchSourceName:
+						result.ChannelMatches.ByName++
+					}
+					channelUpdates = append(channelUpdates, channelUpdate{
+						channelID:     matched.ID,
+						plexChannelID: pc.ID,
+						plexLineupID:  lineupID,
+					})
+					channelMatchMap[pc.ID] = matched.ID
+					logging.Debug(fmt.Sprintf("channel '%s' matched '%s' via %s", pc.DisplayName, matched.ID, matchSourceName(src)))
+				} else {
+					result.UnmatchedChan = append(result.UnmatchedChan, PlexUnmatchedChannel{
+						PlexID:      pc.ID,
+						DisplayName: pc.DisplayName,
+						Reason:      "no_id_lcn_or_name_match",
+					})
+				}
+			}
+		}
+	}
+	if result.ChannelMatches.Total > 0 && result.ChannelMatches.Matched == 0 {
+		logging.Warn(fmt.Sprintf("WARN: Plex returned %d channels but none matched TV Guide channels. Check that both sources reference the same lineup (compare channel IDs/LCNs/names).", result.ChannelMatches.Total))
+	}
+	logChannelSummary(result.ChannelMatches, result.UnmatchedChan)
+
+	// Airing phase — per unique grid key.
+	gridStart := time.Now().UTC()
+	gridEnd := gridStart.AddDate(0, 0, d.retentionDays)
+	var airingUpdates []airingUpdate
+	gridSeen := map[string]bool{}
+
+	for _, task := range tasks {
+		if task.gridKey == "" || gridSeen[task.gridKey] {
+			continue
+		}
+		gridSeen[task.gridKey] = true
+
+		entries, err := client.GetGrid(ctx, task.gridKey, gridStart, gridEnd)
+		if err != nil {
+			msg := fmt.Sprintf("GetGrid(%s): %v", task.gridKey, err)
+			result.Errors = append(result.Errors, msg)
+			logPlexFetchError(msg, err)
+			continue
+		}
+
+		byChannel := map[string][]plex.GridEntry{}
+		for _, e := range entries {
+			byChannel[e.Channel] = append(byChannel[e.Channel], e)
+		}
+
+		for plexChanID, gridEntries := range byChannel {
+			localChannelID, ok := channelMatchMap[plexChanID]
+			if !ok {
+				continue
+			}
+			candidates, err := d.getAiringsForChannel(ctx, localChannelID, gridStart, gridEnd)
+			if err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("getAiringsForChannel(%s): %v", localChannelID, err))
+				continue
+			}
+			for _, entry := range gridEntries {
+				result.AiringMatches.Total++
+				matched, src, reason := plex.MatchAiring(entry, candidates)
+				if matched != nil {
+					result.AiringMatches.Matched++
+					switch src {
+					case plex.MatchSourceProgID:
+						result.AiringMatches.ByProgID++
+					case plex.MatchSourceStartTime:
+						result.AiringMatches.ByStartTime++
+					}
+					airingUpdates = append(airingUpdates, airingUpdate{
+						channelID:     matched.ChannelID,
+						startTime:     matched.Start,
+						plexRatingKey: entry.RatingKey,
+					})
+				} else {
+					result.UnmatchedAirings = append(result.UnmatchedAirings, PlexUnmatchedAiring{
+						ChannelID: localChannelID,
+						Title:     entry.Title,
+						StartTime: time.Unix(entry.BeginsAt, 0).UTC(),
+						Reason:    unmatchedReasonString(reason),
+					})
+				}
+			}
+		}
+	}
+	logAiringSummary(result.AiringMatches, result.UnmatchedAirings)
+
+	if err := d.applyPlexUpdates(ctx, channelUpdates, airingUpdates); err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("applyPlexUpdates: %v", err))
+	}
+
+	logging.Info(fmt.Sprintf("[plex] poll completed in %s", time.Since(result.StartedAt).Round(time.Millisecond)))
+	return result, nil
+}
+
+// getAiringsForChannel returns the (start, prog_id) pair for every airing on
+// channelID whose start_time lies within the [start, end) window. We only
+// load the fields MatchAiring needs.
+func (d *DB) getAiringsForChannel(ctx context.Context, channelID string, start, end time.Time) ([]model.Airing, error) {
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT channel_id, start_time, COALESCE(prog_id, '')
+		FROM airings
+		WHERE channel_id = ? AND start_time >= ? AND start_time < ?
+	`, channelID, start.Format(time.RFC3339), end.Format(time.RFC3339))
+	if err != nil {
+		return nil, fmt.Errorf("querying airings for %s: %w", channelID, err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("closing airings-for-channel rows: %v", err)
+		}
+	}()
+	var out []model.Airing
+	for rows.Next() {
+		var a model.Airing
+		var startStr string
+		if err := rows.Scan(&a.ChannelID, &startStr, &a.ProgID); err != nil {
+			return nil, fmt.Errorf("scanning airing: %w", err)
+		}
+		a.Start, _ = time.Parse(time.RFC3339, startStr)
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// applyPlexUpdates writes all collected channel + airing UPDATEs in a single
+// transaction so partial failures roll the whole set back.
+func (d *DB) applyPlexUpdates(ctx context.Context, channelUpdates []channelUpdate, airingUpdates []airingUpdate) error {
+	if len(channelUpdates) == 0 && len(airingUpdates) == 0 {
+		return nil
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+			log.Printf("plex tx rollback: %v", rbErr)
+		}
+	}()
+
+	if len(channelUpdates) > 0 {
+		stmt, err := tx.PrepareContext(ctx, `UPDATE channels SET plex_channel_id = ?, plex_lineup_id = ? WHERE id = ?`)
+		if err != nil {
+			return fmt.Errorf("prepare channel update: %w", err)
+		}
+		for _, cu := range channelUpdates {
+			if _, err := stmt.ExecContext(ctx, cu.plexChannelID, cu.plexLineupID, cu.channelID); err != nil {
+				_ = stmt.Close()
+				return fmt.Errorf("update channel %s: %w", cu.channelID, err)
+			}
+		}
+		if err := stmt.Close(); err != nil {
+			log.Printf("closing channel update stmt: %v", err)
+		}
+	}
+
+	if len(airingUpdates) > 0 {
+		stmt, err := tx.PrepareContext(ctx, `UPDATE airings SET plex_rating_key = ? WHERE channel_id = ? AND start_time = ?`)
+		if err != nil {
+			return fmt.Errorf("prepare airing update: %w", err)
+		}
+		for _, au := range airingUpdates {
+			startStr := au.startTime.UTC().Format(time.RFC3339)
+			if _, err := stmt.ExecContext(ctx, au.plexRatingKey, au.channelID, startStr); err != nil {
+				_ = stmt.Close()
+				return fmt.Errorf("update airing %s@%s: %w", au.channelID, startStr, err)
+			}
+		}
+		if err := stmt.Close(); err != nil {
+			log.Printf("closing airing update stmt: %v", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit plex tx: %w", err)
+	}
+	return nil
+}
+
+// matchSourceName returns the short string identifier for a MatchSource,
+// used in debug logging.
+func matchSourceName(s plex.MatchSource) string {
+	switch s {
+	case plex.MatchSourceID:
+		return "xmltv-id"
+	case plex.MatchSourceLCN:
+		return "lcn"
+	case plex.MatchSourceName:
+		return "display-name"
+	case plex.MatchSourceProgID:
+		return "progid"
+	case plex.MatchSourceStartTime:
+		return "start-time"
+	}
+	return "none"
+}
+
+// unmatchedReasonString maps an UnmatchedReason to the stable token used in
+// API responses and logs.
+func unmatchedReasonString(r plex.UnmatchedReason) string {
+	switch r {
+	case plex.UnmatchedNoCandidate:
+		return "no_candidate_airing"
+	case plex.UnmatchedNoProgID:
+		return "no_progid_in_plex"
+	case plex.UnmatchedProgIDMismatch:
+		return "progid_mismatch"
+	case plex.UnmatchedNoStartTimeMatch:
+		return "no_start_time_match"
+	}
+	return "unknown"
+}
+
+// logPlexFetchError emits the actionable log line for an HTTP fetch error.
+// Errors that match plex.ErrUnauthorized produce the PLEX_TOKEN guidance.
+func logPlexFetchError(context string, err error) {
+	if errors.Is(err, plex.ErrUnauthorized) {
+		logging.Error("ERROR: Plex returned 401 — PLEX_TOKEN appears invalid. Regenerate at https://plex.tv → Account → Authorized Devices.")
+		return
+	}
+	logging.Warn(fmt.Sprintf("WARN: Plex poll failed (%s): %v.", context, err))
+}
+
+// logChannelSummary emits the per-poll INFO summary block for channel matches.
+func logChannelSummary(stats PlexMatchStats, unmatched []PlexUnmatchedChannel) {
+	logging.Info(fmt.Sprintf("[plex] channels: matched %d/%d (%d by id, %d by lcn, %d by name)",
+		stats.Matched, stats.Total, stats.ByID, stats.ByLCN, stats.ByName))
+	if len(unmatched) == 0 {
+		return
+	}
+	const maxSample = 5
+	sample := make([]string, 0, maxSample)
+	for i, u := range unmatched {
+		if i >= maxSample {
+			break
+		}
+		sample = append(sample, u.PlexID)
+	}
+	suffix := ""
+	if len(unmatched) > maxSample {
+		suffix = fmt.Sprintf(" (and %d more)", len(unmatched)-maxSample)
+	}
+	logging.Info(fmt.Sprintf("[plex]   unmatched Plex channels: %v%s", sample, suffix))
+}
+
+// logAiringSummary emits the per-poll INFO summary block for airing matches.
+func logAiringSummary(stats PlexMatchStats, unmatched []PlexUnmatchedAiring) {
+	logging.Info(fmt.Sprintf("[plex] airings: matched %d/%d (%d by progid, %d by start-time)",
+		stats.Matched, stats.Total, stats.ByProgID, stats.ByStartTime))
+	if len(unmatched) == 0 {
+		return
+	}
+	const maxSample = 5
+	for i, u := range unmatched {
+		if i >= maxSample {
+			break
+		}
+		logging.Info(fmt.Sprintf("[plex]   unmatched sample: %q on %s @ %s (%s)",
+			u.Title, u.ChannelID, u.StartTime.Format("15:04"), u.Reason))
+	}
+	if len(unmatched) > maxSample {
+		logging.Info(fmt.Sprintf("[plex]   (and %d more unmatched)", len(unmatched)-maxSample))
+	}
+}

--- a/internal/database/plex_refresh.go
+++ b/internal/database/plex_refresh.go
@@ -78,6 +78,13 @@ type airingUpdate struct {
 	plexRatingKey string
 }
 
+// dvrTask pairs a DVR's grid key with the lineup IDs it serves. RefreshPlex
+// walks one task per DVR.
+type dvrTask struct {
+	gridKey   string
+	lineupIDs []string
+}
+
 // RefreshPlex performs one Plex EPG enrichment cycle: discover DVRs, match
 // every Plex channel against the local channels table, then match every Plex
 // grid entry against the airings on its already-matched local channel. All
@@ -103,33 +110,53 @@ func (d *DB) RefreshPlex(ctx context.Context, client PlexAPI) (PlexPollResult, e
 		return result, nil
 	}
 
-	type dvrTask struct {
-		gridKey   string
-		lineupIDs []string
-	}
-	var tasks []dvrTask
-	totalLineups := 0
-	for _, dvr := range dvrs {
-		tasks = append(tasks, dvrTask{gridKey: dvr.GridKey, lineupIDs: dvr.LineupIDs})
-		totalLineups += len(dvr.LineupIDs)
-	}
+	tasks, totalLineups := buildDVRTasks(dvrs)
 	result.Lineups = totalLineups
 	if totalLineups == 0 {
 		logging.Warn("WARN: Plex returned 0 DVRs — Plex Live TV / DVR may not be configured on this server.")
 	}
 	logging.Info(fmt.Sprintf("[plex] poll started (%d lineups discovered)", totalLineups))
 
-	// Load local channels once for channel matching.
 	localChannels, err := d.GetChannels(ctx)
 	if err != nil {
 		return result, fmt.Errorf("loading channels: %w", err)
 	}
 
-	// channelMatchMap: Plex channel ID → local channel ID. Used to resolve
-	// grid entries back to local channels in the airing-match phase.
-	channelMatchMap := map[string]string{}
-	var channelUpdates []channelUpdate
+	channelMatchMap, channelUpdates := d.matchAllChannels(ctx, client, tasks, localChannels, &result)
+	logChannelSummary(result.ChannelMatches, result.UnmatchedChan)
 
+	gridStart := time.Now().UTC()
+	gridEnd := gridStart.AddDate(0, 0, d.retentionDays)
+	airingUpdates := d.matchAllAirings(ctx, client, tasks, channelMatchMap, gridStart, gridEnd, &result)
+	logAiringSummary(result.AiringMatches, result.UnmatchedAirings)
+
+	if err := d.applyPlexUpdates(ctx, channelUpdates, airingUpdates); err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("applyPlexUpdates: %v", err))
+	}
+
+	logging.Info(fmt.Sprintf("[plex] poll completed in %s", time.Since(result.StartedAt).Round(time.Millisecond)))
+	return result, nil
+}
+
+// buildDVRTasks flattens the slice of DVRs returned by Plex into the dvrTask
+// shape RefreshPlex iterates, and returns the total lineup count.
+func buildDVRTasks(dvrs []plex.DVR) ([]dvrTask, int) {
+	tasks := make([]dvrTask, 0, len(dvrs))
+	total := 0
+	for _, dvr := range dvrs {
+		tasks = append(tasks, dvrTask{gridKey: dvr.GridKey, lineupIDs: dvr.LineupIDs})
+		total += len(dvr.LineupIDs)
+	}
+	return tasks, total
+}
+
+// matchAllChannels walks every lineup, calls GetLineupChannels, and matches
+// each Plex channel against localChannels. Returns the Plex→local ID map and
+// the pending channel UPDATEs. Stats and unmatched entries are accumulated on
+// result.
+func (d *DB) matchAllChannels(ctx context.Context, client PlexAPI, tasks []dvrTask, localChannels []model.Channel, result *PlexPollResult) (map[string]string, []channelUpdate) {
+	channelMatchMap := map[string]string{}
+	var updates []channelUpdate
 	for _, task := range tasks {
 		for _, lineupID := range task.lineupIDs {
 			pcs, err := client.GetLineupChannels(ctx, lineupID)
@@ -140,31 +167,10 @@ func (d *DB) RefreshPlex(ctx context.Context, client PlexAPI) (PlexPollResult, e
 				continue
 			}
 			for _, pc := range pcs {
-				result.ChannelMatches.Total++
-				matched, src := plex.MatchChannel(pc, localChannels)
-				if matched != nil {
-					result.ChannelMatches.Matched++
-					switch src {
-					case plex.MatchSourceID:
-						result.ChannelMatches.ByID++
-					case plex.MatchSourceLCN:
-						result.ChannelMatches.ByLCN++
-					case plex.MatchSourceName:
-						result.ChannelMatches.ByName++
-					}
-					channelUpdates = append(channelUpdates, channelUpdate{
-						channelID:     matched.ID,
-						plexChannelID: pc.ID,
-						plexLineupID:  lineupID,
-					})
-					channelMatchMap[pc.ID] = matched.ID
-					logging.Debug(fmt.Sprintf("channel '%s' matched '%s' via %s", pc.DisplayName, matched.ID, matchSourceName(src)))
-				} else {
-					result.UnmatchedChan = append(result.UnmatchedChan, PlexUnmatchedChannel{
-						PlexID:      pc.ID,
-						DisplayName: pc.DisplayName,
-						Reason:      "no_id_lcn_or_name_match",
-					})
+				u, ok := matchSingleChannel(pc, lineupID, localChannels, result)
+				if ok {
+					updates = append(updates, u)
+					channelMatchMap[pc.ID] = u.channelID
 				}
 			}
 		}
@@ -172,20 +178,55 @@ func (d *DB) RefreshPlex(ctx context.Context, client PlexAPI) (PlexPollResult, e
 	if result.ChannelMatches.Total > 0 && result.ChannelMatches.Matched == 0 {
 		logging.Warn(fmt.Sprintf("WARN: Plex returned %d channels but none matched TV Guide channels. Check that both sources reference the same lineup (compare channel IDs/LCNs/names).", result.ChannelMatches.Total))
 	}
-	logChannelSummary(result.ChannelMatches, result.UnmatchedChan)
+	return channelMatchMap, updates
+}
 
-	// Airing phase — per unique grid key.
-	gridStart := time.Now().UTC()
-	gridEnd := gridStart.AddDate(0, 0, d.retentionDays)
-	var airingUpdates []airingUpdate
+// matchSingleChannel pairs one Plex channel with a local candidate and
+// updates result's stats. Returns the pending UPDATE row and ok=true on
+// success; ok=false means the channel was logged as unmatched.
+func matchSingleChannel(pc plex.LineupChannel, lineupID string, localChannels []model.Channel, result *PlexPollResult) (channelUpdate, bool) {
+	result.ChannelMatches.Total++
+	matched, src := plex.MatchChannel(pc, localChannels)
+	if matched == nil {
+		result.UnmatchedChan = append(result.UnmatchedChan, PlexUnmatchedChannel{
+			PlexID:      pc.ID,
+			DisplayName: pc.DisplayName,
+			Reason:      "no_id_lcn_or_name_match",
+		})
+		return channelUpdate{}, false
+	}
+	result.ChannelMatches.Matched++
+	tickChannelMatchSource(src, &result.ChannelMatches)
+	logging.Debug(fmt.Sprintf("channel '%s' matched '%s' via %s", pc.DisplayName, matched.ID, matchSourceName(src)))
+	return channelUpdate{
+		channelID:     matched.ID,
+		plexChannelID: pc.ID,
+		plexLineupID:  lineupID,
+	}, true
+}
+
+// tickChannelMatchSource increments the per-source counter for a channel match.
+func tickChannelMatchSource(src plex.MatchSource, stats *PlexMatchStats) {
+	switch src {
+	case plex.MatchSourceID:
+		stats.ByID++
+	case plex.MatchSourceLCN:
+		stats.ByLCN++
+	case plex.MatchSourceName:
+		stats.ByName++
+	}
+}
+
+// matchAllAirings walks unique grid keys, fetches each grid, and matches each
+// entry against airings on its already-matched channel.
+func (d *DB) matchAllAirings(ctx context.Context, client PlexAPI, tasks []dvrTask, channelMatchMap map[string]string, gridStart, gridEnd time.Time, result *PlexPollResult) []airingUpdate {
+	var updates []airingUpdate
 	gridSeen := map[string]bool{}
-
 	for _, task := range tasks {
 		if task.gridKey == "" || gridSeen[task.gridKey] {
 			continue
 		}
 		gridSeen[task.gridKey] = true
-
 		entries, err := client.GetGrid(ctx, task.gridKey, gridStart, gridEnd)
 		if err != nil {
 			msg := fmt.Sprintf("GetGrid(%s): %v", task.gridKey, err)
@@ -193,57 +234,69 @@ func (d *DB) RefreshPlex(ctx context.Context, client PlexAPI) (PlexPollResult, e
 			logPlexFetchError(msg, err)
 			continue
 		}
+		updates = append(updates, d.matchGridEntries(ctx, entries, channelMatchMap, gridStart, gridEnd, result)...)
+	}
+	return updates
+}
 
-		byChannel := map[string][]plex.GridEntry{}
-		for _, e := range entries {
-			byChannel[e.Channel] = append(byChannel[e.Channel], e)
+// matchGridEntries groups entries by Plex channel and pairs each group with
+// the airings on the corresponding local channel.
+func (d *DB) matchGridEntries(ctx context.Context, entries []plex.GridEntry, channelMatchMap map[string]string, gridStart, gridEnd time.Time, result *PlexPollResult) []airingUpdate {
+	byChannel := map[string][]plex.GridEntry{}
+	for _, e := range entries {
+		byChannel[e.Channel] = append(byChannel[e.Channel], e)
+	}
+	var updates []airingUpdate
+	for plexChanID, gridEntries := range byChannel {
+		localChannelID, ok := channelMatchMap[plexChanID]
+		if !ok {
+			continue
 		}
-
-		for plexChanID, gridEntries := range byChannel {
-			localChannelID, ok := channelMatchMap[plexChanID]
-			if !ok {
-				continue
-			}
-			candidates, err := d.getAiringsForChannel(ctx, localChannelID, gridStart, gridEnd)
-			if err != nil {
-				result.Errors = append(result.Errors, fmt.Sprintf("getAiringsForChannel(%s): %v", localChannelID, err))
-				continue
-			}
-			for _, entry := range gridEntries {
-				result.AiringMatches.Total++
-				matched, src, reason := plex.MatchAiring(entry, candidates)
-				if matched != nil {
-					result.AiringMatches.Matched++
-					switch src {
-					case plex.MatchSourceProgID:
-						result.AiringMatches.ByProgID++
-					case plex.MatchSourceStartTime:
-						result.AiringMatches.ByStartTime++
-					}
-					airingUpdates = append(airingUpdates, airingUpdate{
-						channelID:     matched.ChannelID,
-						startTime:     matched.Start,
-						plexRatingKey: entry.RatingKey,
-					})
-				} else {
-					result.UnmatchedAirings = append(result.UnmatchedAirings, PlexUnmatchedAiring{
-						ChannelID: localChannelID,
-						Title:     entry.Title,
-						StartTime: time.Unix(entry.BeginsAt, 0).UTC(),
-						Reason:    unmatchedReasonString(reason),
-					})
-				}
+		candidates, err := d.getAiringsForChannel(ctx, localChannelID, gridStart, gridEnd)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("getAiringsForChannel(%s): %v", localChannelID, err))
+			continue
+		}
+		for _, entry := range gridEntries {
+			if u, ok := matchSingleAiring(entry, localChannelID, candidates, result); ok {
+				updates = append(updates, u)
 			}
 		}
 	}
-	logAiringSummary(result.AiringMatches, result.UnmatchedAirings)
+	return updates
+}
 
-	if err := d.applyPlexUpdates(ctx, channelUpdates, airingUpdates); err != nil {
-		result.Errors = append(result.Errors, fmt.Sprintf("applyPlexUpdates: %v", err))
+// matchSingleAiring pairs one Plex grid entry with a local airing and updates
+// result's stats. Returns ok=false when the entry could not be matched.
+func matchSingleAiring(entry plex.GridEntry, localChannelID string, candidates []model.Airing, result *PlexPollResult) (airingUpdate, bool) {
+	result.AiringMatches.Total++
+	matched, src, reason := plex.MatchAiring(entry, candidates)
+	if matched == nil {
+		result.UnmatchedAirings = append(result.UnmatchedAirings, PlexUnmatchedAiring{
+			ChannelID: localChannelID,
+			Title:     entry.Title,
+			StartTime: time.Unix(entry.BeginsAt, 0).UTC(),
+			Reason:    unmatchedReasonString(reason),
+		})
+		return airingUpdate{}, false
 	}
+	result.AiringMatches.Matched++
+	tickAiringMatchSource(src, &result.AiringMatches)
+	return airingUpdate{
+		channelID:     matched.ChannelID,
+		startTime:     matched.Start,
+		plexRatingKey: entry.RatingKey,
+	}, true
+}
 
-	logging.Info(fmt.Sprintf("[plex] poll completed in %s", time.Since(result.StartedAt).Round(time.Millisecond)))
-	return result, nil
+// tickAiringMatchSource increments the per-source counter for an airing match.
+func tickAiringMatchSource(src plex.MatchSource, stats *PlexMatchStats) {
+	switch src {
+	case plex.MatchSourceProgID:
+		stats.ByProgID++
+	case plex.MatchSourceStartTime:
+		stats.ByStartTime++
+	}
 }
 
 // getAiringsForChannel returns the (start, prog_id) pair for every airing on
@@ -292,41 +345,60 @@ func (d *DB) applyPlexUpdates(ctx context.Context, channelUpdates []channelUpdat
 		}
 	}()
 
-	if len(channelUpdates) > 0 {
-		stmt, err := tx.PrepareContext(ctx, `UPDATE channels SET plex_channel_id = ?, plex_lineup_id = ? WHERE id = ?`)
-		if err != nil {
-			return fmt.Errorf("prepare channel update: %w", err)
-		}
-		for _, cu := range channelUpdates {
-			if _, err := stmt.ExecContext(ctx, cu.plexChannelID, cu.plexLineupID, cu.channelID); err != nil {
-				_ = stmt.Close()
-				return fmt.Errorf("update channel %s: %w", cu.channelID, err)
-			}
-		}
-		if err := stmt.Close(); err != nil {
-			log.Printf("closing channel update stmt: %v", err)
-		}
+	if err := execChannelUpdates(ctx, tx, channelUpdates); err != nil {
+		return err
 	}
-
-	if len(airingUpdates) > 0 {
-		stmt, err := tx.PrepareContext(ctx, `UPDATE airings SET plex_rating_key = ? WHERE channel_id = ? AND start_time = ?`)
-		if err != nil {
-			return fmt.Errorf("prepare airing update: %w", err)
-		}
-		for _, au := range airingUpdates {
-			startStr := au.startTime.UTC().Format(time.RFC3339)
-			if _, err := stmt.ExecContext(ctx, au.plexRatingKey, au.channelID, startStr); err != nil {
-				_ = stmt.Close()
-				return fmt.Errorf("update airing %s@%s: %w", au.channelID, startStr, err)
-			}
-		}
-		if err := stmt.Close(); err != nil {
-			log.Printf("closing airing update stmt: %v", err)
-		}
+	if err := execAiringUpdates(ctx, tx, airingUpdates); err != nil {
+		return err
 	}
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit plex tx: %w", err)
+	}
+	return nil
+}
+
+// execChannelUpdates runs all channel UPDATEs inside tx. A no-op when updates is empty.
+func execChannelUpdates(ctx context.Context, tx *sql.Tx, updates []channelUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	stmt, err := tx.PrepareContext(ctx, `UPDATE channels SET plex_channel_id = ?, plex_lineup_id = ? WHERE id = ?`)
+	if err != nil {
+		return fmt.Errorf("prepare channel update: %w", err)
+	}
+	defer func() {
+		if err := stmt.Close(); err != nil {
+			log.Printf("closing channel update stmt: %v", err)
+		}
+	}()
+	for _, cu := range updates {
+		if _, err := stmt.ExecContext(ctx, cu.plexChannelID, cu.plexLineupID, cu.channelID); err != nil {
+			return fmt.Errorf("update channel %s: %w", cu.channelID, err)
+		}
+	}
+	return nil
+}
+
+// execAiringUpdates runs all airing UPDATEs inside tx. A no-op when updates is empty.
+func execAiringUpdates(ctx context.Context, tx *sql.Tx, updates []airingUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	stmt, err := tx.PrepareContext(ctx, `UPDATE airings SET plex_rating_key = ? WHERE channel_id = ? AND start_time = ?`)
+	if err != nil {
+		return fmt.Errorf("prepare airing update: %w", err)
+	}
+	defer func() {
+		if err := stmt.Close(); err != nil {
+			log.Printf("closing airing update stmt: %v", err)
+		}
+	}()
+	for _, au := range updates {
+		startStr := au.startTime.UTC().Format(time.RFC3339)
+		if _, err := stmt.ExecContext(ctx, au.plexRatingKey, au.channelID, startStr); err != nil {
+			return fmt.Errorf("update airing %s@%s: %w", au.channelID, startStr, err)
+		}
 	}
 	return nil
 }

--- a/internal/database/plex_refresh_test.go
+++ b/internal/database/plex_refresh_test.go
@@ -106,8 +106,18 @@ func seedDBForPlex(t *testing.T, base time.Time) *database.DB {
 	return db
 }
 
-func TestRefreshPlex_EndToEnd_MatchesChannelsAndAirings(t *testing.T) {
-	// Anchor airings just past now so they fall inside the grid window.
+// runEndToEndPoll spins up a DB seeded with three channels + three airings,
+// serves the canonical fixture from a stub Plex server, runs one RefreshPlex
+// cycle, and returns the poll result alongside the live DB. The fixtures are
+// designed to exercise every match outcome in one pass:
+//
+//   - abc.com.au   — channel matched by xmltvId; one airing matched by progid,
+//     one by start-time; one ProgID column verified intact
+//   - seven.com.au — channel matched by lcn; its sole airing remains unmatched
+//     because the corresponding grid entry's progid does not match
+//   - nine.com.au  — no Plex counterpart, so all three plex_* columns stay NULL
+func runEndToEndPoll(t *testing.T) (*database.DB, time.Time, database.PlexPollResult) {
+	t.Helper()
 	base := time.Now().UTC().Truncate(time.Hour).Add(time.Hour)
 	db := seedDBForPlex(t, base)
 
@@ -137,104 +147,117 @@ func TestRefreshPlex_EndToEnd_MatchesChannelsAndAirings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RefreshPlex: %v", err)
 	}
+	return db, base, result
+}
 
-	// Channel stats.
-	if result.ChannelMatches.Total != 3 {
-		t.Errorf("ChannelMatches.Total = %d, want 3", result.ChannelMatches.Total)
-	}
-	if result.ChannelMatches.Matched != 2 {
-		t.Errorf("ChannelMatches.Matched = %d, want 2", result.ChannelMatches.Matched)
-	}
-	if result.ChannelMatches.ByID != 1 {
-		t.Errorf("ChannelMatches.ByID = %d, want 1", result.ChannelMatches.ByID)
-	}
-	if result.ChannelMatches.ByLCN != 1 {
-		t.Errorf("ChannelMatches.ByLCN = %d, want 1", result.ChannelMatches.ByLCN)
-	}
+func TestRefreshPlex_EndToEnd_ChannelStats(t *testing.T) {
+	_, _, result := runEndToEndPoll(t)
+	checkChannelStats(t, result)
 	if len(result.UnmatchedChan) != 1 || result.UnmatchedChan[0].PlexID != "plex.extra" {
 		t.Errorf("UnmatchedChan = %+v, want one entry with PlexID=plex.extra", result.UnmatchedChan)
 	}
+}
 
-	// Airing stats.
-	if result.AiringMatches.Total != 3 {
-		t.Errorf("AiringMatches.Total = %d, want 3", result.AiringMatches.Total)
-	}
-	if result.AiringMatches.Matched != 2 {
-		t.Errorf("AiringMatches.Matched = %d, want 2", result.AiringMatches.Matched)
-	}
-	if result.AiringMatches.ByProgID != 1 {
-		t.Errorf("AiringMatches.ByProgID = %d, want 1", result.AiringMatches.ByProgID)
-	}
-	if result.AiringMatches.ByStartTime != 1 {
-		t.Errorf("AiringMatches.ByStartTime = %d, want 1", result.AiringMatches.ByStartTime)
-	}
+func TestRefreshPlex_EndToEnd_AiringStats(t *testing.T) {
+	_, _, result := runEndToEndPoll(t)
+	checkAiringStats(t, result)
+}
 
-	// Channels in DB.
+func TestRefreshPlex_EndToEnd_ChannelsTablePopulated(t *testing.T) {
+	db, _, _ := runEndToEndPoll(t)
 	chans, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
-	mustPlexID := func(id, want string) {
-		t.Helper()
-		for _, c := range chans {
-			if c.ID == id {
-				if c.PlexChannelID == nil || *c.PlexChannelID != want {
-					t.Errorf("%s PlexChannelID = %v, want %s", id, c.PlexChannelID, want)
-				}
-				return
-			}
-		}
-		t.Errorf("channel %s not found", id)
-	}
-	mustPlexID("abc.com.au", "plex.abc")
-	mustPlexID("seven.com.au", "plex.seven")
+	checkChannelRowState(t, chans)
+}
 
-	// Verify nine.com.au stayed NULL.
-	for _, c := range chans {
-		if c.ID == "nine.com.au" && c.PlexChannelID != nil {
-			t.Errorf("nine.com.au PlexChannelID should be nil, got %v", *c.PlexChannelID)
-		}
-		if c.ID == "abc.com.au" {
-			if c.DisplayName != "ABC" {
-				t.Errorf("abc DisplayName mutated: got %q, want ABC", c.DisplayName)
-			}
-			if c.PlexLineupID == nil || *c.PlexLineupID != "L1" {
-				t.Errorf("abc PlexLineupID = %v, want L1", c.PlexLineupID)
-			}
-		}
-	}
-
-	// Airings in DB.
+func TestRefreshPlex_EndToEnd_AiringsTablePopulated(t *testing.T) {
+	db, base, _ := runEndToEndPoll(t)
 	airings, err := db.GetAirings(context.Background(), base)
 	if err != nil {
 		t.Fatalf("GetAirings: %v", err)
 	}
+	checkAiringRowState(t, airings)
+}
+
+// checkChannelStats asserts the totals/sources on result.ChannelMatches.
+func checkChannelStats(t *testing.T, result database.PlexPollResult) {
+	t.Helper()
+	expectInt(t, "ChannelMatches.Total", result.ChannelMatches.Total, 3)
+	expectInt(t, "ChannelMatches.Matched", result.ChannelMatches.Matched, 2)
+	expectInt(t, "ChannelMatches.ByID", result.ChannelMatches.ByID, 1)
+	expectInt(t, "ChannelMatches.ByLCN", result.ChannelMatches.ByLCN, 1)
+}
+
+// checkAiringStats asserts the totals/sources on result.AiringMatches.
+func checkAiringStats(t *testing.T, result database.PlexPollResult) {
+	t.Helper()
+	expectInt(t, "AiringMatches.Total", result.AiringMatches.Total, 3)
+	expectInt(t, "AiringMatches.Matched", result.AiringMatches.Matched, 2)
+	expectInt(t, "AiringMatches.ByProgID", result.AiringMatches.ByProgID, 1)
+	expectInt(t, "AiringMatches.ByStartTime", result.AiringMatches.ByStartTime, 1)
+}
+
+// checkChannelRowState validates plex_* columns and unchanged display names
+// for every seeded channel.
+func checkChannelRowState(t *testing.T, chans []model.Channel) {
+	t.Helper()
+	for _, c := range chans {
+		switch c.ID {
+		case "abc.com.au":
+			expectPtrEq(t, "abc PlexChannelID", c.PlexChannelID, "plex.abc")
+			expectPtrEq(t, "abc PlexLineupID", c.PlexLineupID, "L1")
+			if c.DisplayName != "ABC" {
+				t.Errorf("abc DisplayName mutated: got %q, want ABC", c.DisplayName)
+			}
+		case "seven.com.au":
+			expectPtrEq(t, "seven PlexChannelID", c.PlexChannelID, "plex.seven")
+		case "nine.com.au":
+			if c.PlexChannelID != nil {
+				t.Errorf("nine.com.au PlexChannelID should be nil, got %v", *c.PlexChannelID)
+			}
+		}
+	}
+}
+
+// checkAiringRowState validates plex_rating_key on each matched airing and
+// confirms the XMLTV ProgID column was not overwritten by Plex.
+func checkAiringRowState(t *testing.T, airings []model.Airing) {
+	t.Helper()
 	var foundNews, foundMovie bool
 	for _, a := range airings {
 		if a.ChannelID == "abc.com.au" && a.Title == "News at Noon" {
 			foundNews = true
-			if a.PlexRatingKey == nil || *a.PlexRatingKey != "rk-1" {
-				t.Errorf("News PlexRatingKey = %v, want rk-1", a.PlexRatingKey)
-			}
+			expectPtrEq(t, "News PlexRatingKey", a.PlexRatingKey, "rk-1")
 			if a.ProgID != "EP000123450001" {
 				t.Errorf("News ProgID mutated: got %q", a.ProgID)
 			}
 		}
 		if a.ChannelID == "abc.com.au" && a.Title == "Movie A" {
 			foundMovie = true
-			if a.PlexRatingKey == nil || *a.PlexRatingKey != "rk-2" {
-				t.Errorf("Movie PlexRatingKey = %v, want rk-2", a.PlexRatingKey)
-			}
+			expectPtrEq(t, "Movie PlexRatingKey", a.PlexRatingKey, "rk-2")
 		}
-		// Morning Show on seven should remain unmatched.
-		if a.ChannelID == "seven.com.au" && a.Title == "Morning Show" {
-			if a.PlexRatingKey != nil {
-				t.Errorf("Morning Show PlexRatingKey should be nil, got %v", *a.PlexRatingKey)
-			}
+		if a.ChannelID == "seven.com.au" && a.Title == "Morning Show" && a.PlexRatingKey != nil {
+			t.Errorf("Morning Show PlexRatingKey should be nil, got %v", *a.PlexRatingKey)
 		}
 	}
 	if !foundNews || !foundMovie {
 		t.Fatalf("expected matched airings; News=%v Movie=%v", foundNews, foundMovie)
+	}
+}
+
+func expectInt(t *testing.T, label string, got, want int) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s = %d, want %d", label, got, want)
+	}
+}
+
+func expectPtrEq(t *testing.T, label string, got *string, want string) {
+	t.Helper()
+	if got == nil || *got != want {
+		t.Errorf("%s = %v, want %s", label, got, want)
 	}
 }
 

--- a/internal/database/plex_refresh_test.go
+++ b/internal/database/plex_refresh_test.go
@@ -1,0 +1,378 @@
+package database_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/images"
+	"github.com/acbgbca/xmltvguide/internal/model"
+	"github.com/acbgbca/xmltvguide/internal/plex"
+	"github.com/acbgbca/xmltvguide/internal/xmltv"
+)
+
+// newPlexFixtureServer returns an httptest server that serves Plex fixture
+// JSON for the four endpoints used by RefreshPlex. lineupBodies is keyed by
+// lineup ID; gridBodies is keyed by the full path prefix used by GetGrid
+// (e.g. "/grid/L1").
+func newPlexFixtureServer(t *testing.T, dvrsBody string, lineupBodies map[string]string, gridBodies map[string]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/identity":
+			_, _ = w.Write([]byte(`{"MediaContainer":{}}`))
+		case r.URL.Path == "/livetv/dvrs":
+			_, _ = w.Write([]byte(dvrsBody))
+		case strings.HasPrefix(r.URL.Path, "/epg/lineups/") && strings.HasSuffix(r.URL.Path, "/channels"):
+			parts := strings.Split(r.URL.Path, "/")
+			if len(parts) < 5 {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			body, ok := lineupBodies[parts[3]]
+			if !ok {
+				body = `{"MediaContainer":{"Channel":[]}}`
+			}
+			_, _ = w.Write([]byte(body))
+		case strings.HasSuffix(r.URL.Path, "/grid"):
+			gridKey := strings.TrimSuffix(r.URL.Path, "/grid")
+			body, ok := gridBodies[gridKey]
+			if !ok {
+				body = `{"MediaContainer":{"Metadata":[]}}`
+			}
+			_, _ = w.Write([]byte(body))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// seedDBForPlex opens a fresh DB and seeds three channels and three airings
+// anchored to base. abc.com.au is matchable by xmltvId; seven.com.au is
+// matchable by LCN; nine.com.au has no matching plex entry.
+func seedDBForPlex(t *testing.T, base time.Time) *database.DB {
+	t.Helper()
+	dir := t.TempDir()
+	cache := images.NewCache(&http.Client{Transport: &failingTransport{}}, filepath.Join(dir, "images"))
+	db, err := database.Open(filepath.Join(dir, "test.db"), 30, "http://test", cache, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	tv := &xmltv.TV{
+		Channels: []xmltv.Channel{
+			{ID: "abc.com.au", DisplayNames: []xmltv.Name{{Value: "ABC"}}, LCN: "2"},
+			{ID: "seven.com.au", DisplayNames: []xmltv.Name{{Value: "Seven"}}, LCN: "7"},
+			{ID: "nine.com.au", DisplayNames: []xmltv.Name{{Value: "Nine"}}, LCN: "9"},
+		},
+		Programmes: []xmltv.Programme{
+			{
+				Channel: "abc.com.au",
+				Start:   xmltv.XmltvTime{Time: base},
+				Stop:    xmltv.XmltvTime{Time: base.Add(time.Hour)},
+				Titles:  []xmltv.Name{{Value: "News at Noon"}},
+				EpisodeNums: []xmltv.EpisodeNum{
+					{System: "dd_progid", Value: "EP000123450001"},
+				},
+			},
+			{
+				Channel: "abc.com.au",
+				Start:   xmltv.XmltvTime{Time: base.Add(time.Hour)},
+				Stop:    xmltv.XmltvTime{Time: base.Add(2 * time.Hour)},
+				Titles:  []xmltv.Name{{Value: "Movie A"}},
+			},
+			{
+				Channel: "seven.com.au",
+				Start:   xmltv.XmltvTime{Time: base},
+				Stop:    xmltv.XmltvTime{Time: base.Add(time.Hour)},
+				Titles:  []xmltv.Name{{Value: "Morning Show"}},
+			},
+		},
+	}
+	if err := db.Refresh(context.Background(), tv, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	return db
+}
+
+func TestRefreshPlex_EndToEnd_MatchesChannelsAndAirings(t *testing.T) {
+	// Anchor airings just past now so they fall inside the grid window.
+	base := time.Now().UTC().Truncate(time.Hour).Add(time.Hour)
+	db := seedDBForPlex(t, base)
+
+	dvrs := `{"MediaContainer":{"Dvr":[{"id":1,"lineupIDs":["L1"],"gridKey":"/grid/L1"}]}}`
+	lineups := map[string]string{
+		"L1": `{"MediaContainer":{"Channel":[
+			{"id":"plex.abc","xmltvId":"abc.com.au","lcn":"2","title":"ABC"},
+			{"id":"plex.seven","lcn":"7","title":"Seven Network"},
+			{"id":"plex.extra","lcn":"42","title":"Extra Channel"}
+		]}}`,
+	}
+	grids := map[string]string{
+		"/grid/L1": fmt.Sprintf(`{"MediaContainer":{"Metadata":[
+			{"ratingKey":"rk-1","channel":"plex.abc","beginsAt":%d,"endsAt":%d,"title":"News at Noon","ddProgID":"EP000123450001"},
+			{"ratingKey":"rk-2","channel":"plex.abc","beginsAt":%d,"endsAt":%d,"title":"Movie A"},
+			{"ratingKey":"rk-3","channel":"plex.seven","beginsAt":%d,"endsAt":%d,"title":"Unrelated Show","ddProgID":"EPNOMATCH"}
+		]}}`,
+			base.Unix(), base.Add(time.Hour).Unix(),
+			base.Add(time.Hour).Unix(), base.Add(2*time.Hour).Unix(),
+			base.Add(3*time.Hour).Unix(), base.Add(4*time.Hour).Unix(),
+		),
+	}
+	srv := newPlexFixtureServer(t, dvrs, lineups, grids)
+	client := plex.NewClient(srv.URL, "tok", &http.Client{Timeout: 2 * time.Second})
+
+	result, err := db.RefreshPlex(context.Background(), client)
+	if err != nil {
+		t.Fatalf("RefreshPlex: %v", err)
+	}
+
+	// Channel stats.
+	if result.ChannelMatches.Total != 3 {
+		t.Errorf("ChannelMatches.Total = %d, want 3", result.ChannelMatches.Total)
+	}
+	if result.ChannelMatches.Matched != 2 {
+		t.Errorf("ChannelMatches.Matched = %d, want 2", result.ChannelMatches.Matched)
+	}
+	if result.ChannelMatches.ByID != 1 {
+		t.Errorf("ChannelMatches.ByID = %d, want 1", result.ChannelMatches.ByID)
+	}
+	if result.ChannelMatches.ByLCN != 1 {
+		t.Errorf("ChannelMatches.ByLCN = %d, want 1", result.ChannelMatches.ByLCN)
+	}
+	if len(result.UnmatchedChan) != 1 || result.UnmatchedChan[0].PlexID != "plex.extra" {
+		t.Errorf("UnmatchedChan = %+v, want one entry with PlexID=plex.extra", result.UnmatchedChan)
+	}
+
+	// Airing stats.
+	if result.AiringMatches.Total != 3 {
+		t.Errorf("AiringMatches.Total = %d, want 3", result.AiringMatches.Total)
+	}
+	if result.AiringMatches.Matched != 2 {
+		t.Errorf("AiringMatches.Matched = %d, want 2", result.AiringMatches.Matched)
+	}
+	if result.AiringMatches.ByProgID != 1 {
+		t.Errorf("AiringMatches.ByProgID = %d, want 1", result.AiringMatches.ByProgID)
+	}
+	if result.AiringMatches.ByStartTime != 1 {
+		t.Errorf("AiringMatches.ByStartTime = %d, want 1", result.AiringMatches.ByStartTime)
+	}
+
+	// Channels in DB.
+	chans, err := db.GetChannels(context.Background())
+	if err != nil {
+		t.Fatalf("GetChannels: %v", err)
+	}
+	mustPlexID := func(id, want string) {
+		t.Helper()
+		for _, c := range chans {
+			if c.ID == id {
+				if c.PlexChannelID == nil || *c.PlexChannelID != want {
+					t.Errorf("%s PlexChannelID = %v, want %s", id, c.PlexChannelID, want)
+				}
+				return
+			}
+		}
+		t.Errorf("channel %s not found", id)
+	}
+	mustPlexID("abc.com.au", "plex.abc")
+	mustPlexID("seven.com.au", "plex.seven")
+
+	// Verify nine.com.au stayed NULL.
+	for _, c := range chans {
+		if c.ID == "nine.com.au" && c.PlexChannelID != nil {
+			t.Errorf("nine.com.au PlexChannelID should be nil, got %v", *c.PlexChannelID)
+		}
+		if c.ID == "abc.com.au" {
+			if c.DisplayName != "ABC" {
+				t.Errorf("abc DisplayName mutated: got %q, want ABC", c.DisplayName)
+			}
+			if c.PlexLineupID == nil || *c.PlexLineupID != "L1" {
+				t.Errorf("abc PlexLineupID = %v, want L1", c.PlexLineupID)
+			}
+		}
+	}
+
+	// Airings in DB.
+	airings, err := db.GetAirings(context.Background(), base)
+	if err != nil {
+		t.Fatalf("GetAirings: %v", err)
+	}
+	var foundNews, foundMovie bool
+	for _, a := range airings {
+		if a.ChannelID == "abc.com.au" && a.Title == "News at Noon" {
+			foundNews = true
+			if a.PlexRatingKey == nil || *a.PlexRatingKey != "rk-1" {
+				t.Errorf("News PlexRatingKey = %v, want rk-1", a.PlexRatingKey)
+			}
+			if a.ProgID != "EP000123450001" {
+				t.Errorf("News ProgID mutated: got %q", a.ProgID)
+			}
+		}
+		if a.ChannelID == "abc.com.au" && a.Title == "Movie A" {
+			foundMovie = true
+			if a.PlexRatingKey == nil || *a.PlexRatingKey != "rk-2" {
+				t.Errorf("Movie PlexRatingKey = %v, want rk-2", a.PlexRatingKey)
+			}
+		}
+		// Morning Show on seven should remain unmatched.
+		if a.ChannelID == "seven.com.au" && a.Title == "Morning Show" {
+			if a.PlexRatingKey != nil {
+				t.Errorf("Morning Show PlexRatingKey should be nil, got %v", *a.PlexRatingKey)
+			}
+		}
+	}
+	if !foundNews || !foundMovie {
+		t.Fatalf("expected matched airings; News=%v Movie=%v", foundNews, foundMovie)
+	}
+}
+
+func TestRefreshPlex_PartialFailure_OneLineupErrors(t *testing.T) {
+	base := time.Now().UTC().Truncate(time.Hour).Add(time.Hour)
+	db := seedDBForPlex(t, base)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/livetv/dvrs":
+			_, _ = w.Write([]byte(`{"MediaContainer":{"Dvr":[
+				{"id":1,"lineupIDs":["L1","L2"],"gridKey":"/grid/main"}
+			]}}`))
+		case r.URL.Path == "/epg/lineups/L1/channels":
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.URL.Path == "/epg/lineups/L2/channels":
+			_, _ = w.Write([]byte(`{"MediaContainer":{"Channel":[
+				{"id":"plex.abc","xmltvId":"abc.com.au","title":"ABC"}
+			]}}`))
+		case strings.HasSuffix(r.URL.Path, "/grid"):
+			_, _ = w.Write([]byte(`{"MediaContainer":{"Metadata":[]}}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"MediaContainer":{}}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	client := plex.NewClient(srv.URL, "tok", &http.Client{Timeout: 2 * time.Second})
+
+	result, err := db.RefreshPlex(context.Background(), client)
+	if err != nil {
+		t.Fatalf("RefreshPlex returned fatal error %v; per-step errors should not abort", err)
+	}
+	if len(result.Errors) == 0 {
+		t.Errorf("expected at least one per-step error in result, got %+v", result.Errors)
+	}
+	if result.ChannelMatches.Matched != 1 {
+		t.Errorf("ChannelMatches.Matched = %d, want 1 (L2 should still succeed)", result.ChannelMatches.Matched)
+	}
+
+	// abc should still be updated despite L1 failing.
+	chans, err := db.GetChannels(context.Background())
+	if err != nil {
+		t.Fatalf("GetChannels: %v", err)
+	}
+	updated := false
+	for _, ch := range chans {
+		if ch.ID == "abc.com.au" && ch.PlexChannelID != nil && *ch.PlexChannelID == "plex.abc" {
+			updated = true
+		}
+	}
+	if !updated {
+		t.Errorf("abc should have plex_channel_id set despite L1 failure")
+	}
+}
+
+func TestRefreshPlex_DoesNotMutateXMLTVColumns(t *testing.T) {
+	base := time.Now().UTC().Truncate(time.Hour).Add(time.Hour)
+	db := seedDBForPlex(t, base)
+
+	// Snapshot pre-refresh state.
+	preChans, _ := db.GetChannels(context.Background())
+	preAirs, _ := db.GetAirings(context.Background(), base)
+
+	dvrs := `{"MediaContainer":{"Dvr":[{"id":1,"lineupIDs":["L1"],"gridKey":"/grid/L1"}]}}`
+	lineups := map[string]string{
+		"L1": `{"MediaContainer":{"Channel":[{"id":"plex.abc","xmltvId":"abc.com.au","title":"Different Name"}]}}`,
+	}
+	grids := map[string]string{
+		"/grid/L1": fmt.Sprintf(`{"MediaContainer":{"Metadata":[
+			{"ratingKey":"rk-1","channel":"plex.abc","beginsAt":%d,"endsAt":%d,"title":"Plex Says Different","ddProgID":"EP000123450001"}
+		]}}`, base.Unix(), base.Add(time.Hour).Unix()),
+	}
+	srv := newPlexFixtureServer(t, dvrs, lineups, grids)
+	client := plex.NewClient(srv.URL, "tok", &http.Client{Timeout: 2 * time.Second})
+
+	if _, err := db.RefreshPlex(context.Background(), client); err != nil {
+		t.Fatalf("RefreshPlex: %v", err)
+	}
+
+	postChans, _ := db.GetChannels(context.Background())
+	postAirs, _ := db.GetAirings(context.Background(), base)
+
+	// Channel XMLTV columns unchanged.
+	if len(preChans) != len(postChans) {
+		t.Fatalf("channel count changed: %d → %d", len(preChans), len(postChans))
+	}
+	for i := range preChans {
+		if preChans[i].DisplayName != postChans[i].DisplayName {
+			t.Errorf("channel[%d].DisplayName changed: %q → %q", i, preChans[i].DisplayName, postChans[i].DisplayName)
+		}
+	}
+	// Airing XMLTV columns unchanged.
+	preB, _ := json.Marshal(stripPlexFields(preAirs))
+	postB, _ := json.Marshal(stripPlexFields(postAirs))
+	if string(preB) != string(postB) {
+		t.Errorf("airing XMLTV columns changed:\npre = %s\npost = %s", preB, postB)
+	}
+}
+
+// stripPlexFields returns a copy of airings with PlexRatingKey cleared so we
+// can compare the XMLTV-derived columns alone.
+func stripPlexFields(airings []model.Airing) []model.Airing {
+	out := make([]model.Airing, len(airings))
+	for i, a := range airings {
+		a.PlexRatingKey = nil
+		out[i] = a
+	}
+	return out
+}
+
+func TestRefreshPlex_NoOpOnZeroDVRs(t *testing.T) {
+	base := time.Now().UTC().Truncate(time.Hour).Add(time.Hour)
+	db := seedDBForPlex(t, base)
+
+	srv := newPlexFixtureServer(t,
+		`{"MediaContainer":{"Dvr":[]}}`,
+		nil, nil,
+	)
+	client := plex.NewClient(srv.URL, "tok", &http.Client{Timeout: 2 * time.Second})
+
+	result, err := db.RefreshPlex(context.Background(), client)
+	if err != nil {
+		t.Fatalf("RefreshPlex: %v", err)
+	}
+	if result.ChannelMatches.Total != 0 || result.ChannelMatches.Matched != 0 {
+		t.Errorf("expected zero channel matches, got %+v", result.ChannelMatches)
+	}
+	if result.AiringMatches.Total != 0 {
+		t.Errorf("expected zero airing matches, got %+v", result.AiringMatches)
+	}
+
+	// Nothing should be persisted on either channels or airings.
+	chans, _ := db.GetChannels(context.Background())
+	for _, ch := range chans {
+		if ch.PlexChannelID != nil {
+			t.Errorf("channel %s should not have PlexChannelID set", ch.ID)
+		}
+	}
+}

--- a/internal/deepcheck/deepcheck.go
+++ b/internal/deepcheck/deepcheck.go
@@ -4,6 +4,7 @@ package deepcheck
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/plex"
 )
 
 // CheckStatus is the SUCCESS/FAILURE indicator for a single check or the
@@ -46,6 +49,12 @@ type DBProbe interface {
 	DeepCheck(ctx context.Context) DBCheckResults
 }
 
+// PlexProbe is the narrow interface deepcheck needs to verify the Plex Media
+// Server is reachable. *plex.Client satisfies it; tests can stub it.
+type PlexProbe interface {
+	Ping(ctx context.Context) error
+}
+
 // DBCheckResults holds the data the DB layer can gather. Per-field errors are
 // stored so the caller can render every check independently — DBCheckResults
 // itself never carries a fatal error.
@@ -68,6 +77,11 @@ type Checker struct {
 	DBPath        string
 	ImageCacheDir string
 	Now           func() time.Time
+
+	// PlexURL is empty when Plex enrichment is not configured. When set, the
+	// plex_reachable check pings PlexClient.
+	PlexURL    string
+	PlexClient PlexProbe
 }
 
 // Run executes every check in order and returns the aggregated report. One
@@ -140,6 +154,9 @@ func (c *Checker) Run(ctx context.Context) Report {
 	// 9. image_cache — write-probe in IMAGE_CACHE_DIR/channels.
 	checks = append(checks, writeProbe("image_cache", filepath.Join(c.ImageCacheDir, "channels")))
 
+	// 10. plex_reachable — only when configured.
+	checks = append(checks, c.probePlex(ctx))
+
 	overall := StatusSuccess
 	for _, r := range checks {
 		if r.Status != StatusSuccess {
@@ -158,6 +175,26 @@ func runCheck(name string, fn func() (string, error)) CheckResult {
 		return CheckResult{Name: name, Status: StatusFailure, Error: err.Error(), Info: info}
 	}
 	return CheckResult{Name: name, Status: StatusSuccess, Info: info}
+}
+
+// probePlex pings the configured Plex Media Server. When PlexURL is empty
+// the check is a no-op success ("not configured") so it never fails the
+// overall report on installations that don't use Plex. When configured, an
+// auth failure is translated into the documented actionable error message.
+func (c *Checker) probePlex(parent context.Context) CheckResult {
+	const name = "plex_reachable"
+	if c.PlexURL == "" || c.PlexClient == nil {
+		return CheckResult{Name: name, Status: StatusSuccess, Info: "not configured"}
+	}
+	ctx, cancel := context.WithTimeout(parent, xmltvProbeTimeout)
+	defer cancel()
+	if err := c.PlexClient.Ping(ctx); err != nil {
+		if errors.Is(err, plex.ErrUnauthorized) {
+			return CheckResult{Name: name, Status: StatusFailure, Error: "PLEX_TOKEN appears invalid (401/403 from Plex)"}
+		}
+		return CheckResult{Name: name, Status: StatusFailure, Error: err.Error()}
+	}
+	return CheckResult{Name: name, Status: StatusSuccess}
 }
 
 // probeXMLTV issues a HEAD request to c.XMLTVURL with a fresh 5s timeout. The

--- a/internal/deepcheck/deepcheck_test.go
+++ b/internal/deepcheck/deepcheck_test.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/plex"
 )
 
 // fakeDB implements DBProbe for tests. Behaviour is configured per-test.
@@ -97,6 +99,7 @@ func TestRun_AllSuccess(t *testing.T) {
 		"disk_data",
 		"disk_tmp",
 		"image_cache",
+		"plex_reachable",
 	}
 	if len(rep.Checks) != len(wantOrder) {
 		t.Fatalf("got %d checks, want %d (%v)", len(rep.Checks), len(wantOrder), rep.Checks)
@@ -439,8 +442,8 @@ func TestRun_AllChecksRun_EvenWhenOneFails(t *testing.T) {
 	c := newChecker(t, db, srv.URL, now)
 
 	rep := c.Run(context.Background())
-	if len(rep.Checks) != 9 {
-		t.Fatalf("expected 9 checks, got %d (%+v)", len(rep.Checks), rep.Checks)
+	if len(rep.Checks) != 10 {
+		t.Fatalf("expected 10 checks, got %d (%+v)", len(rep.Checks), rep.Checks)
 	}
 	// All non-fts checks should still be SUCCESS.
 	for _, c := range rep.Checks {
@@ -510,3 +513,85 @@ func TestRun_XMLTVURL_RespectsPerRequestTimeout(t *testing.T) {
 
 // Compile-time guard that fakeDB implements DBProbe.
 var _ DBProbe = (*fakeDB)(nil)
+
+// fakePlex implements PlexProbe for tests.
+type fakePlex struct {
+	pingErr error
+}
+
+func (f *fakePlex) Ping(ctx context.Context) error { return f.pingErr }
+
+// Compile-time guard that fakePlex implements PlexProbe.
+var _ PlexProbe = (*fakePlex)(nil)
+
+func TestRun_PlexReachable_NotConfigured(t *testing.T) {
+	now := time.Now()
+	srv := successHEADServer(t)
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	c.PlexURL = ""
+	c.PlexClient = nil
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "plex_reachable")
+	if check.Status != StatusSuccess {
+		t.Errorf("plex_reachable status = %q, want SUCCESS (err=%q)", check.Status, check.Error)
+	}
+	if !strings.Contains(strings.ToLower(check.Info), "not configured") {
+		t.Errorf("plex_reachable info = %q, want to mention 'not configured'", check.Info)
+	}
+	// Not-configured plex must not fail the overall report.
+	if rep.Status != StatusSuccess {
+		t.Errorf("global status = %q, want SUCCESS when only plex is unset", rep.Status)
+	}
+}
+
+func TestRun_PlexReachable_Healthy(t *testing.T) {
+	now := time.Now()
+	srv := successHEADServer(t)
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	c.PlexURL = "http://plex.local:32400"
+	c.PlexClient = &fakePlex{pingErr: nil}
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "plex_reachable")
+	if check.Status != StatusSuccess {
+		t.Errorf("plex_reachable status = %q, want SUCCESS (err=%q)", check.Status, check.Error)
+	}
+}
+
+func TestRun_PlexReachable_UnauthorizedReportsActionableMessage(t *testing.T) {
+	now := time.Now()
+	srv := successHEADServer(t)
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	c.PlexURL = "http://plex.local:32400"
+	c.PlexClient = &fakePlex{pingErr: plex.ErrUnauthorized}
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "plex_reachable")
+	if check.Status != StatusFailure {
+		t.Errorf("plex_reachable status = %q, want FAILURE", check.Status)
+	}
+	if !strings.Contains(check.Error, "PLEX_TOKEN") {
+		t.Errorf("plex_reachable error = %q, want to mention PLEX_TOKEN", check.Error)
+	}
+	if rep.Status != StatusFailure {
+		t.Errorf("global status should be FAILURE when plex auth fails")
+	}
+}
+
+func TestRun_PlexReachable_GenericError(t *testing.T) {
+	now := time.Now()
+	srv := successHEADServer(t)
+	c := newChecker(t, healthyDB(now), srv.URL, now)
+	c.PlexURL = "http://plex.local:32400"
+	c.PlexClient = &fakePlex{pingErr: errors.New("connection refused")}
+
+	rep := c.Run(context.Background())
+	check := findCheck(t, rep, "plex_reachable")
+	if check.Status != StatusFailure {
+		t.Errorf("plex_reachable status = %q, want FAILURE", check.Status)
+	}
+	if !strings.Contains(check.Error, "connection refused") {
+		t.Errorf("plex_reachable error = %q, want the underlying error", check.Error)
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -6,10 +6,12 @@ import (
 
 // Channel holds display data for a TV channel.
 type Channel struct {
-	ID          string `json:"id"`
-	DisplayName string `json:"displayName"`
-	Icon        string `json:"icon,omitempty"`
-	LCN         *int   `json:"lcn,omitempty"`
+	ID            string  `json:"id"`
+	DisplayName   string  `json:"displayName"`
+	Icon          string  `json:"icon,omitempty"`
+	LCN           *int    `json:"lcn,omitempty"`
+	PlexChannelID *string `json:"plexChannelId,omitempty"`
+	PlexLineupID  *string `json:"plexLineupId,omitempty"`
 }
 
 // Airing holds all data for a single broadcast slot.
@@ -32,6 +34,7 @@ type Airing struct {
 	Country           string    `json:"country,omitempty"`
 	IsRepeat          bool      `json:"isRepeat"`
 	IsPremiere        bool      `json:"isPremiere"`
+	PlexRatingKey     *string   `json:"plexRatingKey,omitempty"`
 }
 
 // Status holds metadata about the last data refresh.

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/acbgbca/xmltvguide/internal/database"
 	"github.com/acbgbca/xmltvguide/internal/images"
 	"github.com/acbgbca/xmltvguide/internal/logging"
+	"github.com/acbgbca/xmltvguide/internal/plex"
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
 )
 
@@ -171,17 +172,35 @@ func run(cfg config) error {
 		}
 	}()
 
+	// Plex enrichment: only when configured.
+	var plexClient *plex.Client
+	plexState := &plexPollerState{}
+	var plexTicker *time.Ticker
+	if cfg.plexURL != "" {
+		plexClient = plex.NewClient(cfg.plexURL, cfg.plexToken, &http.Client{Timeout: 30 * time.Second})
+		plexTicker = startPlexPoller(db, plexClient, cfg.plexURL, cfg.plexPollInterval, plexState)
+	}
+
 	mux := http.NewServeMux()
 
-	apiHandler := api.New(db, cfg.rssTTL, func() error {
-		return refresh(db, httpClient, cfg.xmltvURL, cfg.pollInterval)
-	}, api.DeepCheckConfig{
+	deepCfg := api.DeepCheckConfig{
 		HTTPClient:    httpClient,
 		XMLTVURL:      cfg.xmltvURL,
 		PollInterval:  cfg.pollInterval,
 		DBPath:        cfg.dbPath,
 		ImageCacheDir: cfg.imageCacheDir,
-	})
+		PlexURL:       cfg.plexURL,
+	}
+	if plexClient != nil {
+		deepCfg.PlexClient = plexClient
+	}
+
+	apiHandler := api.New(db, cfg.rssTTL, func() error {
+		return refresh(db, httpClient, cfg.xmltvURL, cfg.pollInterval)
+	}, deepCfg)
+	if cfg.plexURL != "" {
+		apiHandler.SetPlexStatusFunc(plexState.snapshot)
+	}
 	apiHandler.RegisterRoutes(mux)
 
 	webContent, err := fs.Sub(webFS, "web")
@@ -215,6 +234,9 @@ func run(cfg config) error {
 	log.Println("shutting down...")
 
 	ticker.Stop()
+	if plexTicker != nil {
+		plexTicker.Stop()
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/plex_poller.go
+++ b/plex_poller.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/api"
+	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/logging"
+	"github.com/acbgbca/xmltvguide/internal/plex"
+)
+
+// plexPollerState holds the latest poll result + ticker schedule so the API
+// status endpoint can render it. The struct is concurrency-safe via the mutex.
+type plexPollerState struct {
+	mu       sync.RWMutex
+	last     database.PlexPollResult
+	hasRun   bool
+	nextPoll time.Time
+}
+
+// snapshot returns the current state in the api package's view shape so that
+// /api/plex/status can render it directly. The bool reports whether the
+// poller is enabled; the caller already knows the cfg.plexURL state but it
+// is convenient to encode the answer here.
+func (s *plexPollerState) snapshot() (api.PlexStatusSnapshot, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := api.PlexStatusSnapshot{
+		Enabled:  true,
+		NextPoll: s.nextPoll,
+	}
+	if s.hasRun {
+		out.LastPoll = s.last.StartedAt
+		out.LastDuration = s.last.Duration
+		out.Lineups = s.last.Lineups
+		out.ChannelMatches = api.PlexMatchStats(s.last.ChannelMatches)
+		out.AiringMatches = api.PlexMatchStats(s.last.AiringMatches)
+		out.UnmatchedChannels = convertUnmatchedChannels(s.last.UnmatchedChan)
+		out.UnmatchedAirings = convertUnmatchedAirings(s.last.UnmatchedAirings)
+		out.Errors = append([]string{}, s.last.Errors...)
+	}
+	return out, true
+}
+
+func convertUnmatchedChannels(in []database.PlexUnmatchedChannel) []api.PlexUnmatchedChannel {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]api.PlexUnmatchedChannel, len(in))
+	for i, u := range in {
+		out[i] = api.PlexUnmatchedChannel{PlexID: u.PlexID, DisplayName: u.DisplayName, Reason: u.Reason}
+	}
+	return out
+}
+
+func convertUnmatchedAirings(in []database.PlexUnmatchedAiring) []api.PlexUnmatchedAiring {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]api.PlexUnmatchedAiring, len(in))
+	for i, u := range in {
+		out[i] = api.PlexUnmatchedAiring{ChannelID: u.ChannelID, Title: u.Title, StartTime: u.StartTime, Reason: u.Reason}
+	}
+	return out
+}
+
+// startPlexPoller probes the Plex server once at startup, then kicks off a
+// ticker that calls db.RefreshPlex on every interval. Errors are logged with
+// the actionable guidance defined in #283; nothing fatal — the XMLTV path is
+// independent.
+func startPlexPoller(db *database.DB, client *plex.Client, plexURL string, interval time.Duration, state *plexPollerState) *time.Ticker {
+	// Startup probe — non-fatal; ticker will retry on every tick.
+	pingCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Ping(pingCtx); err != nil {
+		if errors.Is(err, plex.ErrUnauthorized) {
+			logging.Error("ERROR: Plex returned 401 — PLEX_TOKEN appears invalid. Regenerate at https://plex.tv → Account → Authorized Devices.")
+		} else {
+			logging.Error(fmt.Sprintf("ERROR: Plex unreachable at %s: %v. Plex enrichment disabled until reachable. Verify PLEX_URL and that Plex is running.", plexURL, err))
+		}
+	}
+
+	state.mu.Lock()
+	state.nextPoll = time.Now().Add(interval)
+	state.mu.Unlock()
+
+	ticker := time.NewTicker(interval)
+	go func() {
+		// Note: we do not stop the ticker here — the caller owns it and stops
+		// it during shutdown so this goroutine exits cleanly when the range
+		// loop ends.
+		for range ticker.C {
+			runOnePlexPoll(db, client, interval, state)
+		}
+	}()
+	return ticker
+}
+
+// runOnePlexPoll executes one poll cycle and stores the result on state.
+func runOnePlexPoll(db *database.DB, client *plex.Client, interval time.Duration, state *plexPollerState) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	result, err := db.RefreshPlex(ctx, client)
+	if err != nil {
+		logging.Error(fmt.Sprintf("ERROR: Plex poll failed: %v", err))
+	}
+	state.mu.Lock()
+	state.last = result
+	state.hasRun = true
+	state.nextPoll = time.Now().Add(interval)
+	state.mu.Unlock()
+}
+
+// Compile-time guard: *plex.Client must satisfy the database.PlexAPI interface
+// (used by RefreshPlex). If the interface contract drifts this fails fast at
+// build time rather than at runtime.
+var _ database.PlexAPI = (*plex.Client)(nil)


### PR DESCRIPTION
## Summary

Wires the Plex API client (#281) and matchers (#282) into a background poller that persists Plex IDs onto channels/airings, exposes them via `/api/plex/status` with full match diagnostics, and adds a `plex_reachable` check to `/api/deepcheck`.

Closes #283. Closes #276.

- **Database**: New `db.RefreshPlex` orchestrates one poll cycle (`GetDVRs` → match channels → `GetGrid` per unique grid key → match airings → single-transaction UPDATEs). Per-step errors are accumulated in `result.Errors` and never abort the transaction. Helper `getAiringsForChannel` narrows airing candidates to the matched channel within the retention window before matching.
- **Model + queries**: `model.Channel.PlexChannelID/PlexLineupID` and `model.Airing.PlexRatingKey` added as `*string` for proper `omitempty` JSON behaviour. `GetChannels`/`GetAirings` scan the new nullable columns.
- **API**: `GET /api/plex/status` returns `{enabled: false}` when no provider is registered, otherwise the documented shape with channel/airing match stats and unmatched entries. `Handler.SetPlexStatusFunc` plugs in the in-memory poll snapshot.
- **Deepcheck**: New `plex_reachable` check — SUCCESS with `info=\"not configured\"` when `PLEX_URL` empty; otherwise pings and surfaces \`PLEX_TOKEN appears invalid\` on 401/403 via \`errors.Is(err, plex.ErrUnauthorized)\`.
- **main.go + plex_poller.go**: When `PLEX_URL` is set, builds a `plex.Client`, runs a non-fatal startup ping with actionable error logging, then ticks `RefreshPlex` on `PLEX_POLL_INTERVAL` cadence and stores the result behind a mutex for the status endpoint to read.

## Test plan

- [x] `go test ./...` — all packages pass (`database`, `api`, `deepcheck`, `model`, `plex`, root integration)
- [x] `go vet ./...` clean
- [x] TDD: `plex_refresh_test.go` — end-to-end with `httptest` Plex fixtures + real SQLite, partial-failure recovery, XMLTV columns untouched, zero-DVRs no-op
- [x] TDD: `plex_test.go` — disabled vs enabled JSON shape coverage
- [x] TDD: `deepcheck_test.go` — not-configured/healthy/unauthorized/generic-error scenarios; 9→10 check expectations updated across both `deepcheck` and `api` packages
- [x] CLAUDE.md updated with Plex enrichment section, API table, schema notes, and project structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)