### PR TITLE
Fix Plex EPG integration to match real Plex API shape (#287)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ tvguide/
 │   ├── xmltv/parser.go          # Fetch XMLTV from URL and parse into structs
 │   ├── plex/                    # Plex API client + match algorithms
 │   │   ├── client.go            # HTTP client (Ping, GetDVRs, GetLineupChannels, GetGrid)
-│   │   └── match.go             # MatchChannel (id/lcn/name cascade) and MatchAiring (progid/start-time)
+│   │   └── match.go             # MatchChannel (id/lcn/name cascade) and MatchAiring (±5 min start-time)
 │   ├── database/db.go           # SQLite store: schema, Refresh, GetChannels, GetAirings, DeepCheck
 │   ├── database/plex_refresh.go # RefreshPlex orchestrator — pairs Plex IDs onto channels/airings
 │   ├── deepcheck/deepcheck.go   # On-demand deep health probe (DB, disk, XMLTV, Plex reachability)
@@ -87,7 +87,7 @@ tvguide/
 | `POST /api/guide/refresh` | Triggers a refresh of TV guide data. `sync=true`: waits for completion and returns `200 {"ok":true}` or `500 {"error":"..."}`. Default (async): returns `202 Accepted` immediately. |
 | `GET /api/health` | Healthcheck endpoint. Probes SQLite connectivity and FTS availability. Returns `200 {"status":"ok"}` when healthy or `500 {"error":"..."}` when unhealthy. Used by the Docker `HEALTHCHECK` instruction via the `--healthcheck` binary flag — this remains the Docker liveness probe and is unchanged. |
 | `GET /api/deepcheck` | Deep health check across database, FTS, data presence/freshness, XMLTV source reachability, disk writability for `/data`, `/tmp`, and the image cache, and Plex reachability (when configured). Returns JSON `{status, checks[]}`: each entry is `{name, status, error?, info?}` with `status` one of `SUCCESS`/`FAILURE`. HTTP `200` when global status is `SUCCESS`, `503 Service Unavailable` otherwise. The `plex_reachable` check reports `info="not configured"` when `PLEX_URL` is unset and never fails the report in that case. Every check runs independently — one failure does not skip the others. Intended for occasional on-demand diagnostics, not high-frequency probing — use `/api/health` for that. |
-| `GET /api/plex/status` | Snapshot of the most recent Plex EPG enrichment poll. When `PLEX_URL` is unset, returns `{"enabled": false}` only. When enabled, returns `lastPoll`, `nextPoll`, `lastDurationMs`, and `channels`/`airings` blocks containing total/matched counts, per-source counters (`byId`/`byLcn`/`byName` for channels; `byProgId`/`byStartTime` for airings), and the full list of unmatched entries with reasons. HTTP 200 in both cases — the endpoint always exists. |
+| `GET /api/plex/status` | Snapshot of the most recent Plex EPG enrichment poll. When `PLEX_URL` is unset, returns `{"enabled": false}` only. When enabled, returns `lastPoll`, `nextPoll`, `lastDurationMs`, and `channels`/`airings` blocks containing total/matched counts, per-source counters (`byId`/`byLcn`/`byName` for channels; `byStartTime` for airings — the older `byProgId` counter was removed in #287), and the full list of unmatched entries with reasons. HTTP 200 in both cases — the endpoint always exists. Consumers must handle missing per-source counters gracefully: zero values are omitted via `omitempty`, and new counters may be added later. |
 | `GET /` | Serves the embedded frontend (SPA shell) |
 | `GET /{any}` | SPA fallback — serves `index.html` for any path not matching API, images, or static files. Enables client-side routing via History API. |
 
@@ -133,7 +133,8 @@ channels (id PK, display_name, icon, sort_order, lcn, icon_url, plex_channel_id,
 -- lcn:     logical channel number from <lcn> element (nullable); used for display ordering
 -- icon:    local filesystem path of the cached icon file (e.g. /data/images/channels/ch1.png); NULL if not yet downloaded
 -- icon_url: original external URL from the XMLTV source; used to detect URL changes and to re-download if the local file goes missing
--- plex_channel_id, plex_lineup_id: Plex EPG enrichment IDs; nullable, populated by the Plex poller — see "Plex enrichment" section
+-- plex_channel_id: Plex EPG channel id; nullable, populated by the Plex poller
+-- plex_lineup_id:  Plex EPG identifier (e.g. "tv.plex.providers.epg.cloud:4") — the path prefix used for the channels/grid endpoints. Nullable, populated by the Plex poller. See "Plex enrichment" section.
 
 airings (
   channel_id + start_time  -- composite PK
@@ -274,9 +275,9 @@ Plex enrichment is purely **additive**: it populates three new columns on existi
 
 A background ticker (cadence: `PLEX_POLL_INTERVAL`, default 12 h) calls `db.RefreshPlex`. One cycle:
 
-1. `GET /livetv/dvrs` — discover lineup IDs and grid keys.
-2. For each lineup, `GET /epg/lineups/{id}/channels` — match each Plex channel to a local channel via the **channel cascade**: xmltv ID → LCN → display name (case-insensitive). Ambiguous matches (two or more candidates at the same tier) abort without falling through; see `internal/plex/match.go` for the rationale. On match, `UPDATE channels SET plex_channel_id, plex_lineup_id`.
-3. For each unique grid key, `GET /{gridKey}/grid?type=4&beginsAt=now&endsAt=now+RETENTION_DAYS` — group entries by Plex channel, resolve to a local channel via step 2's map, then match each entry against airings on that channel only via the **airing strategy**: `dd_progid` when Plex has one; otherwise exact start-time match. On match, `UPDATE airings SET plex_rating_key`.
+1. `GET /livetv/dvrs` — discover each DVR's `epgIdentifier` (e.g. `tv.plex.providers.epg.cloud:4`). This identifier is both the path prefix for the channels endpoint and the grid endpoint.
+2. For each DVR, `GET /{epgIdentifier}/lineups/dvr/channels` — match each Plex channel to a local channel via the **channel cascade**: id → LCN → display name (case-insensitive). The id tier compares the Plex `id` field against the local channel id — a no-op for Plex Cloud EPG (opaque hex strings) but functional for Plex XMLTV-provider users (where Plex sets `id` to the xmltv id). The LCN tier reads Plex's `vcn` field; `strconv.Atoi` strips leading zeros so `vcn="001"` matches `lcn=1` and `vcn="010"` matches `lcn=10`. Ambiguous matches (two or more candidates at the same tier) abort without falling through; see `internal/plex/match.go` for the rationale. On match, `UPDATE channels SET plex_channel_id, plex_lineup_id` (the EPG identifier is stored in `plex_lineup_id`).
+3. For each unique EPG identifier, `GET /{epgIdentifier}/grid?type=4&beginsAt%3E=<unix>&endsAt%3C=<unix>` — the comparison operators `>` (%3E) and `<` (%3C) are mandatory; without them Plex silently returns `{"size":0}`. Group entries by `Media[0].channelIdentifier`, resolve to a local channel via step 2's map, then match each entry against airings on that channel only via the **airing strategy**: ±5 minute start-time tolerance around `Media[0].beginsAt`; when multiple candidates fall inside the window the one with the smallest absolute delta wins. (Plex Cloud EPG never emits `dd_progid`; the older program-id tier was removed in #287.) On match, `UPDATE airings SET plex_rating_key`.
 4. All UPDATEs commit in a single transaction. Per-step fetch errors are accumulated in `result.Errors` and do not abort the transaction — partial enrichment is preferred over rolling back successful matches.
 
 ### Where the IDs are stored
@@ -294,11 +295,11 @@ All three columns are nullable. Unmatched rows stay `NULL`. The XMLTV refresh pa
 Each poll emits an INFO summary block:
 
 ```
-[plex] poll started (2 lineups discovered)
-[plex] channels: matched 38/45 (32 by id, 4 by lcn, 2 by name)
-[plex]   unmatched Plex channels: [plex.foo plex.bar plex.baz] (and 4 more)
-[plex] airings: matched 1180/1240 (1145 by progid, 35 by start-time)
-[plex]   unmatched sample: "Movie B" on ch5.au @ 21:00 (progid_mismatch)
+[plex] poll started (1 lineups discovered)
+[plex] channels: matched 38/45 (0 by id, 36 by lcn, 2 by name)
+[plex]   unmatched Plex channels: [5fc-foo 5fc-bar 5fc-baz] (and 4 more)
+[plex] airings: matched 1180/1240 (1180 by start-time)
+[plex]   unmatched sample: "Movie B" on ch5.au @ 21:00 (no_start_time_match)
 [plex] poll completed in 2.3s
 ```
 
@@ -311,7 +312,7 @@ Actionable error log lines for common failure modes:
 | Plex unreachable on startup probe | ERROR | `Plex unreachable at <URL>: <err>. Plex enrichment disabled until reachable. Verify PLEX_URL and that Plex is running.` |
 | 401/403 from any endpoint | ERROR | `Plex returned 401 — PLEX_TOKEN appears invalid. Regenerate at https://plex.tv → Account → Authorized Devices.` |
 | Timeout / 5xx during poll | WARN | `Plex poll failed (<endpoint>): <err>. Will retry in <interval>.` |
-| 0 DVRs returned | WARN | `Plex returned 0 DVRs — Plex Live TV / DVR may not be configured on this server.` |
+| `Dvr` array literally empty | WARN | `Plex returned 0 DVRs — Plex Live TV / DVR may not be configured on this server.` |
 | Poll succeeded but 0 channels matched | WARN | `Plex returned N channels but none matched TV Guide channels. Check that both sources reference the same lineup (compare channel IDs/LCNs/names).` |
 
 DEBUG (opt-in via `LOG_LEVEL=debug`): per-HTTP-request `GET <url> → <status> (<bytes>, <ms>)` and per-channel match decisions.

--- a/internal/api/plex.go
+++ b/internal/api/plex.go
@@ -7,15 +7,14 @@ import (
 
 // PlexMatchStats summarises Plex match counts for one entity kind. Per-source
 // counters are non-zero only for the kind they apply to (channels:
-// ByID/ByLCN/ByName; airings: ByProgID/ByStartTime). Zero counters are omitted
-// from the JSON response via omitempty.
+// ByID/ByLCN/ByName; airings: ByStartTime). Zero counters are omitted from the
+// JSON response via omitempty.
 type PlexMatchStats struct {
 	Total       int
 	Matched     int
 	ByID        int
 	ByLCN       int
 	ByName      int
-	ByProgID    int
 	ByStartTime int
 }
 
@@ -76,7 +75,6 @@ type channelStatsView struct {
 type airingStatsView struct {
 	Total       int                       `json:"total"`
 	Matched     int                       `json:"matched"`
-	ByProgID    int                       `json:"byProgId,omitempty"`
 	ByStartTime int                       `json:"byStartTime,omitempty"`
 	Unmatched   []plexUnmatchedAiringView `json:"unmatched,omitempty"`
 }
@@ -135,7 +133,6 @@ func (h *Handler) getPlexStatus(w http.ResponseWriter, r *http.Request) {
 		Airings: airingStatsView{
 			Total:       snap.AiringMatches.Total,
 			Matched:     snap.AiringMatches.Matched,
-			ByProgID:    snap.AiringMatches.ByProgID,
 			ByStartTime: snap.AiringMatches.ByStartTime,
 			Unmatched:   mapUnmatchedAirings(snap.UnmatchedAirings),
 		},

--- a/internal/api/plex_test.go
+++ b/internal/api/plex_test.go
@@ -53,12 +53,12 @@ func plexStatusFixture() api.PlexStatusSnapshot {
 		LastDuration:   2300 * time.Millisecond,
 		Lineups:        1,
 		ChannelMatches: api.PlexMatchStats{Total: 45, Matched: 38, ByID: 32, ByLCN: 4, ByName: 2},
-		AiringMatches:  api.PlexMatchStats{Total: 1240, Matched: 1180, ByProgID: 1145, ByStartTime: 35},
+		AiringMatches:  api.PlexMatchStats{Total: 1240, Matched: 1180, ByStartTime: 1180},
 		UnmatchedChannels: []api.PlexUnmatchedChannel{
 			{PlexID: "plex.foo", DisplayName: "Foo TV", Reason: "no_id_lcn_or_name_match"},
 		},
 		UnmatchedAirings: []api.PlexUnmatchedAiring{
-			{ChannelID: "ch5.au", Title: "Movie B", StartTime: time.Date(2026, 5, 23, 21, 0, 0, 0, time.UTC), Reason: "progid_mismatch"},
+			{ChannelID: "ch5.au", Title: "Movie B", StartTime: time.Date(2026, 5, 23, 21, 0, 0, 0, time.UTC), Reason: "no_start_time_match"},
 		},
 		Errors: []string{},
 	}
@@ -146,8 +146,8 @@ func TestPlexStatus_Enabled_AiringsBlock(t *testing.T) {
 	}
 	expectJSONFloat(t, airings, "total", 1240)
 	expectJSONFloat(t, airings, "matched", 1180)
-	expectJSONFloat(t, airings, "byProgId", 1145)
-	expectJSONFloat(t, airings, "byStartTime", 35)
+	expectJSONFloat(t, airings, "byStartTime", 1180)
+	expectJSONAbsent(t, airings, "byProgId")
 	expectJSONAbsent(t, airings, "byId")
 	expectJSONAbsent(t, airings, "byLcn")
 
@@ -156,7 +156,7 @@ func TestPlexStatus_Enabled_AiringsBlock(t *testing.T) {
 		t.Fatalf("airings.unmatched not [1 entry]: %v", airings["unmatched"])
 	}
 	uam := ua[0].(map[string]any)
-	if uam["channelId"] != "ch5.au" || uam["title"] != "Movie B" || uam["reason"] != "progid_mismatch" {
+	if uam["channelId"] != "ch5.au" || uam["title"] != "Movie B" || uam["reason"] != "no_start_time_match" {
 		t.Errorf("unmatched airing = %v, missing expected fields", uam)
 	}
 }

--- a/internal/database/plex_refresh.go
+++ b/internal/database/plex_refresh.go
@@ -17,20 +17,19 @@ import (
 // *plex.Client satisfies it; tests can stub it.
 type PlexAPI interface {
 	GetDVRs(ctx context.Context) ([]plex.DVR, error)
-	GetLineupChannels(ctx context.Context, lineupID string) ([]plex.LineupChannel, error)
-	GetGrid(ctx context.Context, gridKey string, beginsAt, endsAt time.Time) ([]plex.GridEntry, error)
+	GetLineupChannels(ctx context.Context, epgIdentifier string) ([]plex.LineupChannel, error)
+	GetGrid(ctx context.Context, epgIdentifier string, beginsAt, endsAt time.Time) ([]plex.GridEntry, error)
 }
 
 // PlexMatchStats summarises how many entities were matched and via which
 // source. Per-source counters are populated only for the relevant kind:
-// channels populate ByID/ByLCN/ByName; airings populate ByProgID/ByStartTime.
+// channels populate ByID/ByLCN/ByName; airings populate ByStartTime.
 type PlexMatchStats struct {
 	Total       int
 	Matched     int
 	ByID        int
 	ByLCN       int
 	ByName      int
-	ByProgID    int
 	ByStartTime int
 }
 
@@ -78,11 +77,10 @@ type airingUpdate struct {
 	plexRatingKey string
 }
 
-// dvrTask pairs a DVR's grid key with the lineup IDs it serves. RefreshPlex
-// walks one task per DVR.
+// dvrTask pairs one DVR with its EPG identifier. The identifier is both the
+// channels-endpoint path prefix and the grid-endpoint path prefix.
 type dvrTask struct {
-	gridKey   string
-	lineupIDs []string
+	epgIdentifier string
 }
 
 // RefreshPlex performs one Plex EPG enrichment cycle: discover DVRs, match
@@ -110,12 +108,12 @@ func (d *DB) RefreshPlex(ctx context.Context, client PlexAPI) (PlexPollResult, e
 		return result, nil
 	}
 
-	tasks, totalLineups := buildDVRTasks(dvrs)
-	result.Lineups = totalLineups
-	if totalLineups == 0 {
+	if len(dvrs) == 0 {
 		logging.Warn("WARN: Plex returned 0 DVRs — Plex Live TV / DVR may not be configured on this server.")
 	}
-	logging.Info(fmt.Sprintf("[plex] poll started (%d lineups discovered)", totalLineups))
+	tasks := buildDVRTasks(dvrs)
+	result.Lineups = len(tasks)
+	logging.Info(fmt.Sprintf("[plex] poll started (%d lineups discovered)", len(tasks)))
 
 	localChannels, err := d.GetChannels(ctx)
 	if err != nil {
@@ -138,40 +136,38 @@ func (d *DB) RefreshPlex(ctx context.Context, client PlexAPI) (PlexPollResult, e
 	return result, nil
 }
 
-// buildDVRTasks flattens the slice of DVRs returned by Plex into the dvrTask
-// shape RefreshPlex iterates, and returns the total lineup count.
-func buildDVRTasks(dvrs []plex.DVR) ([]dvrTask, int) {
+// buildDVRTasks emits one task per DVR keyed on its EPG identifier. DVRs
+// without an EPG identifier are skipped (they can't be queried).
+func buildDVRTasks(dvrs []plex.DVR) []dvrTask {
 	tasks := make([]dvrTask, 0, len(dvrs))
-	total := 0
 	for _, dvr := range dvrs {
-		tasks = append(tasks, dvrTask{gridKey: dvr.GridKey, lineupIDs: dvr.LineupIDs})
-		total += len(dvr.LineupIDs)
+		if dvr.EPGIdentifier == "" {
+			continue
+		}
+		tasks = append(tasks, dvrTask{epgIdentifier: dvr.EPGIdentifier})
 	}
-	return tasks, total
+	return tasks
 }
 
-// matchAllChannels walks every lineup, calls GetLineupChannels, and matches
-// each Plex channel against localChannels. Returns the Plex→local ID map and
-// the pending channel UPDATEs. Stats and unmatched entries are accumulated on
-// result.
+// matchAllChannels walks every DVR's channels endpoint and matches each Plex
+// channel against localChannels. Returns the Plex→local ID map and the pending
+// channel UPDATEs. Stats and unmatched entries are accumulated on result.
 func (d *DB) matchAllChannels(ctx context.Context, client PlexAPI, tasks []dvrTask, localChannels []model.Channel, result *PlexPollResult) (map[string]string, []channelUpdate) {
 	channelMatchMap := map[string]string{}
 	var updates []channelUpdate
 	for _, task := range tasks {
-		for _, lineupID := range task.lineupIDs {
-			pcs, err := client.GetLineupChannels(ctx, lineupID)
-			if err != nil {
-				msg := fmt.Sprintf("GetLineupChannels(%s): %v", lineupID, err)
-				result.Errors = append(result.Errors, msg)
-				logPlexFetchError(msg, err)
-				continue
-			}
-			for _, pc := range pcs {
-				u, ok := matchSingleChannel(pc, lineupID, localChannels, result)
-				if ok {
-					updates = append(updates, u)
-					channelMatchMap[pc.ID] = u.channelID
-				}
+		pcs, err := client.GetLineupChannels(ctx, task.epgIdentifier)
+		if err != nil {
+			msg := fmt.Sprintf("GetLineupChannels(%s): %v", task.epgIdentifier, err)
+			result.Errors = append(result.Errors, msg)
+			logPlexFetchError(msg, err)
+			continue
+		}
+		for _, pc := range pcs {
+			u, ok := matchSingleChannel(pc, task.epgIdentifier, localChannels, result)
+			if ok {
+				updates = append(updates, u)
+				channelMatchMap[pc.ID] = u.channelID
 			}
 		}
 	}
@@ -184,7 +180,7 @@ func (d *DB) matchAllChannels(ctx context.Context, client PlexAPI, tasks []dvrTa
 // matchSingleChannel pairs one Plex channel with a local candidate and
 // updates result's stats. Returns the pending UPDATE row and ok=true on
 // success; ok=false means the channel was logged as unmatched.
-func matchSingleChannel(pc plex.LineupChannel, lineupID string, localChannels []model.Channel, result *PlexPollResult) (channelUpdate, bool) {
+func matchSingleChannel(pc plex.LineupChannel, epgIdentifier string, localChannels []model.Channel, result *PlexPollResult) (channelUpdate, bool) {
 	result.ChannelMatches.Total++
 	matched, src := plex.MatchChannel(pc, localChannels)
 	if matched == nil {
@@ -201,7 +197,7 @@ func matchSingleChannel(pc plex.LineupChannel, lineupID string, localChannels []
 	return channelUpdate{
 		channelID:     matched.ID,
 		plexChannelID: pc.ID,
-		plexLineupID:  lineupID,
+		plexLineupID:  epgIdentifier,
 	}, true
 }
 
@@ -217,19 +213,19 @@ func tickChannelMatchSource(src plex.MatchSource, stats *PlexMatchStats) {
 	}
 }
 
-// matchAllAirings walks unique grid keys, fetches each grid, and matches each
-// entry against airings on its already-matched channel.
+// matchAllAirings walks unique EPG identifiers, fetches each grid, and matches
+// each entry against airings on its already-matched channel.
 func (d *DB) matchAllAirings(ctx context.Context, client PlexAPI, tasks []dvrTask, channelMatchMap map[string]string, gridStart, gridEnd time.Time, result *PlexPollResult) []airingUpdate {
 	var updates []airingUpdate
-	gridSeen := map[string]bool{}
+	seen := map[string]bool{}
 	for _, task := range tasks {
-		if task.gridKey == "" || gridSeen[task.gridKey] {
+		if task.epgIdentifier == "" || seen[task.epgIdentifier] {
 			continue
 		}
-		gridSeen[task.gridKey] = true
-		entries, err := client.GetGrid(ctx, task.gridKey, gridStart, gridEnd)
+		seen[task.epgIdentifier] = true
+		entries, err := client.GetGrid(ctx, task.epgIdentifier, gridStart, gridEnd)
 		if err != nil {
-			msg := fmt.Sprintf("GetGrid(%s): %v", task.gridKey, err)
+			msg := fmt.Sprintf("GetGrid(%s): %v", task.epgIdentifier, err)
 			result.Errors = append(result.Errors, msg)
 			logPlexFetchError(msg, err)
 			continue
@@ -239,12 +235,21 @@ func (d *DB) matchAllAirings(ctx context.Context, client PlexAPI, tasks []dvrTas
 	return updates
 }
 
-// matchGridEntries groups entries by Plex channel and pairs each group with
-// the airings on the corresponding local channel.
+// matchGridEntries groups entries by Media[0].channelIdentifier and pairs each
+// group with the airings on the corresponding local channel.
 func (d *DB) matchGridEntries(ctx context.Context, entries []plex.GridEntry, channelMatchMap map[string]string, gridStart, gridEnd time.Time, result *PlexPollResult) []airingUpdate {
 	byChannel := map[string][]plex.GridEntry{}
 	for _, e := range entries {
-		byChannel[e.Channel] = append(byChannel[e.Channel], e)
+		media, ok := e.PrimaryMedia()
+		if !ok {
+			result.AiringMatches.Total++
+			result.UnmatchedAirings = append(result.UnmatchedAirings, PlexUnmatchedAiring{
+				Title:  e.Title,
+				Reason: "no_media",
+			})
+			continue
+		}
+		byChannel[media.ChannelIdentifier] = append(byChannel[media.ChannelIdentifier], e)
 	}
 	var updates []airingUpdate
 	for plexChanID, gridEntries := range byChannel {
@@ -272,10 +277,14 @@ func matchSingleAiring(entry plex.GridEntry, localChannelID string, candidates [
 	result.AiringMatches.Total++
 	matched, src, reason := plex.MatchAiring(entry, candidates)
 	if matched == nil {
+		var startTime time.Time
+		if media, ok := entry.PrimaryMedia(); ok {
+			startTime = time.Unix(media.BeginsAt, 0).UTC()
+		}
 		result.UnmatchedAirings = append(result.UnmatchedAirings, PlexUnmatchedAiring{
 			ChannelID: localChannelID,
 			Title:     entry.Title,
-			StartTime: time.Unix(entry.BeginsAt, 0).UTC(),
+			StartTime: startTime,
 			Reason:    unmatchedReasonString(reason),
 		})
 		return airingUpdate{}, false
@@ -291,10 +300,7 @@ func matchSingleAiring(entry plex.GridEntry, localChannelID string, candidates [
 
 // tickAiringMatchSource increments the per-source counter for an airing match.
 func tickAiringMatchSource(src plex.MatchSource, stats *PlexMatchStats) {
-	switch src {
-	case plex.MatchSourceProgID:
-		stats.ByProgID++
-	case plex.MatchSourceStartTime:
+	if src == plex.MatchSourceStartTime {
 		stats.ByStartTime++
 	}
 }
@@ -413,8 +419,6 @@ func matchSourceName(s plex.MatchSource) string {
 		return "lcn"
 	case plex.MatchSourceName:
 		return "display-name"
-	case plex.MatchSourceProgID:
-		return "progid"
 	case plex.MatchSourceStartTime:
 		return "start-time"
 	}
@@ -427,10 +431,6 @@ func unmatchedReasonString(r plex.UnmatchedReason) string {
 	switch r {
 	case plex.UnmatchedNoCandidate:
 		return "no_candidate_airing"
-	case plex.UnmatchedNoProgID:
-		return "no_progid_in_plex"
-	case plex.UnmatchedProgIDMismatch:
-		return "progid_mismatch"
 	case plex.UnmatchedNoStartTimeMatch:
 		return "no_start_time_match"
 	}
@@ -471,8 +471,8 @@ func logChannelSummary(stats PlexMatchStats, unmatched []PlexUnmatchedChannel) {
 
 // logAiringSummary emits the per-poll INFO summary block for airing matches.
 func logAiringSummary(stats PlexMatchStats, unmatched []PlexUnmatchedAiring) {
-	logging.Info(fmt.Sprintf("[plex] airings: matched %d/%d (%d by progid, %d by start-time)",
-		stats.Matched, stats.Total, stats.ByProgID, stats.ByStartTime))
+	logging.Info(fmt.Sprintf("[plex] airings: matched %d/%d (%d by start-time)",
+		stats.Matched, stats.Total, stats.ByStartTime))
 	if len(unmatched) == 0 {
 		return
 	}

--- a/internal/database/plex_refresh_test.go
+++ b/internal/database/plex_refresh_test.go
@@ -18,11 +18,13 @@ import (
 	"github.com/acbgbca/xmltvguide/internal/xmltv"
 )
 
+const testEPGID = "tv.plex.providers.epg.cloud:4"
+
 // newPlexFixtureServer returns an httptest server that serves Plex fixture
-// JSON for the four endpoints used by RefreshPlex. lineupBodies is keyed by
-// lineup ID; gridBodies is keyed by the full path prefix used by GetGrid
-// (e.g. "/grid/L1").
-func newPlexFixtureServer(t *testing.T, dvrsBody string, lineupBodies map[string]string, gridBodies map[string]string) *httptest.Server {
+// JSON for the three endpoints used by RefreshPlex. channelsByEPG is keyed by
+// epgIdentifier; gridByEPG is keyed by epgIdentifier and returns the body for
+// `/{epgIdentifier}/grid`.
+func newPlexFixtureServer(t *testing.T, dvrsBody string, channelsByEPG map[string]string, gridByEPG map[string]string) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -31,20 +33,18 @@ func newPlexFixtureServer(t *testing.T, dvrsBody string, lineupBodies map[string
 			_, _ = w.Write([]byte(`{"MediaContainer":{}}`))
 		case r.URL.Path == "/livetv/dvrs":
 			_, _ = w.Write([]byte(dvrsBody))
-		case strings.HasPrefix(r.URL.Path, "/epg/lineups/") && strings.HasSuffix(r.URL.Path, "/channels"):
-			parts := strings.Split(r.URL.Path, "/")
-			if len(parts) < 5 {
-				w.WriteHeader(http.StatusNotFound)
-				return
-			}
-			body, ok := lineupBodies[parts[3]]
+		case strings.HasSuffix(r.URL.Path, "/lineups/dvr/channels"):
+			epg := strings.TrimPrefix(r.URL.Path, "/")
+			epg = strings.TrimSuffix(epg, "/lineups/dvr/channels")
+			body, ok := channelsByEPG[epg]
 			if !ok {
 				body = `{"MediaContainer":{"Channel":[]}}`
 			}
 			_, _ = w.Write([]byte(body))
 		case strings.HasSuffix(r.URL.Path, "/grid"):
-			gridKey := strings.TrimSuffix(r.URL.Path, "/grid")
-			body, ok := gridBodies[gridKey]
+			epg := strings.TrimPrefix(r.URL.Path, "/")
+			epg = strings.TrimSuffix(epg, "/grid")
+			body, ok := gridByEPG[epg]
 			if !ok {
 				body = `{"MediaContainer":{"Metadata":[]}}`
 			}
@@ -111,36 +111,37 @@ func seedDBForPlex(t *testing.T, base time.Time) *database.DB {
 // cycle, and returns the poll result alongside the live DB. The fixtures are
 // designed to exercise every match outcome in one pass:
 //
-//   - abc.com.au   — channel matched by xmltvId; one airing matched by progid,
-//     one by start-time; one ProgID column verified intact
-//   - seven.com.au — channel matched by lcn; its sole airing remains unmatched
-//     because the corresponding grid entry's progid does not match
+//   - abc.com.au   — channel matched by id (Plex XMLTV-provider style); two
+//     airings matched by start-time (one exact, one +3 min within tolerance)
+//   - seven.com.au — channel matched by vcn=7; its sole airing remains
+//     unmatched because the Plex grid entry's BeginsAt is +10 min away (out of
+//     the ±5 min window)
 //   - nine.com.au  — no Plex counterpart, so all three plex_* columns stay NULL
 func runEndToEndPoll(t *testing.T) (*database.DB, time.Time, database.PlexPollResult) {
 	t.Helper()
 	base := time.Now().UTC().Truncate(time.Hour).Add(time.Hour)
 	db := seedDBForPlex(t, base)
 
-	dvrs := `{"MediaContainer":{"Dvr":[{"id":1,"lineupIDs":["L1"],"gridKey":"/grid/L1"}]}}`
-	lineups := map[string]string{
-		"L1": `{"MediaContainer":{"Channel":[
-			{"id":"plex.abc","xmltvId":"abc.com.au","lcn":"2","title":"ABC"},
-			{"id":"plex.seven","lcn":"7","title":"Seven Network"},
-			{"id":"plex.extra","lcn":"42","title":"Extra Channel"}
+	dvrs := fmt.Sprintf(`{"MediaContainer":{"Dvr":[{"key":"4","epgIdentifier":%q}]}}`, testEPGID)
+	channels := map[string]string{
+		testEPGID: `{"MediaContainer":{"Channel":[
+			{"id":"abc.com.au","vcn":"002","title":"ABC","callSign":"ABCAUS"},
+			{"id":"plex-seven-hex","vcn":"7","title":"Seven Network","callSign":"SEVEN"},
+			{"id":"plex-extra-hex","vcn":"42","title":"Extra Channel","callSign":"EXTRA"}
 		]}}`,
 	}
 	grids := map[string]string{
-		"/grid/L1": fmt.Sprintf(`{"MediaContainer":{"Metadata":[
-			{"ratingKey":"rk-1","channel":"plex.abc","beginsAt":%d,"endsAt":%d,"title":"News at Noon","ddProgID":"EP000123450001"},
-			{"ratingKey":"rk-2","channel":"plex.abc","beginsAt":%d,"endsAt":%d,"title":"Movie A"},
-			{"ratingKey":"rk-3","channel":"plex.seven","beginsAt":%d,"endsAt":%d,"title":"Unrelated Show","ddProgID":"EPNOMATCH"}
+		testEPGID: fmt.Sprintf(`{"MediaContainer":{"Metadata":[
+			{"ratingKey":"rk-1","title":"News at Noon","Media":[{"channelIdentifier":"abc.com.au","beginsAt":%d,"endsAt":%d}]},
+			{"ratingKey":"rk-2","title":"Movie A","Media":[{"channelIdentifier":"abc.com.au","beginsAt":%d,"endsAt":%d}]},
+			{"ratingKey":"rk-3","title":"Unrelated Show","Media":[{"channelIdentifier":"plex-seven-hex","beginsAt":%d,"endsAt":%d}]}
 		]}}`,
 			base.Unix(), base.Add(time.Hour).Unix(),
-			base.Add(time.Hour).Unix(), base.Add(2*time.Hour).Unix(),
-			base.Add(3*time.Hour).Unix(), base.Add(4*time.Hour).Unix(),
+			base.Add(time.Hour).Add(3*time.Minute).Unix(), base.Add(2*time.Hour).Unix(),
+			base.Add(10*time.Minute).Unix(), base.Add(70*time.Minute).Unix(),
 		),
 	}
-	srv := newPlexFixtureServer(t, dvrs, lineups, grids)
+	srv := newPlexFixtureServer(t, dvrs, channels, grids)
 	client := plex.NewClient(srv.URL, "tok", &http.Client{Timeout: 2 * time.Second})
 
 	result, err := db.RefreshPlex(context.Background(), client)
@@ -153,8 +154,8 @@ func runEndToEndPoll(t *testing.T) (*database.DB, time.Time, database.PlexPollRe
 func TestRefreshPlex_EndToEnd_ChannelStats(t *testing.T) {
 	_, _, result := runEndToEndPoll(t)
 	checkChannelStats(t, result)
-	if len(result.UnmatchedChan) != 1 || result.UnmatchedChan[0].PlexID != "plex.extra" {
-		t.Errorf("UnmatchedChan = %+v, want one entry with PlexID=plex.extra", result.UnmatchedChan)
+	if len(result.UnmatchedChan) != 1 || result.UnmatchedChan[0].PlexID != "plex-extra-hex" {
+		t.Errorf("UnmatchedChan = %+v, want one entry with PlexID=plex-extra-hex", result.UnmatchedChan)
 	}
 }
 
@@ -195,24 +196,24 @@ func checkAiringStats(t *testing.T, result database.PlexPollResult) {
 	t.Helper()
 	expectInt(t, "AiringMatches.Total", result.AiringMatches.Total, 3)
 	expectInt(t, "AiringMatches.Matched", result.AiringMatches.Matched, 2)
-	expectInt(t, "AiringMatches.ByProgID", result.AiringMatches.ByProgID, 1)
-	expectInt(t, "AiringMatches.ByStartTime", result.AiringMatches.ByStartTime, 1)
+	expectInt(t, "AiringMatches.ByStartTime", result.AiringMatches.ByStartTime, 2)
 }
 
 // checkChannelRowState validates plex_* columns and unchanged display names
-// for every seeded channel.
+// for every seeded channel. plex_lineup_id stores the EPG identifier.
 func checkChannelRowState(t *testing.T, chans []model.Channel) {
 	t.Helper()
 	for _, c := range chans {
 		switch c.ID {
 		case "abc.com.au":
-			expectPtrEq(t, "abc PlexChannelID", c.PlexChannelID, "plex.abc")
-			expectPtrEq(t, "abc PlexLineupID", c.PlexLineupID, "L1")
+			expectPtrEq(t, "abc PlexChannelID", c.PlexChannelID, "abc.com.au")
+			expectPtrEq(t, "abc PlexLineupID", c.PlexLineupID, testEPGID)
 			if c.DisplayName != "ABC" {
 				t.Errorf("abc DisplayName mutated: got %q, want ABC", c.DisplayName)
 			}
 		case "seven.com.au":
-			expectPtrEq(t, "seven PlexChannelID", c.PlexChannelID, "plex.seven")
+			expectPtrEq(t, "seven PlexChannelID", c.PlexChannelID, "plex-seven-hex")
+			expectPtrEq(t, "seven PlexLineupID", c.PlexLineupID, testEPGID)
 		case "nine.com.au":
 			if c.PlexChannelID != nil {
 				t.Errorf("nine.com.au PlexChannelID should be nil, got %v", *c.PlexChannelID)
@@ -261,22 +262,26 @@ func expectPtrEq(t *testing.T, label string, got *string, want string) {
 	}
 }
 
-func TestRefreshPlex_PartialFailure_OneLineupErrors(t *testing.T) {
+func TestRefreshPlex_PartialFailure_ChannelsEndpointErrors(t *testing.T) {
 	base := time.Now().UTC().Truncate(time.Hour).Add(time.Hour)
 	db := seedDBForPlex(t, base)
+
+	const failingEPG = "tv.plex.providers.epg.cloud:1"
+	const okEPG = "tv.plex.providers.epg.cloud:2"
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/livetv/dvrs":
-			_, _ = w.Write([]byte(`{"MediaContainer":{"Dvr":[
-				{"id":1,"lineupIDs":["L1","L2"],"gridKey":"/grid/main"}
-			]}}`))
-		case r.URL.Path == "/epg/lineups/L1/channels":
+			_, _ = fmt.Fprintf(w, `{"MediaContainer":{"Dvr":[
+				{"key":"1","epgIdentifier":%q},
+				{"key":"2","epgIdentifier":%q}
+			]}}`, failingEPG, okEPG)
+		case r.URL.Path == "/"+failingEPG+"/lineups/dvr/channels":
 			w.WriteHeader(http.StatusInternalServerError)
-		case r.URL.Path == "/epg/lineups/L2/channels":
+		case r.URL.Path == "/"+okEPG+"/lineups/dvr/channels":
 			_, _ = w.Write([]byte(`{"MediaContainer":{"Channel":[
-				{"id":"plex.abc","xmltvId":"abc.com.au","title":"ABC"}
+				{"id":"abc.com.au","title":"ABC","vcn":"2"}
 			]}}`))
 		case strings.HasSuffix(r.URL.Path, "/grid"):
 			_, _ = w.Write([]byte(`{"MediaContainer":{"Metadata":[]}}`))
@@ -296,22 +301,22 @@ func TestRefreshPlex_PartialFailure_OneLineupErrors(t *testing.T) {
 		t.Errorf("expected at least one per-step error in result, got %+v", result.Errors)
 	}
 	if result.ChannelMatches.Matched != 1 {
-		t.Errorf("ChannelMatches.Matched = %d, want 1 (L2 should still succeed)", result.ChannelMatches.Matched)
+		t.Errorf("ChannelMatches.Matched = %d, want 1 (second EPG should still succeed)", result.ChannelMatches.Matched)
 	}
 
-	// abc should still be updated despite L1 failing.
+	// abc should still be updated despite the first EPG failing.
 	chans, err := db.GetChannels(context.Background())
 	if err != nil {
 		t.Fatalf("GetChannels: %v", err)
 	}
 	updated := false
 	for _, ch := range chans {
-		if ch.ID == "abc.com.au" && ch.PlexChannelID != nil && *ch.PlexChannelID == "plex.abc" {
+		if ch.ID == "abc.com.au" && ch.PlexChannelID != nil && *ch.PlexChannelID == "abc.com.au" {
 			updated = true
 		}
 	}
 	if !updated {
-		t.Errorf("abc should have plex_channel_id set despite L1 failure")
+		t.Errorf("abc should have plex_channel_id set despite first EPG failure")
 	}
 }
 
@@ -323,16 +328,16 @@ func TestRefreshPlex_DoesNotMutateXMLTVColumns(t *testing.T) {
 	preChans, _ := db.GetChannels(context.Background())
 	preAirs, _ := db.GetAirings(context.Background(), base)
 
-	dvrs := `{"MediaContainer":{"Dvr":[{"id":1,"lineupIDs":["L1"],"gridKey":"/grid/L1"}]}}`
-	lineups := map[string]string{
-		"L1": `{"MediaContainer":{"Channel":[{"id":"plex.abc","xmltvId":"abc.com.au","title":"Different Name"}]}}`,
+	dvrs := fmt.Sprintf(`{"MediaContainer":{"Dvr":[{"key":"4","epgIdentifier":%q}]}}`, testEPGID)
+	channels := map[string]string{
+		testEPGID: `{"MediaContainer":{"Channel":[{"id":"abc.com.au","title":"Different Name","vcn":"2"}]}}`,
 	}
 	grids := map[string]string{
-		"/grid/L1": fmt.Sprintf(`{"MediaContainer":{"Metadata":[
-			{"ratingKey":"rk-1","channel":"plex.abc","beginsAt":%d,"endsAt":%d,"title":"Plex Says Different","ddProgID":"EP000123450001"}
+		testEPGID: fmt.Sprintf(`{"MediaContainer":{"Metadata":[
+			{"ratingKey":"rk-1","title":"Plex Says Different","Media":[{"channelIdentifier":"abc.com.au","beginsAt":%d,"endsAt":%d}]}
 		]}}`, base.Unix(), base.Add(time.Hour).Unix()),
 	}
-	srv := newPlexFixtureServer(t, dvrs, lineups, grids)
+	srv := newPlexFixtureServer(t, dvrs, channels, grids)
 	client := plex.NewClient(srv.URL, "tok", &http.Client{Timeout: 2 * time.Second})
 
 	if _, err := db.RefreshPlex(context.Background(), client); err != nil {

--- a/internal/plex/client.go
+++ b/internal/plex/client.go
@@ -60,9 +60,11 @@ func (c *Client) GetDVRs(ctx context.Context) ([]DVR, error) {
 	return out.MediaContainer.Dvr, nil
 }
 
-// GetLineupChannels issues GET /epg/lineups/{lineupID}/channels.
-func (c *Client) GetLineupChannels(ctx context.Context, lineupID string) ([]LineupChannel, error) {
-	path := "/epg/lineups/" + lineupID + "/channels"
+// GetLineupChannels issues GET /{epgIdentifier}/lineups/dvr/channels — the
+// path Plex Cloud EPG actually exposes (the older /epg/lineups/{id}/channels
+// returns 404 against real servers).
+func (c *Client) GetLineupChannels(ctx context.Context, epgIdentifier string) ([]LineupChannel, error) {
+	path := "/" + strings.TrimPrefix(epgIdentifier, "/") + "/lineups/dvr/channels"
 	body, err := c.doRequest(ctx, path, nil)
 	if err != nil {
 		return nil, err
@@ -74,18 +76,16 @@ func (c *Client) GetLineupChannels(ctx context.Context, lineupID string) ([]Line
 	return out.MediaContainer.Channel, nil
 }
 
-// GetGrid issues GET /{gridKey}/grid?type=4&beginsAt=<unix>&endsAt=<unix>.
-func (c *Client) GetGrid(ctx context.Context, gridKey string, beginsAt, endsAt time.Time) ([]GridEntry, error) {
-	// gridKey is a path prefix returned by /livetv/dvrs; preserve its leading
-	// slash but tolerate inputs without one.
-	if !strings.HasPrefix(gridKey, "/") {
-		gridKey = "/" + gridKey
-	}
-	path := gridKey + "/grid"
+// GetGrid issues GET /{epgIdentifier}/grid?type=4&beginsAt>=<unix>&endsAt<=<unix>.
+// Plex requires the comparison operators on beginsAt/endsAt — without them
+// the server silently returns {"MediaContainer":{"size":0}}. The operator
+// characters `>` and `<` are url-encoded as %3E and %3C in the wire format.
+func (c *Client) GetGrid(ctx context.Context, epgIdentifier string, beginsAt, endsAt time.Time) ([]GridEntry, error) {
+	path := "/" + strings.TrimPrefix(epgIdentifier, "/") + "/grid"
 	query := map[string]string{
-		"type":     "4",
-		"beginsAt": strconv.FormatInt(beginsAt.Unix(), 10),
-		"endsAt":   strconv.FormatInt(endsAt.Unix(), 10),
+		"type":      "4",
+		"beginsAt>": strconv.FormatInt(beginsAt.Unix(), 10),
+		"endsAt<":   strconv.FormatInt(endsAt.Unix(), 10),
 	}
 	body, err := c.doRequest(ctx, path, query)
 	if err != nil {

--- a/internal/plex/client_test.go
+++ b/internal/plex/client_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +25,15 @@ func startServer(t *testing.T, handler http.Handler) *httptest.Server {
 func newClient(t *testing.T, baseURL, token string) *plex.Client {
 	t.Helper()
 	return plex.NewClient(baseURL, token, &http.Client{Timeout: 2 * time.Second})
+}
+
+func readFixture(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", name, err)
+	}
+	return string(b)
 }
 
 // --- Ping ---
@@ -80,14 +91,7 @@ func TestPing_ServerErrorWrapsURL(t *testing.T) {
 // --- GetDVRs ---
 
 func TestGetDVRs_HappyPath(t *testing.T) {
-	body := `{
-		"MediaContainer": {
-			"Dvr": [
-				{"id": 1, "lineupIDs": ["xmltv:1"], "gridKey": "/tv.plex.providers.epg.xmltv:1"},
-				{"id": 2, "lineupIDs": ["cloud:7", "cloud:8"], "gridKey": "/tv.plex.providers.epg.cloud:2"}
-			]
-		}
-	}`
+	body := readFixture(t, "dvrs.json")
 	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/livetv/dvrs" {
 			t.Errorf("expected /livetv/dvrs, got %s", r.URL.Path)
@@ -104,20 +108,14 @@ func TestGetDVRs_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetDVRs: %v", err)
 	}
-	if len(dvrs) != 2 {
-		t.Fatalf("expected 2 DVRs, got %d", len(dvrs))
+	if len(dvrs) != 1 {
+		t.Fatalf("expected 1 DVR, got %d", len(dvrs))
 	}
-	if dvrs[0].ID != 1 {
-		t.Errorf("dvrs[0].ID = %d, want 1", dvrs[0].ID)
+	if dvrs[0].Key != "4" {
+		t.Errorf("dvrs[0].Key = %q, want %q", dvrs[0].Key, "4")
 	}
-	if dvrs[0].GridKey != "/tv.plex.providers.epg.xmltv:1" {
-		t.Errorf("dvrs[0].GridKey = %q", dvrs[0].GridKey)
-	}
-	if len(dvrs[0].LineupIDs) != 1 || dvrs[0].LineupIDs[0] != "xmltv:1" {
-		t.Errorf("dvrs[0].LineupIDs = %v", dvrs[0].LineupIDs)
-	}
-	if len(dvrs[1].LineupIDs) != 2 {
-		t.Errorf("dvrs[1].LineupIDs = %v, want 2 entries", dvrs[1].LineupIDs)
+	if dvrs[0].EPGIdentifier != "tv.plex.providers.epg.cloud:4" {
+		t.Errorf("dvrs[0].EPGIdentifier = %q", dvrs[0].EPGIdentifier)
 	}
 }
 
@@ -163,44 +161,38 @@ func TestGetDVRs_MalformedJSON(t *testing.T) {
 // --- GetLineupChannels ---
 
 func TestGetLineupChannels_HappyPath(t *testing.T) {
-	body := `{
-		"MediaContainer": {
-			"Channel": [
-				{"id": "ch-1", "xmltvId": "abc.com.au", "lcn": "2", "title": "ABC"},
-				{"id": "ch-2", "title": "SBS Viceland"}
-			]
-		}
-	}`
+	body := readFixture(t, "channels.json")
+	const epgID = "tv.plex.providers.epg.cloud:4"
+	wantPath := "/" + epgID + "/lineups/dvr/channels"
+
 	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/epg/lineups/xmltv:1/channels" {
-			t.Errorf("expected /epg/lineups/xmltv:1/channels, got %s", r.URL.Path)
+		if r.URL.Path != wantPath {
+			t.Errorf("expected path %q, got %q", wantPath, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	}))
 
 	c := newClient(t, srv.URL, "tok")
-	chans, err := c.GetLineupChannels(context.Background(), "xmltv:1")
+	chans, err := c.GetLineupChannels(context.Background(), epgID)
 	if err != nil {
 		t.Fatalf("GetLineupChannels: %v", err)
 	}
-	if len(chans) != 2 {
-		t.Fatalf("expected 2 channels, got %d", len(chans))
+	if len(chans) != 3 {
+		t.Fatalf("expected 3 channels, got %d", len(chans))
 	}
-	if chans[0].ID != "ch-1" {
-		t.Errorf("chans[0].ID = %q", chans[0].ID)
+	first := chans[0]
+	if first.ID != "5fc76c607dc1e8002d48a65d-5fc705f4dd53a6002d8f9173" {
+		t.Errorf("chans[0].ID = %q", first.ID)
 	}
-	if chans[0].XMLTVID != "abc.com.au" {
-		t.Errorf("chans[0].XMLTVID = %q", chans[0].XMLTVID)
+	if first.VCN != "001" {
+		t.Errorf("chans[0].VCN = %q, want %q", first.VCN, "001")
 	}
-	if chans[0].LCN != "2" {
-		t.Errorf("chans[0].LCN = %q", chans[0].LCN)
+	if first.DisplayName != "Network Ten (Australia)" {
+		t.Errorf("chans[0].DisplayName = %q", first.DisplayName)
 	}
-	if chans[0].DisplayName != "ABC" {
-		t.Errorf("chans[0].DisplayName = %q", chans[0].DisplayName)
-	}
-	if chans[1].XMLTVID != "" || chans[1].LCN != "" {
-		t.Errorf("optional fields should be empty: %+v", chans[1])
+	if first.CallSign != "THMEANZ" {
+		t.Errorf("chans[0].CallSign = %q", first.CallSign)
 	}
 }
 
@@ -209,7 +201,7 @@ func TestGetLineupChannels_Unauthorized(t *testing.T) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
 	c := newClient(t, srv.URL, "tok")
-	_, err := c.GetLineupChannels(context.Background(), "xmltv:1")
+	_, err := c.GetLineupChannels(context.Background(), "tv.plex.providers.epg.cloud:4")
 	if !errors.Is(err, plex.ErrUnauthorized) {
 		t.Errorf("expected ErrUnauthorized, got %v", err)
 	}
@@ -218,63 +210,66 @@ func TestGetLineupChannels_Unauthorized(t *testing.T) {
 // --- GetGrid ---
 
 func TestGetGrid_HappyPath(t *testing.T) {
-	begins := time.Date(2025, 6, 10, 12, 0, 0, 0, time.UTC)
-	ends := begins.Add(2 * time.Hour)
+	body := readFixture(t, "grid.json")
+	const epgID = "tv.plex.providers.epg.cloud:4"
+	wantPathPrefix := "/" + epgID + "/grid"
+	begins := time.Date(2025, 6, 10, 14, 0, 0, 0, time.UTC) // 1749564000
+	ends := begins.Add(24 * time.Hour)                      // 1749650400
 
-	body := `{
-		"MediaContainer": {
-			"Metadata": [
-				{"ratingKey": "rk-1", "channel": "ch-1", "beginsAt": 1749556800, "endsAt": 1749560400, "title": "News at Noon", "ddProgID": "EP000123450001"},
-				{"ratingKey": "rk-2", "channel": "ch-1", "beginsAt": 1749560400, "endsAt": 1749564000, "title": "Sports"}
-			]
-		}
-	}`
 	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasPrefix(r.URL.Path, "/tv.plex.providers.epg.xmltv:1/grid") {
-			t.Errorf("unexpected path: %s", r.URL.Path)
+		if r.URL.Path != wantPathPrefix {
+			t.Errorf("unexpected path: %s, want %s", r.URL.Path, wantPathPrefix)
 		}
-		q := r.URL.Query()
-		if q.Get("type") != "4" {
-			t.Errorf("type query = %q, want 4", q.Get("type"))
+		raw := r.URL.RawQuery
+		if !strings.Contains(raw, "type=4") {
+			t.Errorf("raw query missing type=4: %q", raw)
 		}
-		if q.Get("beginsAt") == "" {
-			t.Errorf("beginsAt missing")
+		// The Plex grid query requires comparison operators on beginsAt/endsAt
+		// (without them Plex silently returns size:0). The operator characters
+		// `>` and `<` must be percent-encoded as %3E and %3C in the raw query.
+		if !strings.Contains(raw, "beginsAt%3E=") {
+			t.Errorf("raw query should encode beginsAt with > operator; got %q", raw)
 		}
-		if q.Get("endsAt") == "" {
-			t.Errorf("endsAt missing")
+		if !strings.Contains(raw, "endsAt%3C=") {
+			t.Errorf("raw query should encode endsAt with < operator; got %q", raw)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	}))
 
 	c := newClient(t, srv.URL, "tok")
-	entries, err := c.GetGrid(context.Background(), "/tv.plex.providers.epg.xmltv:1", begins, ends)
+	entries, err := c.GetGrid(context.Background(), epgID, begins, ends)
 	if err != nil {
 		t.Fatalf("GetGrid: %v", err)
 	}
 	if len(entries) != 2 {
 		t.Fatalf("want 2 entries, got %d", len(entries))
 	}
-	if entries[0].RatingKey != "rk-1" {
+	if entries[0].RatingKey != "plex%3A%2F%2Fepisode%2F6a01ce4627f52460ad3410f4" {
 		t.Errorf("entries[0].RatingKey = %q", entries[0].RatingKey)
 	}
-	if entries[0].Channel != "ch-1" {
-		t.Errorf("entries[0].Channel = %q", entries[0].Channel)
-	}
-	if entries[0].BeginsAt != 1749556800 {
-		t.Errorf("entries[0].BeginsAt = %d", entries[0].BeginsAt)
-	}
-	if entries[0].EndsAt != 1749560400 {
-		t.Errorf("entries[0].EndsAt = %d", entries[0].EndsAt)
-	}
-	if entries[0].Title != "News at Noon" {
+	if entries[0].Title != "MasterChef Australia" {
 		t.Errorf("entries[0].Title = %q", entries[0].Title)
 	}
-	if entries[0].DdProgID != "EP000123450001" {
-		t.Errorf("entries[0].DdProgID = %q", entries[0].DdProgID)
+	media, ok := entries[0].PrimaryMedia()
+	if !ok {
+		t.Fatalf("entries[0].PrimaryMedia() returned ok=false")
 	}
-	if entries[1].DdProgID != "" {
-		t.Errorf("entries[1].DdProgID should be empty when absent; got %q", entries[1].DdProgID)
+	if media.ChannelIdentifier != "5fc76c607dc1e8002d48a65d-5fc705f4dd53a6002d8f9173" {
+		t.Errorf("media.ChannelIdentifier = %q", media.ChannelIdentifier)
+	}
+	if media.BeginsAt != 1749564000 {
+		t.Errorf("media.BeginsAt = %d, want 1749564000", media.BeginsAt)
+	}
+	if media.EndsAt != 1749567600 {
+		t.Errorf("media.EndsAt = %d, want 1749567600", media.EndsAt)
+	}
+}
+
+func TestGetGrid_PrimaryMediaEmpty(t *testing.T) {
+	entry := plex.GridEntry{RatingKey: "rk", Title: "no media"}
+	if _, ok := entry.PrimaryMedia(); ok {
+		t.Errorf("expected ok=false for entry with no Media")
 	}
 }
 
@@ -282,25 +277,23 @@ func TestGetGrid_PassesUnixTimes(t *testing.T) {
 	begins := time.Date(2025, 6, 10, 0, 0, 0, 0, time.UTC)
 	ends := time.Date(2025, 6, 11, 0, 0, 0, 0, time.UTC)
 
-	var capturedBegins, capturedEnds string
+	var captured string
 	srv := startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedBegins = r.URL.Query().Get("beginsAt")
-		capturedEnds = r.URL.Query().Get("endsAt")
+		captured = r.URL.RawQuery
 		_, _ = w.Write([]byte(`{"MediaContainer":{"Metadata":[]}}`))
 	}))
 
 	c := newClient(t, srv.URL, "tok")
-	if _, err := c.GetGrid(context.Background(), "/grid-key", begins, ends); err != nil {
+	if _, err := c.GetGrid(context.Background(), "tv.plex.providers.epg.cloud:4", begins, ends); err != nil {
 		t.Fatalf("GetGrid: %v", err)
 	}
 
-	wantBegins := "1749513600" // unix seconds for 2025-06-10 UTC
-	wantEnds := "1749600000"
-	if capturedBegins != wantBegins {
-		t.Errorf("beginsAt = %q, want %q", capturedBegins, wantBegins)
+	// 1749513600 = 2025-06-10 00:00:00 UTC; 1749600000 = 2025-06-11 00:00:00 UTC
+	if !strings.Contains(captured, "beginsAt%3E=1749513600") {
+		t.Errorf("raw query missing beginsAt%%3E=1749513600: %q", captured)
 	}
-	if capturedEnds != wantEnds {
-		t.Errorf("endsAt = %q, want %q", capturedEnds, wantEnds)
+	if !strings.Contains(captured, "endsAt%3C=1749600000") {
+		t.Errorf("raw query missing endsAt%%3C=1749600000: %q", captured)
 	}
 }
 
@@ -311,11 +304,11 @@ func TestGetGrid_NetworkTimeoutWraps(t *testing.T) {
 	}))
 	c := plex.NewClient(srv.URL, "tok", &http.Client{Timeout: 50 * time.Millisecond})
 
-	_, err := c.GetGrid(context.Background(), "/grid-key", time.Now(), time.Now().Add(time.Hour))
+	_, err := c.GetGrid(context.Background(), "tv.plex.providers.epg.cloud:4", time.Now(), time.Now().Add(time.Hour))
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
-	if !strings.Contains(err.Error(), "/grid-key") {
+	if !strings.Contains(err.Error(), "/tv.plex.providers.epg.cloud:4") {
 		t.Errorf("error should include URL; got: %v", err)
 	}
 }
@@ -346,8 +339,8 @@ func TestClient_AlwaysSendsToken(t *testing.T) {
 	ctx := context.Background()
 	_ = c.Ping(ctx)
 	_, _ = c.GetDVRs(ctx)
-	_, _ = c.GetLineupChannels(ctx, "lineup")
-	_, _ = c.GetGrid(ctx, "/grid-key", time.Now(), time.Now().Add(time.Hour))
+	_, _ = c.GetLineupChannels(ctx, "tv.plex.providers.epg.cloud:4")
+	_, _ = c.GetGrid(ctx, "tv.plex.providers.epg.cloud:4", time.Now(), time.Now().Add(time.Hour))
 
 	if calls != 4 {
 		t.Errorf("expected 4 calls, got %d", calls)

--- a/internal/plex/client_test.go
+++ b/internal/plex/client_test.go
@@ -29,6 +29,7 @@ func newClient(t *testing.T, baseURL, token string) *plex.Client {
 
 func readFixture(t *testing.T, name string) string {
 	t.Helper()
+	// #nosec G304 -- test-only fixture loader; name is always a hardcoded constant from this test file.
 	b, err := os.ReadFile(filepath.Join("testdata", name))
 	if err != nil {
 		t.Fatalf("reading fixture %s: %v", name, err)

--- a/internal/plex/match.go
+++ b/internal/plex/match.go
@@ -17,7 +17,6 @@ const (
 	MatchSourceID
 	MatchSourceLCN
 	MatchSourceName
-	MatchSourceProgID
 	MatchSourceStartTime
 )
 
@@ -28,10 +27,15 @@ type UnmatchedReason int
 const (
 	UnmatchedNone UnmatchedReason = iota
 	UnmatchedNoCandidate
-	UnmatchedNoProgID
-	UnmatchedProgIDMismatch
 	UnmatchedNoStartTimeMatch
 )
+
+// AiringMatchToleranceSeconds is the ±tolerance applied when matching a Plex
+// grid entry to a local airing by start time. Live channels routinely run a
+// few minutes late and shift their successor accordingly; the tolerance is
+// large enough to absorb that drift but tight enough that successive shows
+// don't overlap.
+const AiringMatchToleranceSeconds = 300
 
 // tierResult describes the outcome of a single matcher tier.
 type tierResult int
@@ -65,7 +69,10 @@ func findUnique(candidates []model.Channel, pred func(*model.Channel) bool) (*mo
 // MatchChannel pairs a Plex lineup channel with one local channel. The cascade
 // is ID → LCN → Name. At each tier, an ambiguous result (two or more
 // candidates match by the same property) returns MatchSourceNone without
-// falling through — see issue #282 for the rationale.
+// falling through — see issue #282 for the rationale. The ID tier is a no-op
+// on Plex Cloud EPG (its `id` is a long hex string that won't collide with any
+// local xmltv id) but remains useful for Plex XMLTV-provider users where the
+// channel `id` is the xmltv id.
 func MatchChannel(plex LineupChannel, candidates []model.Channel) (*model.Channel, MatchSource) {
 	tiers := []struct {
 		source MatchSource
@@ -91,22 +98,25 @@ func MatchChannel(plex LineupChannel, candidates []model.Channel) (*model.Channe
 	return nil, MatchSourceNone
 }
 
-// idPredicate returns a match function for the ID tier, or nil if Plex has no
-// xmltv id to compare against.
+// idPredicate returns a match function for the ID tier. Compares the Plex
+// channel ID against the local channel ID; for Plex XMLTV-provider users this
+// is the xmltv id, for Plex Cloud EPG users it is an opaque hex string that
+// won't match (no-op).
 func idPredicate(plex LineupChannel) func(*model.Channel) bool {
-	if plex.XMLTVID == "" {
+	if plex.ID == "" {
 		return nil
 	}
-	return func(c *model.Channel) bool { return c.ID == plex.XMLTVID }
+	return func(c *model.Channel) bool { return c.ID == plex.ID }
 }
 
 // lcnPredicate returns a match function for the LCN tier, or nil if Plex has
-// no LCN or its LCN is not a valid integer.
+// no VCN or its VCN is not a valid integer. strconv.Atoi handles the
+// zero-padded form ("001" → 1, "010" → 10).
 func lcnPredicate(plex LineupChannel) func(*model.Channel) bool {
-	if plex.LCN == "" {
+	if plex.VCN == "" {
 		return nil
 	}
-	plexLCN, err := strconv.Atoi(plex.LCN)
+	plexLCN, err := strconv.Atoi(plex.VCN)
 	if err != nil {
 		return nil
 	}
@@ -128,26 +138,33 @@ func namePredicate(plex LineupChannel) func(*model.Channel) bool {
 }
 
 // MatchAiring pairs a Plex grid entry with one airing on the already-matched
-// channel. Callers must narrow candidates to the matched channel before
-// invoking. See issue #282 for the strategy rules.
+// channel using a ±AiringMatchToleranceSeconds window around the Plex
+// BeginsAt; when multiple candidates fall inside the window the one with the
+// smallest absolute delta wins. Plex Cloud EPG never emits dd_progid, so the
+// older program-id tier is gone — see issue #287.
 func MatchAiring(plex GridEntry, candidates []model.Airing) (*model.Airing, MatchSource, UnmatchedReason) {
 	if len(candidates) == 0 {
 		return nil, MatchSourceNone, UnmatchedNoCandidate
 	}
-
-	if plex.DdProgID != "" {
-		for i := range candidates {
-			if candidates[i].ProgID == plex.DdProgID {
-				return &candidates[i], MatchSourceProgID, UnmatchedNone
-			}
-		}
-		return nil, MatchSourceNone, UnmatchedProgIDMismatch
+	media, ok := plex.PrimaryMedia()
+	if !ok {
+		return nil, MatchSourceNone, UnmatchedNoStartTimeMatch
 	}
 
+	var best *model.Airing
+	bestDelta := int64(AiringMatchToleranceSeconds + 1)
 	for i := range candidates {
-		if candidates[i].Start.Unix() == plex.BeginsAt {
-			return &candidates[i], MatchSourceStartTime, UnmatchedNone
+		delta := candidates[i].Start.Unix() - media.BeginsAt
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta <= AiringMatchToleranceSeconds && delta < bestDelta {
+			best = &candidates[i]
+			bestDelta = delta
 		}
 	}
-	return nil, MatchSourceNone, UnmatchedNoStartTimeMatch
+	if best == nil {
+		return nil, MatchSourceNone, UnmatchedNoStartTimeMatch
+	}
+	return best, MatchSourceStartTime, UnmatchedNone
 }

--- a/internal/plex/match_test.go
+++ b/internal/plex/match_test.go
@@ -11,8 +11,10 @@ import (
 func intPtr(n int) *int { return &n }
 
 func TestMatchChannel(t *testing.T) {
+	lcn1 := intPtr(1)
 	lcn7 := intPtr(7)
 	lcn9 := intPtr(9)
+	lcn10 := intPtr(10)
 
 	cases := []struct {
 		name       string
@@ -22,8 +24,12 @@ func TestMatchChannel(t *testing.T) {
 		wantSource plex.MatchSource
 	}{
 		{
-			name: "hit by id",
-			plex: plex.LineupChannel{ID: "1", XMLTVID: "abc.xmltv", LCN: "7", DisplayName: "ABC"},
+			// Plex XMLTV-provider implementations set the channel id to the XMLTV id, so
+			// the id tier remains useful for those users; for Plex Cloud EPG the id is a
+			// long hex string that won't collide with any local xmltv id and the tier
+			// silently no-ops.
+			name: "hit by id (xmltv provider style)",
+			plex: plex.LineupChannel{ID: "abc.xmltv", VCN: "7", DisplayName: "ABC"},
 			candidates: []model.Channel{
 				{ID: "other.xmltv", DisplayName: "Other", LCN: lcn9},
 				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
@@ -32,8 +38,8 @@ func TestMatchChannel(t *testing.T) {
 			wantSource: plex.MatchSourceID,
 		},
 		{
-			name: "hit by lcn",
-			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "7", DisplayName: "Totally Different"},
+			name: "hit by vcn 7 matches lcn 7",
+			plex: plex.LineupChannel{ID: "plex-hex-id", VCN: "7", DisplayName: "Totally Different"},
 			candidates: []model.Channel{
 				{ID: "other.xmltv", DisplayName: "Other", LCN: lcn9},
 				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
@@ -42,8 +48,46 @@ func TestMatchChannel(t *testing.T) {
 			wantSource: plex.MatchSourceLCN,
 		},
 		{
+			name: "hit by vcn 001 matches lcn 1 (leading zero strip)",
+			plex: plex.LineupChannel{ID: "plex-hex-id", VCN: "001", DisplayName: "Totally Different"},
+			candidates: []model.Channel{
+				{ID: "other.xmltv", DisplayName: "Other", LCN: lcn9},
+				{ID: "ten.xmltv", DisplayName: "Network Ten", LCN: lcn1},
+			},
+			wantID:     "ten.xmltv",
+			wantSource: plex.MatchSourceLCN,
+		},
+		{
+			name: "hit by vcn 010 matches lcn 10",
+			plex: plex.LineupChannel{ID: "plex-hex-id", VCN: "010", DisplayName: "Different"},
+			candidates: []model.Channel{
+				{ID: "ten.xmltv", DisplayName: "Network Ten", LCN: lcn1},
+				{ID: "bold.xmltv", DisplayName: "10 Bold", LCN: lcn10},
+			},
+			wantID:     "bold.xmltv",
+			wantSource: plex.MatchSourceLCN,
+		},
+		{
+			name: "non-numeric vcn falls through to name tier",
+			plex: plex.LineupChannel{ID: "plex-hex-id", VCN: "abc", DisplayName: "ABC"},
+			candidates: []model.Channel{
+				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
+			},
+			wantID:     "abc.xmltv",
+			wantSource: plex.MatchSourceName,
+		},
+		{
+			name: "empty vcn falls through to name tier",
+			plex: plex.LineupChannel{ID: "plex-hex-id", VCN: "", DisplayName: "ABC"},
+			candidates: []model.Channel{
+				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
+			},
+			wantID:     "abc.xmltv",
+			wantSource: plex.MatchSourceName,
+		},
+		{
 			name: "hit by name case-insensitive",
-			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "", DisplayName: "abc"},
+			plex: plex.LineupChannel{ID: "plex-hex-id", VCN: "", DisplayName: "abc"},
 			candidates: []model.Channel{
 				{ID: "other.xmltv", DisplayName: "Other", LCN: lcn9},
 				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
@@ -53,14 +97,14 @@ func TestMatchChannel(t *testing.T) {
 		},
 		{
 			name:       "miss with no candidates",
-			plex:       plex.LineupChannel{ID: "1", XMLTVID: "abc.xmltv", LCN: "7", DisplayName: "ABC"},
+			plex:       plex.LineupChannel{ID: "abc.xmltv", VCN: "7", DisplayName: "ABC"},
 			candidates: nil,
 			wantID:     "",
 			wantSource: plex.MatchSourceNone,
 		},
 		{
 			name: "ambiguous name returns none",
-			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "", DisplayName: "ABC"},
+			plex: plex.LineupChannel{ID: "plex-hex-id", VCN: "", DisplayName: "ABC"},
 			candidates: []model.Channel{
 				{ID: "abc1.xmltv", DisplayName: "ABC", LCN: nil},
 				{ID: "abc2.xmltv", DisplayName: "abc", LCN: nil},
@@ -69,47 +113,20 @@ func TestMatchChannel(t *testing.T) {
 			wantSource: plex.MatchSourceNone,
 		},
 		{
-			name: "both have lcn but different falls through to name",
-			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "7", DisplayName: "ABC"},
-			candidates: []model.Channel{
-				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn9},
-			},
-			wantID:     "abc.xmltv",
-			wantSource: plex.MatchSourceName,
-		},
-		{
-			name: "no match at any tier returns none",
-			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "42", DisplayName: "Nothing"},
-			candidates: []model.Channel{
-				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
-			},
-			wantID:     "",
-			wantSource: plex.MatchSourceNone,
-		},
-		{
-			name: "plex has no lcn skips lcn matcher",
-			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "", DisplayName: "ABC"},
-			candidates: []model.Channel{
-				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
-			},
-			wantID:     "abc.xmltv",
-			wantSource: plex.MatchSourceName,
-		},
-		{
-			name: "candidate without lcn is skipped by lcn matcher",
-			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "7", DisplayName: "ABC"},
-			candidates: []model.Channel{
-				{ID: "abc.xmltv", DisplayName: "Different", LCN: nil},
-			},
-			wantID:     "",
-			wantSource: plex.MatchSourceNone,
-		},
-		{
 			name: "ambiguous lcn returns none without falling through",
-			plex: plex.LineupChannel{ID: "1", XMLTVID: "no-such-id", LCN: "7", DisplayName: "ABC"},
+			plex: plex.LineupChannel{ID: "plex-hex-id", VCN: "7", DisplayName: "ABC"},
 			candidates: []model.Channel{
 				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
 				{ID: "other.xmltv", DisplayName: "Other", LCN: lcn7},
+			},
+			wantID:     "",
+			wantSource: plex.MatchSourceNone,
+		},
+		{
+			name: "no match at any tier returns none",
+			plex: plex.LineupChannel{ID: "plex-hex-id", VCN: "42", DisplayName: "Nothing"},
+			candidates: []model.Channel{
+				{ID: "abc.xmltv", DisplayName: "ABC", LCN: lcn7},
 			},
 			wantID:     "",
 			wantSource: plex.MatchSourceNone,
@@ -133,80 +150,109 @@ func TestMatchChannel(t *testing.T) {
 	}
 }
 
+// makeEntry is a helper for MatchAiring tests that wraps a single Media block
+// with the supplied beginsAt timestamp around the typical fields.
+func makeEntry(ratingKey string, beginsAt int64) plex.GridEntry {
+	return plex.GridEntry{
+		RatingKey: ratingKey,
+		Media: []plex.GridMedia{
+			{
+				ChannelIdentifier: "plex-channel",
+				BeginsAt:          beginsAt,
+				EndsAt:            beginsAt + 3600,
+			},
+		},
+	}
+}
+
 func TestMatchAiring(t *testing.T) {
 	start := time.Date(2025, 6, 10, 14, 0, 0, 0, time.UTC)
-	other := time.Date(2025, 6, 10, 15, 0, 0, 0, time.UTC)
+	startUnix := start.Unix()
 
 	cases := []struct {
 		name       string
 		plex       plex.GridEntry
 		candidates []model.Airing
-		wantID     string // channel_id of the matched airing, empty for no match
 		wantStart  time.Time
 		wantSource plex.MatchSource
 		wantReason plex.UnmatchedReason
 	}{
 		{
-			name: "hit by progid",
-			plex: plex.GridEntry{RatingKey: "rk1", BeginsAt: other.Unix(), DdProgID: "EP123"},
+			name: "exact start time match",
+			plex: makeEntry("rk1", startUnix),
 			candidates: []model.Airing{
-				{ChannelID: "ch1", Start: start, ProgID: "EP999"},
-				{ChannelID: "ch1", Start: other, ProgID: "EP123"},
+				{ChannelID: "ch1", Start: start.Add(2 * time.Hour)},
+				{ChannelID: "ch1", Start: start},
 			},
-			wantID:     "ch1",
-			wantStart:  other,
-			wantSource: plex.MatchSourceProgID,
-			wantReason: plex.UnmatchedNone,
-		},
-		{
-			name: "hit by start time when no progid",
-			plex: plex.GridEntry{RatingKey: "rk1", BeginsAt: start.Unix(), DdProgID: ""},
-			candidates: []model.Airing{
-				{ChannelID: "ch1", Start: other, ProgID: "EP999"},
-				{ChannelID: "ch1", Start: start, ProgID: ""},
-			},
-			wantID:     "ch1",
 			wantStart:  start,
 			wantSource: plex.MatchSourceStartTime,
 			wantReason: plex.UnmatchedNone,
 		},
 		{
-			name: "progid mismatch does not fall through to start time",
-			plex: plex.GridEntry{RatingKey: "rk1", BeginsAt: start.Unix(), DdProgID: "EP123"},
+			name: "+3 minutes is within tolerance",
+			plex: makeEntry("rk1", startUnix),
 			candidates: []model.Airing{
-				{ChannelID: "ch1", Start: start, ProgID: "EP999"},
+				{ChannelID: "ch1", Start: start.Add(3 * time.Minute)},
 			},
-			wantID:     "",
-			wantSource: plex.MatchSourceNone,
-			wantReason: plex.UnmatchedProgIDMismatch,
+			wantStart:  start.Add(3 * time.Minute),
+			wantSource: plex.MatchSourceStartTime,
+			wantReason: plex.UnmatchedNone,
 		},
 		{
-			name:       "no candidates returns unmatched no candidate",
-			plex:       plex.GridEntry{RatingKey: "rk1", BeginsAt: start.Unix(), DdProgID: "EP123"},
-			candidates: nil,
-			wantID:     "",
-			wantSource: plex.MatchSourceNone,
-			wantReason: plex.UnmatchedNoCandidate,
+			name: "+5 minutes is at boundary and must match",
+			plex: makeEntry("rk1", startUnix),
+			candidates: []model.Airing{
+				{ChannelID: "ch1", Start: start.Add(5 * time.Minute)},
+			},
+			wantStart:  start.Add(5 * time.Minute),
+			wantSource: plex.MatchSourceStartTime,
+			wantReason: plex.UnmatchedNone,
 		},
 		{
-			name: "start time miss returns unmatched no start time",
-			plex: plex.GridEntry{RatingKey: "rk1", BeginsAt: start.Unix(), DdProgID: ""},
+			name: "-5 minutes is at boundary and must match",
+			plex: makeEntry("rk1", startUnix),
 			candidates: []model.Airing{
-				{ChannelID: "ch1", Start: other, ProgID: ""},
+				{ChannelID: "ch1", Start: start.Add(-5 * time.Minute)},
 			},
-			wantID:     "",
+			wantStart:  start.Add(-5 * time.Minute),
+			wantSource: plex.MatchSourceStartTime,
+			wantReason: plex.UnmatchedNone,
+		},
+		{
+			name: "+6 minutes is outside tolerance and must miss",
+			plex: makeEntry("rk1", startUnix),
+			candidates: []model.Airing{
+				{ChannelID: "ch1", Start: start.Add(6 * time.Minute)},
+			},
 			wantSource: plex.MatchSourceNone,
 			wantReason: plex.UnmatchedNoStartTimeMatch,
 		},
 		{
-			name: "candidate progid empty does not match progid path",
-			plex: plex.GridEntry{RatingKey: "rk1", BeginsAt: start.Unix(), DdProgID: "EP123"},
+			name: "two candidates within tolerance — closest wins",
+			plex: makeEntry("rk1", startUnix),
 			candidates: []model.Airing{
-				{ChannelID: "ch1", Start: start, ProgID: ""},
+				{ChannelID: "ch1", Start: start.Add(4 * time.Minute)},
+				{ChannelID: "ch1", Start: start.Add(2 * time.Minute)},
 			},
-			wantID:     "",
+			wantStart:  start.Add(2 * time.Minute),
+			wantSource: plex.MatchSourceStartTime,
+			wantReason: plex.UnmatchedNone,
+		},
+		{
+			name:       "no candidates returns UnmatchedNoCandidate",
+			plex:       makeEntry("rk1", startUnix),
+			candidates: nil,
 			wantSource: plex.MatchSourceNone,
-			wantReason: plex.UnmatchedProgIDMismatch,
+			wantReason: plex.UnmatchedNoCandidate,
+		},
+		{
+			name: "no media on grid entry returns UnmatchedNoStartTimeMatch",
+			plex: plex.GridEntry{RatingKey: "rk1"},
+			candidates: []model.Airing{
+				{ChannelID: "ch1", Start: start},
+			},
+			wantSource: plex.MatchSourceNone,
+			wantReason: plex.UnmatchedNoStartTimeMatch,
 		},
 	}
 
@@ -219,13 +265,9 @@ func TestMatchAiring(t *testing.T) {
 			if reason != tc.wantReason {
 				t.Errorf("reason: got %v, want %v", reason, tc.wantReason)
 			}
-			gotID, gotStart := "", time.Time{}
+			gotStart := time.Time{}
 			if got != nil {
-				gotID = got.ChannelID
 				gotStart = got.Start
-			}
-			if gotID != tc.wantID {
-				t.Errorf("matched channel_id: got %q, want %q", gotID, tc.wantID)
 			}
 			if !gotStart.Equal(tc.wantStart) {
 				t.Errorf("matched start: got %v, want %v", gotStart, tc.wantStart)

--- a/internal/plex/match_test.go
+++ b/internal/plex/match_test.go
@@ -151,10 +151,11 @@ func TestMatchChannel(t *testing.T) {
 }
 
 // makeEntry is a helper for MatchAiring tests that wraps a single Media block
-// with the supplied beginsAt timestamp around the typical fields.
-func makeEntry(ratingKey string, beginsAt int64) plex.GridEntry {
+// with the supplied beginsAt timestamp around the typical fields. The rating
+// key is irrelevant to MatchAiring's behaviour, so it's hardcoded here.
+func makeEntry(beginsAt int64) plex.GridEntry {
 	return plex.GridEntry{
-		RatingKey: ratingKey,
+		RatingKey: "rk",
 		Media: []plex.GridMedia{
 			{
 				ChannelIdentifier: "plex-channel",
@@ -179,7 +180,7 @@ func TestMatchAiring(t *testing.T) {
 	}{
 		{
 			name: "exact start time match",
-			plex: makeEntry("rk1", startUnix),
+			plex: makeEntry(startUnix),
 			candidates: []model.Airing{
 				{ChannelID: "ch1", Start: start.Add(2 * time.Hour)},
 				{ChannelID: "ch1", Start: start},
@@ -190,7 +191,7 @@ func TestMatchAiring(t *testing.T) {
 		},
 		{
 			name: "+3 minutes is within tolerance",
-			plex: makeEntry("rk1", startUnix),
+			plex: makeEntry(startUnix),
 			candidates: []model.Airing{
 				{ChannelID: "ch1", Start: start.Add(3 * time.Minute)},
 			},
@@ -200,7 +201,7 @@ func TestMatchAiring(t *testing.T) {
 		},
 		{
 			name: "+5 minutes is at boundary and must match",
-			plex: makeEntry("rk1", startUnix),
+			plex: makeEntry(startUnix),
 			candidates: []model.Airing{
 				{ChannelID: "ch1", Start: start.Add(5 * time.Minute)},
 			},
@@ -210,7 +211,7 @@ func TestMatchAiring(t *testing.T) {
 		},
 		{
 			name: "-5 minutes is at boundary and must match",
-			plex: makeEntry("rk1", startUnix),
+			plex: makeEntry(startUnix),
 			candidates: []model.Airing{
 				{ChannelID: "ch1", Start: start.Add(-5 * time.Minute)},
 			},
@@ -220,7 +221,7 @@ func TestMatchAiring(t *testing.T) {
 		},
 		{
 			name: "+6 minutes is outside tolerance and must miss",
-			plex: makeEntry("rk1", startUnix),
+			plex: makeEntry(startUnix),
 			candidates: []model.Airing{
 				{ChannelID: "ch1", Start: start.Add(6 * time.Minute)},
 			},
@@ -229,7 +230,7 @@ func TestMatchAiring(t *testing.T) {
 		},
 		{
 			name: "two candidates within tolerance — closest wins",
-			plex: makeEntry("rk1", startUnix),
+			plex: makeEntry(startUnix),
 			candidates: []model.Airing{
 				{ChannelID: "ch1", Start: start.Add(4 * time.Minute)},
 				{ChannelID: "ch1", Start: start.Add(2 * time.Minute)},
@@ -240,7 +241,7 @@ func TestMatchAiring(t *testing.T) {
 		},
 		{
 			name:       "no candidates returns UnmatchedNoCandidate",
-			plex:       makeEntry("rk1", startUnix),
+			plex:       makeEntry(startUnix),
 			candidates: nil,
 			wantSource: plex.MatchSourceNone,
 			wantReason: plex.UnmatchedNoCandidate,

--- a/internal/plex/testdata/channels.json
+++ b/internal/plex/testdata/channels.json
@@ -1,0 +1,37 @@
+{
+  "MediaContainer": {
+    "size": 3,
+    "Channel": [
+      {
+        "id": "5fc76c607dc1e8002d48a65d-5fc705f4dd53a6002d8f9173",
+        "gridKey": "5fc76c607dc1e8002d48a65d-5fc705f4dd53a6002d8f9173",
+        "vcn": "001",
+        "isHd": true,
+        "thumb": "https://example.com/thumbs/ten.png",
+        "title": "Network Ten (Australia)",
+        "callSign": "THMEANZ",
+        "language": "en"
+      },
+      {
+        "id": "5fc76c607dc1e8002d48a65d-1a2b3c4d5e6f",
+        "gridKey": "5fc76c607dc1e8002d48a65d-1a2b3c4d5e6f",
+        "vcn": "010",
+        "isHd": true,
+        "thumb": "https://example.com/thumbs/ten-bold.png",
+        "title": "10 Bold Drama",
+        "callSign": "TENBOLD",
+        "language": "en"
+      },
+      {
+        "id": "5fc76c607dc1e8002d48a65d-aabbccddeeff",
+        "gridKey": "5fc76c607dc1e8002d48a65d-aabbccddeeff",
+        "vcn": "002",
+        "isHd": true,
+        "thumb": "https://example.com/thumbs/abc.png",
+        "title": "ABC TV",
+        "callSign": "ABCAUS",
+        "language": "en"
+      }
+    ]
+  }
+}

--- a/internal/plex/testdata/dvrs.json
+++ b/internal/plex/testdata/dvrs.json
@@ -1,0 +1,22 @@
+{
+  "MediaContainer": {
+    "size": 1,
+    "Dvr": [
+      {
+        "key": "4",
+        "uuid": "abcdef12-3456-7890-abcd-ef1234567890",
+        "language": "eng",
+        "lineupTitle": "Freeview - Melbourne (61 channels)",
+        "lineup": "lineup://tv.plex.providers.epg.cloud/melbourne-au",
+        "country": "aus",
+        "epgIdentifier": "tv.plex.providers.epg.cloud:4",
+        "Lineup": [
+          {
+            "id": "lineup://tv.plex.providers.epg.cloud/melbourne-au",
+            "title": "Freeview - Melbourne (61 channels)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/plex/testdata/grid.json
+++ b/internal/plex/testdata/grid.json
@@ -1,0 +1,56 @@
+{
+  "MediaContainer": {
+    "size": 2,
+    "Metadata": [
+      {
+        "ratingKey": "plex%3A%2F%2Fepisode%2F6a01ce4627f52460ad3410f4",
+        "key": "/tv.plex.providers.epg.cloud:4/metadata/6a01ce4627f52460ad3410f4",
+        "guid": "plex://episode/6a01ce4627f52460ad3410f4",
+        "type": "episode",
+        "title": "MasterChef Australia",
+        "grandparentTitle": "MasterChef Australia",
+        "parentTitle": "Season 18",
+        "summary": "Contestants face the dessert challenge.",
+        "year": 2026,
+        "duration": 4200000,
+        "originallyAvailableAt": "2026-05-20 22:00:00",
+        "Media": [
+          {
+            "id": 64,
+            "channelCallSign": "THMEANZ",
+            "channelIdentifier": "5fc76c607dc1e8002d48a65d-5fc705f4dd53a6002d8f9173",
+            "channelVcn": "001",
+            "gridKey": "5fc705f4dd53a6002d8f9173",
+            "beginsAt": 1749564000,
+            "endsAt": 1749567600,
+            "channelID": 1,
+            "protocol": "livetv"
+          }
+        ]
+      },
+      {
+        "ratingKey": "plex%3A%2F%2Fepisode%2Fdeadbeef0987654321",
+        "key": "/tv.plex.providers.epg.cloud:4/metadata/deadbeef0987654321",
+        "guid": "plex://episode/deadbeef0987654321",
+        "type": "episode",
+        "title": "ABC News Tonight",
+        "grandparentTitle": "ABC News Tonight",
+        "year": 2026,
+        "duration": 1800000,
+        "Media": [
+          {
+            "id": 65,
+            "channelCallSign": "ABCAUS",
+            "channelIdentifier": "5fc76c607dc1e8002d48a65d-aabbccddeeff",
+            "channelVcn": "002",
+            "gridKey": "aabbccddeeff",
+            "beginsAt": 1749567600,
+            "endsAt": 1749571200,
+            "channelID": 2,
+            "protocol": "livetv"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/plex/types.go
+++ b/internal/plex/types.go
@@ -2,33 +2,48 @@
 // Media Server EPG API used by this app.
 package plex
 
-// DVR represents a single DVR configured on a Plex Media Server. The minimal
-// fields here are what the EPG enrichment poller needs: an identifier, the
-// lineup IDs the DVR draws from, and the path prefix used to query the
-// EPG grid (`{GridKey}/grid?...`).
+// DVR represents a single DVR configured on a Plex Media Server. Identity is a
+// single `epgIdentifier` (e.g. `tv.plex.providers.epg.cloud:4`) — Plex Cloud
+// EPG returns one DVR ↔ one EPG identifier, which is also the path prefix used
+// for the channels and grid endpoints.
 type DVR struct {
-	ID        int      `json:"id"`
-	LineupIDs []string `json:"lineupIDs,omitempty"`
-	GridKey   string   `json:"gridKey,omitempty"`
+	Key           string `json:"key"`
+	EPGIdentifier string `json:"epgIdentifier"`
 }
 
-// LineupChannel describes one channel within a Plex EPG lineup.
+// LineupChannel describes one channel within a Plex EPG lineup. `vcn` is the
+// Plex equivalent of XMLTV's LCN — a zero-padded string like "001" or "010".
+// CallSign is captured for diagnostics but not used for matching.
 type LineupChannel struct {
 	ID          string `json:"id"`
-	XMLTVID     string `json:"xmltvId,omitempty"`
-	LCN         string `json:"lcn,omitempty"`
+	VCN         string `json:"vcn,omitempty"`
 	DisplayName string `json:"title,omitempty"`
+	CallSign    string `json:"callSign,omitempty"`
 }
 
-// GridEntry describes a single airing returned by the EPG grid endpoint.
-// BeginsAt and EndsAt are unix-seconds timestamps as returned by Plex.
+// GridMedia is the per-broadcast slot info under a grid entry's Media[]. Real
+// Plex responses always have exactly one entry here for EPG queries; we
+// nevertheless model it as a slice to mirror the JSON.
+type GridMedia struct {
+	ChannelIdentifier string `json:"channelIdentifier"`
+	BeginsAt          int64  `json:"beginsAt"`
+	EndsAt            int64  `json:"endsAt"`
+}
+
+// GridEntry describes a single airing returned by the EPG grid endpoint. The
+// channel and timing info lives inside Media[0]; use PrimaryMedia to access it.
 type GridEntry struct {
-	RatingKey string `json:"ratingKey"`
-	Channel   string `json:"channel,omitempty"`
-	BeginsAt  int64  `json:"beginsAt"`
-	EndsAt    int64  `json:"endsAt"`
-	Title     string `json:"title,omitempty"`
-	DdProgID  string `json:"ddProgID,omitempty"`
+	RatingKey string      `json:"ratingKey"`
+	Title     string      `json:"title,omitempty"`
+	Media     []GridMedia `json:"Media,omitempty"`
+}
+
+// PrimaryMedia returns the first Media block, or ok=false when Media is empty.
+func (g GridEntry) PrimaryMedia() (GridMedia, bool) {
+	if len(g.Media) == 0 {
+		return GridMedia{}, false
+	}
+	return g.Media[0], true
 }
 
 // Internal response wrappers — Plex wraps all responses in a MediaContainer.


### PR DESCRIPTION
## Summary

Reworks the Plex EPG integration shipped in #281–#283 to match the actual JSON returned by real Plex Cloud EPG servers. Before this change every poll reported `0 DVRs` and persisted nothing; after it, the channels and airings tables get populated.

Closes #287.

- DVR identity is `epgIdentifier` (e.g. `tv.plex.providers.epg.cloud:4`), not `id`/`lineupIDs`/`gridKey`. One DVR ↔ one EPG identifier.
- Channels endpoint is `/{epgIdentifier}/lineups/dvr/channels`; LCN matching reads Plex's `vcn` field (zero-padded, normalised by `strconv.Atoi` so `vcn="001"` matches `lcn=1`).
- Grid endpoint is `/{epgIdentifier}/grid?type=4&beginsAt%3E=<unix>&endsAt%3C=<unix>` — the `>`/`<` operators are mandatory; without them Plex silently returns `size:0`.
- Grid entries nest channel + timing info under `Media[0]`; added a small `PrimaryMedia()` helper.
- Airing matching is start-time only with ±5 min tolerance, closest-match wins. The `dd_progid` tier is gone (Plex Cloud EPG never emits one).
- Dropped `ByProgID` from `/api/plex/status`; PWA has no Plex consumer code so the removal is safe.
- "0 DVRs" warning now fires on `len(dvrs)==0`, not on absent lineup IDs.

## Test plan

- [x] `go test ./...` passes
- [x] Real-shape fixtures live in `internal/plex/testdata/{dvrs,channels,grid}.json`, anchored to `FIXED_NOW = 2025-06-10T14:00:00Z` so timestamps remain stable
- [x] Channel-match tests cover vcn "001"↔lcn 1, vcn "010"↔lcn 10, empty/non-numeric vcn fall-through
- [x] Airing-match tests cover exact match, +3 min, ±5 min boundary, +6 min miss, closest-of-two-candidates
- [x] `/api/plex/status` test asserts `byProgId` is absent from the response body
- [ ] Manual: point a real Plex server at the build and confirm non-zero matches in `/api/plex/status`

## Note on grid query operators

The issue's captured `curl` probe used `beginsAt%3E=` / `endsAt%3C=` (i.e. `>` and `<`), while the prose mentioned `>=`/`<=`. I went with the literal captured URL — operators `>`/`<`. If the live Plex server actually needs `>=`/`<=`, flip the map keys in `internal/plex/client.go` to `"beginsAt>="`/`"endsAt<="` and update the assertions in `client_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)