### PR TITLE
Add Watch now deep links from airing modal to Plex (#277)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ tvguide/
 │       ├── health.go            # GET /api/health
 │       ├── deepcheck.go         # GET /api/deepcheck
 │       ├── plex.go              # GET /api/plex/status
+│       ├── plex_link.go         # GET /api/channels/{id}/plex-link — "Watch now" deep links
 │       └── debug.go             # Debug/status endpoints
 ├── web/                         # Frontend — embedded into binary via go:embed
 │   ├── index.html               # App shell (no JS framework)
@@ -62,7 +63,7 @@ tvguide/
 │       ├── utils/date.js        # Date formatting utilities
 │       ├── store/preferences.js # Channel hide/favourite persistence (localStorage)
 │       ├── store/favourites.js  # Saved search persistence (localStorage)
-│       ├── components/modal.js  # Airing detail modal
+│       ├── components/modal.js  # Airing detail modal — fetches /api/channels/{id}/plex-link on open and shows Plex Web / Plex App "Watch now" buttons when the channel has a Plex mapping
 │       └── pages/
 │           ├── guide.js         # Guide tab rendering
 │           ├── search.js        # Search tab rendering
@@ -87,6 +88,7 @@ tvguide/
 | `POST /api/guide/refresh` | Triggers a refresh of TV guide data. `sync=true`: waits for completion and returns `200 {"ok":true}` or `500 {"error":"..."}`. Default (async): returns `202 Accepted` immediately. |
 | `GET /api/health` | Healthcheck endpoint. Probes SQLite connectivity and FTS availability. Returns `200 {"status":"ok"}` when healthy or `500 {"error":"..."}` when unhealthy. Used by the Docker `HEALTHCHECK` instruction via the `--healthcheck` binary flag — this remains the Docker liveness probe and is unchanged. |
 | `GET /api/deepcheck` | Deep health check across database, FTS, data presence/freshness, XMLTV source reachability, disk writability for `/data`, `/tmp`, and the image cache, and Plex reachability (when configured). Returns JSON `{status, checks[]}`: each entry is `{name, status, error?, info?}` with `status` one of `SUCCESS`/`FAILURE`. HTTP `200` when global status is `SUCCESS`, `503 Service Unavailable` otherwise. The `plex_reachable` check reports `info="not configured"` when `PLEX_URL` is unset and never fails the report in that case. Every check runs independently — one failure does not skip the others. Intended for occasional on-demand diagnostics, not high-frequency probing — use `/api/health` for that. |
+| `GET /api/channels/{id}/plex-link` | Returns `{"webUrl": "...", "appUrl": "..."}` for opening the channel in Plex. `webUrl` is `{base}/web/index.html#!/livetv/{lineupId}/channels/{plexChannelId}` (base from `PLEX_EXTERNAL_URL`, falling back to `PLEX_URL`); `appUrl` uses the `plex://livetv?lineup=…&channel=…` scheme so the Plex mobile app can claim it. HTTP `404` when the channel has no Plex mapping, the channel id is unknown, or neither `PLEX_EXTERNAL_URL` nor `PLEX_URL` is configured — the frontend hides the modal's "Watch now" buttons in that case. |
 | `GET /api/plex/status` | Snapshot of the most recent Plex EPG enrichment poll. When `PLEX_URL` is unset, returns `{"enabled": false}` only. When enabled, returns `lastPoll`, `nextPoll`, `lastDurationMs`, and `channels`/`airings` blocks containing total/matched counts, per-source counters (`byId`/`byLcn`/`byName` for channels; `byStartTime` for airings — the older `byProgId` counter was removed in #287), and the full list of unmatched entries with reasons. HTTP 200 in both cases — the endpoint always exists. Consumers must handle missing per-source counters gracefully: zero values are omitted via `omitempty`, and new counters may be added later. |
 | `GET /` | Serves the embedded frontend (SPA shell) |
 | `GET /{any}` | SPA fallback — serves `index.html` for any path not matching API, images, or static files. Enables client-side routing via History API. |
@@ -109,6 +111,7 @@ tvguide/
 | `PLEX_URL` | *(unset)* | Origin of the Plex Media Server used as an EPG enrichment source (e.g. `http://plex.local:32400`). Enrichment is a no-op while this is unset. Requires `PLEX_TOKEN`; if `PLEX_TOKEN` is empty, Plex enrichment is disabled with an error log line and the XMLTV path continues to work. |
 | `PLEX_TOKEN` | *(unset)* | `X-Plex-Token` value for authenticating against the Plex Media Server identified by `PLEX_URL`. Required whenever `PLEX_URL` is set. |
 | `PLEX_POLL_INTERVAL` | `12h` | How often to re-poll the Plex EPG endpoints for enrichment. Accepts Go duration strings: `6h`, `30m`, etc. Independent of `POLL_INTERVAL` (the XMLTV cadence). |
+| `PLEX_EXTERNAL_URL` | *(unset)* | User-facing Plex base URL used to build "Watch now" deep links from the airing modal. Use this when the user's clients reach Plex via a different URL than the server uses for polling (e.g. `https://plex.example.com` from a mobile device while `PLEX_URL=http://plex.local:32400` on the LAN). When unset, the deep-link endpoint falls back to `PLEX_URL`; when neither is set, `/api/channels/{id}/plex-link` returns 404 and the modal hides the buttons. |
 
 ## How to build and run
 

--- a/e2e/tests/watch-now.spec.ts
+++ b/e2e/tests/watch-now.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '../fixtures';
+import { GuidePage } from '../pages/GuidePage';
+
+const PLEX_LINK = {
+  webUrl: 'https://plex.example.com/web/index.html#!/livetv/tv.plex.providers.epg.cloud:4/channels/plex-ch1',
+  appUrl: 'plex://livetv?lineup=tv.plex.providers.epg.cloud:4&channel=plex-ch1',
+};
+
+test.describe('Modal — Watch now buttons', () => {
+  test('shows both Plex Web and Plex App buttons when the channel has a Plex mapping', async ({ page }) => {
+    await page.route('**/api/channels/ch1/plex-link', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PLEX_LINK) })
+    );
+
+    const guide = new GuidePage(page);
+    await guide.goto();
+    await guide.clickProgramme('ABC Breakfast');
+    await expect(guide.modal).toBeVisible();
+
+    const watchWeb = page.locator('#modalWatchWeb');
+    const watchApp = page.locator('#modalWatchApp');
+    await expect(watchWeb).toBeVisible();
+    await expect(watchApp).toBeVisible();
+    await expect(watchWeb).toHaveAttribute('href', PLEX_LINK.webUrl);
+    await expect(watchApp).toHaveAttribute('href', PLEX_LINK.appUrl);
+  });
+
+  test('hides Watch now buttons when the channel has no Plex mapping', async ({ page }) => {
+    // 404 = no mapping / Plex unconfigured / unknown channel
+    await page.route('**/api/channels/ch3/plex-link', (route) =>
+      route.fulfill({ status: 404, contentType: 'text/plain', body: 'not found' })
+    );
+
+    const guide = new GuidePage(page);
+    await guide.goto();
+    await guide.clickProgramme('Sunrise');
+    await expect(guide.modal).toBeVisible();
+
+    // The Watch now container should remain hidden — the buttons must not be
+    // surfaced when the channel can't be tuned via Plex.
+    await expect(page.locator('#modalWatchNow')).toBeHidden();
+  });
+
+  test('does not leak buttons from a previous airing into one without a mapping', async ({ page }) => {
+    await page.route('**/api/channels/ch1/plex-link', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PLEX_LINK) })
+    );
+    await page.route('**/api/channels/ch3/plex-link', (route) =>
+      route.fulfill({ status: 404, contentType: 'text/plain', body: 'not found' })
+    );
+
+    const guide = new GuidePage(page);
+    await guide.goto();
+
+    // First open: ch1 → buttons visible
+    await guide.clickProgramme('ABC Breakfast');
+    await expect(page.locator('#modalWatchNow')).toBeVisible();
+    await guide.closeModal();
+    await expect(page.locator('#modalBackdrop')).not.toBeVisible();
+
+    // Second open: ch3 → buttons hidden again
+    await guide.clickProgramme('Sunrise');
+    await expect(guide.modal).toBeVisible();
+    await expect(page.locator('#modalWatchNow')).toBeHidden();
+  });
+});

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -44,6 +44,7 @@ type Handler struct {
 	refreshFn    func() error // optional; nil means refresh endpoint returns 501
 	deep         DeepCheckConfig
 	plexStatusFn PlexStatusFunc // optional; nil means /api/plex/status returns {"enabled": false}
+	plexLinkURL  string         // base URL for Plex deep links; empty means /api/channels/{id}/plex-link returns 404
 }
 
 // New creates a new Handler backed by db. rssTTL is the server-wide default
@@ -69,6 +70,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/health", h.getHealth)
 	mux.HandleFunc("GET /api/deepcheck", h.getDeepCheck)
 	mux.HandleFunc("GET /api/plex/status", h.getPlexStatus)
+	mux.HandleFunc("GET /api/channels/{id}/plex-link", h.getPlexLink)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/api/plex_link.go
+++ b/internal/api/plex_link.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// plexLinkView is the JSON payload for GET /api/channels/{id}/plex-link.
+// Both URLs target the same Plex Live TV channel; the frontend chooses which
+// to open based on a "Watch in Plex Web" / "Open in Plex App" button.
+type plexLinkView struct {
+	WebURL string `json:"webUrl"`
+	AppURL string `json:"appUrl"`
+}
+
+// SetPlexLinkURL configures the Plex base URL used to build "Watch now"
+// deep links. Pass the user-facing URL (PLEX_EXTERNAL_URL, falling back to
+// PLEX_URL). Empty disables the endpoint — it returns 404 in that case.
+func (h *Handler) SetPlexLinkURL(externalURL string) {
+	h.plexLinkURL = externalURL
+}
+
+func (h *Handler) getPlexLink(w http.ResponseWriter, r *http.Request) {
+	if h.plexLinkURL == "" {
+		http.NotFound(w, r)
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+	channels, err := h.db.GetChannels(r.Context())
+	if err != nil {
+		http.Error(w, "database error", http.StatusInternalServerError)
+		return
+	}
+	for i := range channels {
+		c := channels[i]
+		if c.ID != id {
+			continue
+		}
+		if c.PlexChannelID == nil || c.PlexLineupID == nil {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSON(w, buildPlexLinks(h.plexLinkURL, *c.PlexLineupID, *c.PlexChannelID))
+		return
+	}
+	http.NotFound(w, r)
+}
+
+// buildPlexLinks constructs the web + app deep-link URLs for one Plex channel.
+// base is trimmed of any trailing slash so the result never contains "//".
+// lineupID often contains a colon (e.g. tv.plex.providers.epg.cloud:4) which
+// url.PathEscape encodes for safe inclusion in a URL path.
+func buildPlexLinks(base, lineupID, channelID string) plexLinkView {
+	base = strings.TrimRight(base, "/")
+	encLineup := url.PathEscape(lineupID)
+	encChannel := url.PathEscape(channelID)
+	return plexLinkView{
+		WebURL: base + "/web/index.html#!/livetv/" + encLineup + "/channels/" + encChannel,
+		AppURL: "plex://livetv?lineup=" + encLineup + "&channel=" + encChannel,
+	}
+}

--- a/internal/api/plex_link_test.go
+++ b/internal/api/plex_link_test.go
@@ -1,0 +1,178 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/acbgbca/xmltvguide/internal/api"
+	"github.com/acbgbca/xmltvguide/internal/database"
+	"github.com/acbgbca/xmltvguide/internal/images"
+	"github.com/acbgbca/xmltvguide/internal/plex"
+	"github.com/acbgbca/xmltvguide/internal/xmltv"
+)
+
+const testPlexEPG = "tv.plex.providers.epg.cloud:4"
+
+// stubPlexAPI implements database.PlexAPI for tests so we can seed
+// plex_channel_id / plex_lineup_id without spinning up an HTTP server.
+type stubPlexAPI struct {
+	dvrs     []plex.DVR
+	channels map[string][]plex.LineupChannel
+	grid     map[string][]plex.GridEntry
+}
+
+func (s *stubPlexAPI) GetDVRs(_ context.Context) ([]plex.DVR, error) {
+	return s.dvrs, nil
+}
+func (s *stubPlexAPI) GetLineupChannels(_ context.Context, epg string) ([]plex.LineupChannel, error) {
+	return s.channels[epg], nil
+}
+func (s *stubPlexAPI) GetGrid(_ context.Context, epg string, _, _ time.Time) ([]plex.GridEntry, error) {
+	return s.grid[epg], nil
+}
+
+// newPlexLinkServer creates a test API server with two channels: ch1 has Plex
+// mapping populated (via RefreshPlex against a stub Plex API); ch2 does not.
+// externalURL is wired through SetPlexLinkURL — pass "" to simulate no Plex
+// configuration.
+func newPlexLinkServer(t *testing.T, externalURL string) *httptest.Server {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := database.Open(filepath.Join(dir, "test.db"), 7, "http://test-source", images.NewCache(&http.Client{}, filepath.Join(dir, "images")), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	tv := &xmltv.TV{
+		Channels: []xmltv.Channel{
+			{ID: "ch1", DisplayNames: []xmltv.Name{{Value: "ABC"}}, LCN: "2"},
+			{ID: "ch2", DisplayNames: []xmltv.Name{{Value: "SBS"}}, LCN: "3"},
+		},
+	}
+	if err := db.Refresh(context.Background(), tv, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	stub := &stubPlexAPI{
+		dvrs: []plex.DVR{{EPGIdentifier: testPlexEPG}},
+		channels: map[string][]plex.LineupChannel{
+			testPlexEPG: {{ID: "ch1", VCN: "2", DisplayName: "ABC"}},
+		},
+	}
+	if _, err := db.RefreshPlex(context.Background(), stub); err != nil {
+		t.Fatalf("RefreshPlex: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	h := api.New(db, 0, nil, api.DeepCheckConfig{})
+	if externalURL != "" {
+		h.SetPlexLinkURL(externalURL)
+	}
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		srv.Close()
+		db.Close()
+	})
+	return srv
+}
+
+func TestPlexLink_MappedChannel_Returns200WithURLs(t *testing.T) {
+	srv := newPlexLinkServer(t, "https://plex.example.com")
+
+	resp, err := httpGet(t, srv.URL+"/api/channels/ch1/plex-link")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	web, app := body["webUrl"], body["appUrl"]
+	if !strings.HasPrefix(web, "https://plex.example.com/") {
+		t.Errorf("webUrl = %q, want prefix https://plex.example.com/", web)
+	}
+	if !strings.Contains(web, "/web/index.html") {
+		t.Errorf("webUrl = %q, want it to contain /web/index.html", web)
+	}
+	// The lineup id must appear somewhere in the path/fragment — colon is
+	// valid in path segments per RFC 3986 so no encoding is required.
+	if !strings.Contains(web, "tv.plex.providers.epg.cloud:4") {
+		t.Errorf("webUrl = %q, want lineup id present", web)
+	}
+	// The plex_channel_id is the last path segment.
+	if !strings.Contains(web, "ch1") {
+		t.Errorf("webUrl = %q, want plex channel id ch1 present", web)
+	}
+	if !strings.HasPrefix(app, "plex://") {
+		t.Errorf("appUrl = %q, want plex:// scheme", app)
+	}
+	if !strings.Contains(app, "ch1") {
+		t.Errorf("appUrl = %q, want plex channel id ch1 present", app)
+	}
+}
+
+func TestPlexLink_MappedChannel_TrailingSlashOnExternalURL(t *testing.T) {
+	srv := newPlexLinkServer(t, "https://plex.example.com/")
+	resp, err := httpGet(t, srv.URL+"/api/channels/ch1/plex-link")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if strings.Contains(body["webUrl"], "com//web") {
+		t.Errorf("webUrl = %q, trailing slash should be trimmed (no double //)", body["webUrl"])
+	}
+}
+
+func TestPlexLink_UnmappedChannel_Returns404(t *testing.T) {
+	srv := newPlexLinkServer(t, "https://plex.example.com")
+	resp, err := httpGet(t, srv.URL+"/api/channels/ch2/plex-link")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for channel without Plex mapping", resp.StatusCode)
+	}
+}
+
+func TestPlexLink_UnknownChannel_Returns404(t *testing.T) {
+	srv := newPlexLinkServer(t, "https://plex.example.com")
+	resp, err := httpGet(t, srv.URL+"/api/channels/does-not-exist/plex-link")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for unknown channel", resp.StatusCode)
+	}
+}
+
+func TestPlexLink_NoExternalURLConfigured_Returns404(t *testing.T) {
+	// Plex not configured at all: even a mapped channel should 404 because
+	// the server has no base URL to build a link from.
+	srv := newPlexLinkServer(t, "")
+	resp, err := httpGet(t, srv.URL+"/api/channels/ch1/plex-link")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 when Plex external URL is not configured", resp.StatusCode)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ type config struct {
 	plexURL          string
 	plexToken        string
 	plexPollInterval time.Duration
+	plexExternalURL  string
 }
 
 func parseConfig() (config, error) {
@@ -105,6 +106,7 @@ func parseConfig() (config, error) {
 
 	plexURL := os.Getenv("PLEX_URL")
 	plexToken := os.Getenv("PLEX_TOKEN")
+	plexExternalURL := os.Getenv("PLEX_EXTERNAL_URL")
 	plexPollInterval := 12 * time.Hour
 	if v := os.Getenv("PLEX_POLL_INTERVAL"); v != "" {
 		d, err := time.ParseDuration(v)
@@ -136,6 +138,7 @@ func parseConfig() (config, error) {
 		plexURL:          plexURL,
 		plexToken:        plexToken,
 		plexPollInterval: plexPollInterval,
+		plexExternalURL:  plexExternalURL,
 	}, nil
 }
 
@@ -198,9 +201,7 @@ func run(cfg config) error {
 	apiHandler := api.New(db, cfg.rssTTL, func() error {
 		return refresh(db, httpClient, cfg.xmltvURL, cfg.pollInterval)
 	}, deepCfg)
-	if cfg.plexURL != "" {
-		apiHandler.SetPlexStatusFunc(plexState.snapshot)
-	}
+	wirePlexAPI(apiHandler, cfg, plexState)
 	apiHandler.RegisterRoutes(mux)
 
 	webContent, err := fs.Sub(webFS, "web")
@@ -296,6 +297,26 @@ func healthcheck() error {
 		return fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// wirePlexAPI registers the optional Plex-related handlers on apiHandler.
+// /api/plex/status needs the live poll snapshot; /api/channels/{id}/plex-link
+// needs a user-facing base URL. PLEX_EXTERNAL_URL takes precedence over
+// PLEX_URL because the user's mobile devices may reach Plex over a different
+// URL than the server uses for polling (e.g. https://plex.example.com vs
+// http://plex.local:32400). Both setters are no-ops on empty input, leaving
+// the corresponding endpoint disabled.
+func wirePlexAPI(apiHandler *api.Handler, cfg config, plexState *plexPollerState) {
+	if cfg.plexURL != "" {
+		apiHandler.SetPlexStatusFunc(plexState.snapshot)
+	}
+	linkURL := cfg.plexExternalURL
+	if linkURL == "" {
+		linkURL = cfg.plexURL
+	}
+	if linkURL != "" {
+		apiHandler.SetPlexLinkURL(linkURL)
+	}
 }
 
 func runInitialRefresh(db *database.DB, client *http.Client, xmltvURL string, pollInterval time.Duration, refreshOnStart bool) {

--- a/web/index.html
+++ b/web/index.html
@@ -168,6 +168,10 @@
             <div class="modal-subtitle" id="modalSubtitle"></div>
             <div class="modal-badges" id="modalBadges"></div>
             <p class="modal-desc" id="modalDesc"></p>
+            <div class="modal-watch-now" id="modalWatchNow" style="display:none">
+                <a class="watch-btn watch-btn-web" id="modalWatchWeb" href="#" target="_blank" rel="noopener noreferrer">Open in Plex Web</a>
+                <a class="watch-btn watch-btn-app" id="modalWatchApp" href="#">Open in Plex App</a>
+            </div>
         </div>
     </div>
 

--- a/web/js/components/modal.js
+++ b/web/js/components/modal.js
@@ -33,6 +33,13 @@ export function openProgrammeModal(prog) {
 
     document.getElementById('modalDesc').textContent = prog.description || 'No description available.';
 
+    // Watch now: hide buttons until we hear back from the backend so a previous
+    // airing's URLs can't leak into one without a Plex mapping.
+    resetWatchNow();
+    if (prog.channelId) {
+        updateWatchNow(prog.channelId);
+    }
+
     document.getElementById('modalBackdrop').classList.add('open');
 }
 
@@ -48,6 +55,7 @@ export function openSearchAiringModal(airing, title) {
         episodeNumDisplay: airing.episodeNumDisplay,
         isRepeat:          airing.isRepeat,
         isPremiere:        airing.isPremiere,
+        channelId:         airing.channelId,
     };
     openProgrammeModal(prog);
 }
@@ -65,4 +73,25 @@ function addBadge(container, text) {
     b.className   = 'badge';
     b.textContent = text;
     container.appendChild(b);
+}
+
+function resetWatchNow() {
+    const wrap = document.getElementById('modalWatchNow');
+    wrap.style.display = 'none';
+    document.getElementById('modalWatchWeb').setAttribute('href', '#');
+    document.getElementById('modalWatchApp').setAttribute('href', '#');
+}
+
+async function updateWatchNow(channelId) {
+    try {
+        const resp = await fetch(`/api/channels/${encodeURIComponent(channelId)}/plex-link`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        if (!data?.webUrl || !data?.appUrl) return;
+        document.getElementById('modalWatchWeb').setAttribute('href', data.webUrl);
+        document.getElementById('modalWatchApp').setAttribute('href', data.appUrl);
+        document.getElementById('modalWatchNow').style.display = '';
+    } catch {
+        // Network errors silently hide the buttons — Watch now is non-critical.
+    }
 }

--- a/web/style/modal.css
+++ b/web/style/modal.css
@@ -122,3 +122,31 @@
     line-height: 1.65;
     color: var(--text-secondary);
 }
+
+.modal-watch-now {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 16px;
+}
+
+.watch-btn {
+    flex: 1 1 0;
+    min-width: 140px;
+    text-align: center;
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 10px 14px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    transition: background 0.15s, border-color 0.15s;
+}
+
+.watch-btn:hover {
+    background: var(--accent, #e5a00d);
+    border-color: var(--accent, #e5a00d);
+    color: #000;
+}


### PR DESCRIPTION
## Summary
- New `GET /api/channels/{id}/plex-link` returns `{webUrl, appUrl}` for one channel, built from `plex_channel_id` / `plex_lineup_id` populated by the existing Plex EPG poller. 404 when there's no mapping, the channel is unknown, or neither `PLEX_EXTERNAL_URL` nor `PLEX_URL` is set.
- New `PLEX_EXTERNAL_URL` env var for the user-facing Plex base URL (mobile clients often reach Plex over a different URL than the server uses for polling). Falls back to `PLEX_URL` when unset.
- Airing modal shows two "Watch now" buttons — "Open in Plex Web" (new tab) and "Open in Plex App" (`plex://` scheme). Buttons are hidden when the endpoint returns 404, and reset between modal openings so URLs from a previous airing can't leak.

Closes #277.

## Test plan
- [ ] `go test ./...` passes
- [ ] `make test-ui` passes (166 / 1 pre-existing skip)
- [ ] With `PLEX_EXTERNAL_URL` set, click an airing on a Plex-mapped channel and confirm both buttons appear
- [ ] Click "Open in Plex Web" — opens a new tab to the channel in Plex Web
- [ ] Click "Open in Plex App" on iOS — opens (or prompts to open) the Plex app
- [ ] Click an airing on a channel without a Plex mapping — no buttons visible
- [ ] Unset both `PLEX_URL` and `PLEX_EXTERNAL_URL` — buttons never appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)